### PR TITLE
Backport upstream fixes for latest Clang.

### DIFF
--- a/js/src/build/autoconf/toolchain.m4
+++ b/js/src/build/autoconf/toolchain.m4
@@ -48,13 +48,13 @@ fi
 CLANG_CC=
 CLANG_CXX=
 if test "$GCC" = yes; then
-   if test "`$CC -v 2>&1 | grep -c 'clang version'`" != "0"; then
+   if test "`$CC -v 2>&1 | grep -c 'clang version\|Apple.*clang'`" != "0"; then
      CLANG_CC=1
    fi
 fi
 
 if test "$GXX" = yes; then
-   if test "`$CXX -v 2>&1 | grep -c 'clang version'`" != "0"; then
+   if test "`$CXX -v 2>&1 | grep -c 'clang version\|Apple.*clang'`" != "0"; then
      CLANG_CXX=1
    fi
 fi


### PR DESCRIPTION
This is required to compile on recent OS Xen.
