### PR TITLE
Improve ARM cross compilation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,7 @@ use std::process::{Command, Stdio};
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
     let result = Command::new("make")
-        .args(&["-f", "makefile.cargo"])
+        .args(&["-R", "-f", "makefile.cargo"])
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
         .status()

--- a/makefile.cargo
+++ b/makefile.cargo
@@ -1,29 +1,26 @@
+CONFIGURE_FLAGS := --disable-jemalloc
+
 ifeq (eabi,$(findstring eabi,$(TARGET)))
 
-CC := $(TARGET)-gcc
-CPP := $(TARGET)-gcc -E
-CXX := $(TARGET)-g++
-AR := $(TARGET)-ar
+CC ?= $(TARGET)-gcc
+CPP ?= $(TARGET)-gcc -E
+CXX ?= $(TARGET)-g++
+AR ?= $(TARGET)-ar
 
-CONFIGURE_FLAGS := --target=$(TARGET)
+CONFIGURE_FLAGS += --target=$(TARGET) --without-intl-api
 
 	ifeq (androideabi,$(findstring androideabi,$(TARGET)))
 		CONFIGURE_FLAGS += \
 			--with-android-ndk=$(ANDROID_NDK) \
 			--with-android-toolchain=$(ANDROID_TOOLCHAIN) \
-			--without-intl-api \
-			--disable-jemalloc \
 			$(NULL)
 	endif
-
 else
 
 CC ?= gcc
 CPP ?= gcc -E
 CXX ?= g++
 AR ?= ar
-
-CONFIGURE_FLAGS := --disable-jemalloc
 
 endif
 

--- a/mozjs/config/external/zlib/moz.build
+++ b/mozjs/config/external/zlib/moz.build
@@ -17,5 +17,5 @@ else:
         # ]
         pass
     DIRS += [
-        '../../../modules/zlib',
+        '../../../modules/zlib/src',
     ]


### PR DESCRIPTION
The first patch fixes some configuration flags for ARM, which also means `jemalloc` is now disabled for all targets.
The second patch fixes zlib flags, which caused moz.build errors during cross compilation. I'm not sure if this is the correct way to solve this of if this works for all platforms, could you check it?

Requires servo/servo#6531
Part of servo/servo#6327

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/mozjs/48)
<!-- Reviewable:end -->
