### PR TITLE
Also disable jemalloc on Android/Gonk

### DIFF
--- a/makefile.cargo
+++ b/makefile.cargo
@@ -12,6 +12,7 @@ CONFIGURE_FLAGS := --target=$(TARGET)
 			--with-android-ndk=$(ANDROID_NDK) \
 			--with-android-toolchain=$(ANDROID_TOOLCHAIN) \
 			--without-intl-api \
+			--disable-jemalloc \
 			$(NULL)
 	endif
 
@@ -22,7 +23,7 @@ CPP ?= gcc -E
 CXX ?= g++
 AR ?= ar
 
-CONFIGURE_FLAGS = --disable-jemalloc
+CONFIGURE_FLAGS := --disable-jemalloc
 
 endif
 


### PR DESCRIPTION
Jemalloc needs to be disabled since jemalloc's definition of malloc_usable_size is different from the system's definition on OSX and Android. Ideally, we'd get SM to use Rust's jemalloc.