### PR TITLE
Add AArch64 as an architecture supported by Double-Conversion.

### DIFF
--- a/mfbt/double-conversion/more-architectures.patch
+++ b/mfbt/double-conversion/more-architectures.patch
@@ -1,7 +1,7 @@
 diff --git a/mfbt/double-conversion/utils.h b/mfbt/double-conversion/utils.h
 --- a/mfbt/double-conversion/utils.h
 +++ b/mfbt/double-conversion/utils.h
-@@ -48,20 +48,24 @@
+@@ -48,20 +48,25 @@
  // An easy way to test if the floating-point operations are correct is to
  // evaluate: 89255.0/1e22. If the floating-point stack is 64 bits wide then
  // the result is equal to 89255e-22.
@@ -11,12 +11,14 @@ diff --git a/mfbt/double-conversion/utils.h b/mfbt/double-conversion/utils.h
  // On Linux,x86 89255e-22 != Div_double(89255.0/1e22)
  #if defined(_M_X64) || defined(__x86_64__) || \
 -    defined(__ARMEL__) || \
+-    defined(_MIPS_ARCH_MIPS32R2)
 +    defined(__ARMEL__) || defined(__avr32__) || \
 +    defined(__hppa__) || defined(__ia64__) || \
 +    defined(__mips__) || defined(__powerpc__) || \
 +    defined(__sparc__) || defined(__sparc) || defined(__s390__) || \
 +    defined(__SH4__) || defined(__alpha__) || \
-     defined(_MIPS_ARCH_MIPS32R2)
++    defined(_MIPS_ARCH_MIPS32R2) || \
++    defined(__AARCH64EL__)
  #define DOUBLE_CONVERSION_CORRECT_DOUBLE_OPERATIONS 1
 -#elif defined(_M_IX86) || defined(__i386__)
 +#elif defined(_M_IX86) || defined(__i386__) || defined(__i386)

--- a/mfbt/double-conversion/utils.h
+++ b/mfbt/double-conversion/utils.h
@@ -58,7 +58,8 @@
     defined(__mips__) || defined(__powerpc__) || \
     defined(__sparc__) || defined(__sparc) || defined(__s390__) || \
     defined(__SH4__) || defined(__alpha__) || \
-    defined(_MIPS_ARCH_MIPS32R2)
+    defined(_MIPS_ARCH_MIPS32R2) || \
+    defined(__AARCH64EL__)
 #define DOUBLE_CONVERSION_CORRECT_DOUBLE_OPERATIONS 1
 #elif defined(_M_IX86) || defined(__i386__) || defined(__i386)
 #if defined(_WIN32)


### PR DESCRIPTION
Tested for correctness as described in the comment.