### PR TITLE
Backport the patch for bug 784631

### DIFF
--- a/js/src/jsinterp.cpp
+++ b/js/src/jsinterp.cpp
@@ -1238,6 +1238,7 @@ js::Interpret(JSContext *cx, StackFrame *entryFrame, InterpMode interpMode)
     RootedPropertyName rootName0(cx);
     RootedId rootId0(cx);
     RootedShape rootShape0(cx);
+    DebugOnly<uint32_t> blockDepth;
 
     if (!entryFrame)
         entryFrame = regs.fp();
@@ -3665,7 +3666,7 @@ BEGIN_CASE(JSOP_LEAVEBLOCK)
 BEGIN_CASE(JSOP_LEAVEFORLETIN)
 BEGIN_CASE(JSOP_LEAVEBLOCKEXPR)
 {
-    DebugOnly<uint32_t> blockDepth = regs.fp()->blockChain().stackDepth();
+    blockDepth = regs.fp()->blockChain().stackDepth();
 
     regs.fp()->popBlock(cx);
 

--- a/js/src/jsutil.h
+++ b/js/src/jsutil.h
@@ -432,10 +432,10 @@ typedef size_t jsbitmap;
 #if defined(__clang__)
 # define JS_SILENCE_UNUSED_VALUE_IN_EXPR(expr)                                \
     JS_BEGIN_MACRO                                                            \
-        _Pragma("clang diagnostic push")                                      \
-        _Pragma("clang diagnostic ignored \"-Wunused-value\"")                \
-        expr;                                                                 \
-        _Pragma("clang diagnostic pop")                                       \
+        _Pragma("(clang diagnostic push)")                                    \
+        _Pragma("(clang diagnostic ignored \"-Wunused-value\")")              \
+        {expr;}                                                               \
+        _Pragma("(clang diagnostic pop)")                                     \
     JS_END_MACRO
 #elif (__GNUC__ >= 5) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
 # define JS_SILENCE_UNUSED_VALUE_IN_EXPR(expr)                                \


### PR DESCRIPTION
Without this change, we get a build failure when using recent clang:

```
js/src/jsinterp.cpp:3685:9: error: indirect goto might cross protected scopes
```
