### PR TITLE
Help mozjs build where rust-mozjs expects it

### DIFF
--- a/js/src/shell/Makefile.in
+++ b/js/src/shell/Makefile.in
@@ -46,7 +46,7 @@ endif
 
 # People expect the js shell to wind up in the top-level JS dir.
 libs::
-	$(INSTALL) $(IFLAGS2) $(PROGRAM) $(DEPTH)
+	#$(INSTALL) $(IFLAGS2) $(PROGRAM) $(DEPTH)
 
 GARBAGE += $(DEPTH)/$(PROGRAM)
 


### PR DESCRIPTION
This versions of mozjs has a js top-level directory that clashes with the ./js binary, at least with the layout rust-mozjs expects when compiling servo. Don't copy the js binary to the wrong place.
