### PR TITLE
Remove cruft.

### DIFF
--- a/js/src/jsapi.cpp
+++ b/js/src/jsapi.cpp
@@ -735,7 +735,6 @@ JSRuntime::JSRuntime()
 #endif
     selfHostedGlobal_(NULL),
     nativeStackBase(0),
-    nativeStackEnd(0),
     nativeStackQuota(0),
     interpreterFrames(NULL),
     cxCallback(NULL),
@@ -7084,13 +7083,6 @@ JS_SetRuntimeThread(JSRuntime *rt)
 #ifdef JS_THREADSAFE
     rt->setOwnerThread();
 #endif
-}
-
-extern JS_PUBLIC_API(void)
-JS_SetNativeStackBounds(JSRuntime *rt, uintptr_t stackBase, uintptr_t stackEnd)
-{
-    rt->nativeStackBase = stackBase;
-    rt->nativeStackEnd = stackEnd;
 }
 
 extern JS_NEVER_INLINE JS_PUBLIC_API(void)

--- a/js/src/jsapi.cpp
+++ b/js/src/jsapi.cpp
@@ -773,7 +773,7 @@ JSRuntime::JSRuntime()
     gcLowFrequencyHeapGrowth(1.5),
     gcDynamicHeapGrowth(false),
     gcDynamicMarkSlice(false),
-    gcInhibit(0),
+    gcInhibit(false),
     gcShouldCleanUpEverything(false),
     gcIsNeeded(0),
     gcWeakMapList(NULL),
@@ -7168,14 +7168,15 @@ JS_ScheduleGC(JSContext *cx, uint32_t count)
 JS_PUBLIC_API(void)
 JS_InhibitGC(JSContext *cx)
 {
-    ++cx->runtime->gcInhibit;
+    JS_ASSERT(!cx->runtime->gcInhibit);
+    cx->runtime->gcInhibit = true;
 }
 
 JS_PUBLIC_API(void)
 JS_AllowGC(JSContext *cx)
 {
     JS_ASSERT(cx->runtime->gcInhibit);
-    --cx->runtime->gcInhibit;
+    cx->runtime->gcInhibit = false;
 }
 
 /************************************************************************/

--- a/js/src/jsapi.cpp
+++ b/js/src/jsapi.cpp
@@ -773,7 +773,6 @@ JSRuntime::JSRuntime()
     gcLowFrequencyHeapGrowth(1.5),
     gcDynamicHeapGrowth(false),
     gcDynamicMarkSlice(false),
-    gcInhibit(false),
     gcShouldCleanUpEverything(false),
     gcIsNeeded(0),
     gcWeakMapList(NULL),
@@ -7164,20 +7163,6 @@ JS_ScheduleGC(JSContext *cx, uint32_t count)
     cx->runtime->gcNextScheduled = count;
 }
 #endif
-
-JS_PUBLIC_API(void)
-JS_InhibitGC(JSContext *cx)
-{
-    JS_ASSERT(!cx->runtime->gcInhibit);
-    cx->runtime->gcInhibit = true;
-}
-
-JS_PUBLIC_API(void)
-JS_AllowGC(JSContext *cx)
-{
-    JS_ASSERT(cx->runtime->gcInhibit);
-    cx->runtime->gcInhibit = false;
-}
 
 /************************************************************************/
 

--- a/js/src/jsapi.cpp
+++ b/js/src/jsapi.cpp
@@ -7087,15 +7087,10 @@ JS_SetRuntimeThread(JSRuntime *rt)
 }
 
 extern JS_PUBLIC_API(void)
-JS_SetNativeStackBounds(JSRuntime *rt, uintptr_t minValue, uintptr_t maxValue)
+JS_SetNativeStackBounds(JSRuntime *rt, uintptr_t stackBase, uintptr_t stackEnd)
 {
-#if JS_STACK_GROWTH_DIRECTION < 0
-    rt->nativeStackBase = maxValue;
-    rt->nativeStackEnd = minValue;
-#else
-    rt->nativeStackBase = minValue;
-    rt->nativeStackEnd = maxValue;
-#endif
+    rt->nativeStackBase = stackBase;
+    rt->nativeStackEnd = stackEnd;
 }
 
 extern JS_NEVER_INLINE JS_PUBLIC_API(void)

--- a/js/src/jsapi.h
+++ b/js/src/jsapi.h
@@ -6259,7 +6259,7 @@ extern JS_PUBLIC_API(void)
 JS_SetRuntimeThread(JSRuntime *rt);
 
 extern JS_PUBLIC_API(void)
-JS_SetNativeStackBounds(JSRuntime *rt, uintptr_t minValue, uintptr_t maxValue);
+JS_SetNativeStackBounds(JSRuntime *rt, uintptr_t stackBase, uintptr_t stackEnd);
 
 #ifdef __cplusplus
 JS_END_EXTERN_C

--- a/js/src/jsapi.h
+++ b/js/src/jsapi.h
@@ -6328,12 +6328,6 @@ extern JS_PUBLIC_API(void)
 JS_ScheduleGC(JSContext *cx, uint32_t count);
 #endif
 
-extern JS_PUBLIC_API(void)
-JS_InhibitGC(JSContext *cx);
-
-extern JS_PUBLIC_API(void)
-JS_AllowGC(JSContext *cx);
-
 /*
  * Convert a uint32_t index into a jsid.
  */

--- a/js/src/jsapi.h
+++ b/js/src/jsapi.h
@@ -6258,9 +6258,6 @@ JS_ClearRuntimeThread(JSRuntime *rt);
 extern JS_PUBLIC_API(void)
 JS_SetRuntimeThread(JSRuntime *rt);
 
-extern JS_PUBLIC_API(void)
-JS_SetNativeStackBounds(JSRuntime *rt, uintptr_t stackBase, uintptr_t stackEnd);
-
 #ifdef __cplusplus
 JS_END_EXTERN_C
 

--- a/js/src/jscntxt.h
+++ b/js/src/jscntxt.h
@@ -525,7 +525,7 @@ struct JSRuntime : js::RuntimeFriendFields
     double              gcLowFrequencyHeapGrowth;
     bool                gcDynamicHeapGrowth;
     bool                gcDynamicMarkSlice;
-    uint64_t            gcInhibit;
+    bool                gcInhibit;
 
     /* During shutdown, the GC needs to clean up every possible object. */
     bool                gcShouldCleanUpEverything;

--- a/js/src/jscntxt.h
+++ b/js/src/jscntxt.h
@@ -439,9 +439,6 @@ struct JSRuntime : js::RuntimeFriendFields
     /* Base address of the native stack for the current thread. */
     uintptr_t           nativeStackBase;
 
-    /* Base address of the native stack for the current thread. */
-    uintptr_t           nativeStackEnd;
-
     /* The native stack size limit that runtime should not exceed. */
     size_t              nativeStackQuota;
 

--- a/js/src/jscntxt.h
+++ b/js/src/jscntxt.h
@@ -525,7 +525,6 @@ struct JSRuntime : js::RuntimeFriendFields
     double              gcLowFrequencyHeapGrowth;
     bool                gcDynamicHeapGrowth;
     bool                gcDynamicMarkSlice;
-    bool                gcInhibit;
 
     /* During shutdown, the GC needs to clean up every possible object. */
     bool                gcShouldCleanUpEverything;

--- a/js/src/jsgc.cpp
+++ b/js/src/jsgc.cpp
@@ -4430,10 +4430,6 @@ Collect(JSRuntime *rt, bool incremental, int64_t budget,
 {
     JS_AbortIfWrongThread(rt);
 
-    if (rt->gcInhibit) {
-        return;
-    }
-
     ContextIter cx(rt);
     if (!cx.done())
         MaybeCheckStackRoots(cx);

--- a/js/src/jsgc.cpp
+++ b/js/src/jsgc.cpp
@@ -1177,11 +1177,9 @@ MarkConservativeStackRoots(JSTracer *trc, bool useSavedRoots)
     uintptr_t *stackMin, *stackEnd;
 #if JS_STACK_GROWTH_DIRECTION > 0
     stackMin = rt->nativeStackBase;
-    stackEnd = rt->nativeStackEnd ? reinterpret_cast<uintptr_t*>(rt->nativeStackEnd)
-                                 : cgcd->nativeStackTop;
+    stackEnd = cgcd->nativeStackTop;
 #else
-    stackMin = rt->nativeStackEnd ? reinterpret_cast<uintptr_t*>(rt->nativeStackEnd)
-                                 : cgcd->nativeStackTop + 1;
+    stackMin = cgcd->nativeStackTop + 1;
     stackEnd = reinterpret_cast<uintptr_t *>(rt->nativeStackBase);
 #endif
 


### PR DESCRIPTION
These APIs are no longer used by Servo, so there is no need to retain them here.