### PR TITLE
Bug 1107777 - Add autoJSAPIOwnsErrorReporting flag to JSContext options. AutoJSAPI sets it. r=bholley

### DIFF
--- a/js/src/jsapi.cpp
+++ b/js/src/jsapi.cpp
@@ -5111,7 +5111,8 @@ struct AutoLastFrameCheck {
     ~AutoLastFrameCheck() {
         if (cx->isExceptionPending() &&
             !JS_IsRunning(cx) &&
-            !cx->hasRunOption(JSOPTION_DONT_REPORT_UNCAUGHT)) {
+            !cx->hasRunOption(JSOPTION_DONT_REPORT_UNCAUGHT) &&
+            !cx->hasRunOption(JSOPTION_AUTOJSAPI_OWNS_ERROR_REPORTING)) {
             js_ReportUncaughtException(cx);
         }
     }

--- a/js/src/jsapi.h
+++ b/js/src/jsapi.h
@@ -3232,7 +3232,17 @@ JS_StringToVersion(const char *string);
                                                    backtracks more than n^3
                                                    times, where n is length
                                                    of the input string */
-/* JS_BIT(10) is currently unused. */
+
+// dontReportUncaught isn't respected by all JSAPI codepaths, particularly
+// the JS_ReportError* functions that eventually report the error even when
+// dontReportUncaught is set, if script is not running. We want a way to
+// indicate that the embedder will always handle any exceptions, and that
+// SpiderMonkey should just leave them on the context. This is the way we
+// want to do all future error handling in Gecko - stealing the exception
+// explicitly from the context and handling it as per the situation. This
+// will eventually become the default and these 2 flags should go away.
+#define JSOPTION_AUTOJSAPI_OWNS_ERROR_REPORTING \
+                                JS_BIT(10)
 
 /* JS_BIT(11) is currently unused. */
 

--- a/js/src/jscntxt.cpp
+++ b/js/src/jscntxt.cpp
@@ -440,7 +440,7 @@ ReportError(JSContext *cx, const char *message, JSErrorReport *reportp,
      * propagates out of scope.  This is needed for compatibility
      * with the old scheme.
      */
-    if (!JS_IsRunning(cx) ||
+    if (!(cx->hasRunOption(JSOPTION_AUTOJSAPI_OWNS_ERROR_REPORTING) || JS_IsRunning(cx)) ||
         !js_ErrorToException(cx, message, reportp, callback, userRef)) {
         js_ReportErrorAgain(cx, message, reportp);
     } else if (JSDebugErrorHook hook = cx->runtime->debugHooks.debugErrorHook) {

--- a/js/xpconnect/src/XPCWrappedJSClass.cpp
+++ b/js/xpconnect/src/XPCWrappedJSClass.cpp
@@ -305,8 +305,11 @@ nsXPCWrappedJSClass::CallQueryInterfaceOnJSObject(XPCCallContext& ccx,
             }
 
             // Don't report if reporting was disabled by someone else.
-            if (!(oldOpts & JSOPTION_DONT_REPORT_UNCAUGHT))
+            if (!(oldOpts & JSOPTION_DONT_REPORT_UNCAUGHT) &&
+                !(oldOpts & JSOPTION_AUTOJSAPI_OWNS_ERROR_REPORTING))
+            {
                 JS_ReportPendingException(cx);
+            }
         }
     }
 


### PR DESCRIPTION
r? @bholley
