### PR TITLE
Fix build under MSYS2/MINGW64

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -7,6 +7,7 @@ use std::process::{Command, Stdio};
 
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
+    let target = env::var("TARGET").unwrap();
     let result = Command::new("make")
         .args(&["-R", "-f", "makefile.cargo"])
         .stdout(Stdio::inherit())
@@ -15,7 +16,14 @@ fn main() {
         .unwrap();
     assert!(result.success());
     println!("cargo:rustc-link-search=native={}/dist/lib", out_dir);
-    println!("cargo:rustc-link-lib=static=js_static");
+    if target.contains("windows") {
+        // On Windows, because dynamic libs and static libs end up
+        // with different symbols for the import, we have to build
+        // with the shared mozjs DLL.
+        println!("cargo:rustc-link-lib=mozjs");
+    } else {
+        println!("cargo:rustc-link-lib=static=js_static");
+    }
     println!("cargo:rustc-link-lib=stdc++");
     println!("cargo:outdir={}", out_dir);
 }

--- a/makefile.cargo
+++ b/makefile.cargo
@@ -28,26 +28,67 @@ ifneq (,$(CARGO_FEATURE_DEBUGMOZJS))
 	CONFIGURE_FLAGS += --enable-debug=-g --enable-optimize=-O0
 endif
 
-ifeq (windows,$(findstring windows,$(TARGET)))
+ifeq ($(MSYSTEM),MINGW64)
 	# msys2 sets CC=cc as default. however, there is no `cc.exe`.
 	# overwrite it here.
 	ifeq ($(CC),cc)
 		CC = gcc
 		CPP = gcc -E
 	endif
+
 	# cargo uses Windows native path. msys2 make unfortunately doesn't understand it.
 	OUT_DIR:=$(shell cygpath "$(OUT_DIR)")
+
 	# on windows, SM requires moztools which contains prebuilt libraries like glib and libIDL.
-	# we don't need them, so just set any fake path.
-	MOZ_TOOLS=$(OUT_DIR)
+	# we don't need them, so just set / -- configure will check that $(MOZ_TOOLS)/bin exists
+	# and that it's in the path.
+	MOZ_TOOLS=/
+
+	# This is a mess.  m-c/spidermonkey includes its own copy of virtualenv.py,
+	# which doesn't have the fixes needed to make it work with msys2/mingw64.
+	# The only way we can successfully build under msys2 is to use the win32-native
+	# python.
+
+	ifneq (,$(wildcard c:/python27/python.exe))
+	FORCED_PYTHON := "c:/python27/python.exe"
+	else ifneq(,$(NATIVE_WIN32_PYTHON))
+	FORCED_PYTHON := "$(NATIVE_WIN32_PYTHON)"
+	else
+	$(message You must either have the Native Win32 python installed in C:/python27, or set NATIVE_WIN32_PYTHON to point to the appropriate python.exe.)
+	$(message Download the Python installer from  https://www.python.org/downloads/release/python-2710/)
+	$(error Can't find native Win32 python)
+	endif
+
+	# on windows/mingw64, we need to not use virtualenv -- the virtualenv.py script
+	# that ships with m-c doesn't work on mingw.
+	ifeq ($(MSYSTEM),MINGW64)
+	DONT_POPULATE_VIRTUALENV=1
+	endif
+
+	# we build with system nspr, expecting a msys2 mingw64 build
+	# The mingw64 nspr-config gives -lplc4 for example, but only libplc4.dll.a and libplc4_s.a exist.
+	# We can't use static NSPR because it doesn't properly work with threads.  This would all
+	# be fixed once a Windows equivalent to PosixNSPR.{cpp,h} is written.
+	#CONFIGURE_FLAGS += --with-system-nspr
+	CONFIGURE_FLAGS += --with-nspr-cflags="-I/mingw64/include/nspr"
+	CONFIGURE_FLAGS += --with-nspr-libs="-lplds4.dll -lplc4.dll -lnspr4.dll"
 endif
 
 SRC_DIR = $(shell pwd)
 
 .PHONY : all
+ifneq (,$(FORCED_PYTHON))
+all:
+	cd $(OUT_DIR) && \
+	PYTHON="$(FORCED_PYTHON)" \
+	MOZ_TOOLS="$(MOZ_TOOLS)" CC="$(CC)" CPP="$(CPP)" CXX="$(CXX)" AR="$(AR)" \
+	$(SRC_DIR)/mozjs/js/src/configure --enable-gczeal $(strip $(CONFIGURE_FLAGS))
+	cd $(OUT_DIR) && make -f Makefile -j$(NUM_JOBS)
+else
 all:
 	cd $(OUT_DIR) && \
 	MOZ_TOOLS="$(MOZ_TOOLS)" CC="$(CC)" CPP="$(CPP)" CXX="$(CXX)" AR="$(AR)" \
 	$(SRC_DIR)/mozjs/js/src/configure --enable-gczeal $(strip $(CONFIGURE_FLAGS))
 	cd $(OUT_DIR) && make -f Makefile -j$(NUM_JOBS)
+endif
 

--- a/mozjs/config/baseconfig.mk
+++ b/mozjs/config/baseconfig.mk
@@ -31,8 +31,11 @@ ifdef .PYMAKE
 $(error Pymake is no longer supported. Please upgrade to MozillaBuild 1.9 or newer and build with 'mach' or 'mozmake')
 endif
 
+# don't support MSYS make, except if we're actually under mingw64/msys2
+ifneq ($(MSYSTEM),MINGW64)
 ifeq (a,$(firstword a$(subst /, ,$(abspath .))))
 $(error MSYS make is not supported)
+endif
 endif
 # 4.0- happens to be greater than 4.0, lower than the mozmake version,
 # and lower than 4.0.1 or 4.1, whatever next version of gnu make will

--- a/mozjs/config/external/icu/Makefile.in
+++ b/mozjs/config/external/icu/Makefile.in
@@ -24,10 +24,13 @@ ifdef USE_ICU
         ICU_TARGET := target
       endif
     else # !MOZ_SHARED_ICU
-      ifeq ($(OS_ARCH),WINNT)
+      ifeq ($(MSYSTEM),MINGW64)
+        ICU_LIB_RENAME = $(foreach libname,$(ICU_LIB_NAMES),\
+                             cp -p $(DEPTH)/intl/icu/target/lib/libs$(libname)$(MOZ_ICU_DBG_SUFFIX).a $(DEPTH)/intl/icu/target/lib/lib$(libname)$(MOZ_ICU_DBG_SUFFIX).a;)
+      else ifeq ($(OS_ARCH),WINNT)
         ICU_LIB_RENAME = $(foreach libname,$(ICU_LIB_NAMES),\
                              cp -p $(DEPTH)/intl/icu/target/lib/s$(libname)$(MOZ_ICU_DBG_SUFFIX).lib $(DEPTH)/intl/icu/target/lib/$(libname)$(MOZ_ICU_DBG_SUFFIX).lib;)
-      endif
+      endif # WINNT
     endif # MOZ_SHARED_ICU
   endif # !MOZ_NATIVE_ICU
 endif # USE_ICU

--- a/mozjs/intl/icu/source/config/mh-mingw
+++ b/mozjs/intl/icu/source/config/mh-mingw
@@ -66,13 +66,11 @@ SO_TARGET_VERSION_SUFFIX =
 endif
 
 # Static library prefix and file extension
-LIBSICU = lib$(LIBPREFIX)$(STATIC_PREFIX)$(ICUPREFIX)
+LIBSICU = $(LIBPREFIX)$(STATIC_PREFIX)$(ICUPREFIX)
 A = a
 
 ## An import library is needed for z/OS and MSVC
 IMPORT_LIB_EXT = .dll.a
-
-LIBPREFIX=
 
 # Change the stubnames so that poorly working FAT disks and installation programs can work.
 # This is also for backwards compatibility.

--- a/mozjs/intl/icu/source/config/mh-mingw64
+++ b/mozjs/intl/icu/source/config/mh-mingw64
@@ -66,13 +66,11 @@ SO_TARGET_VERSION_SUFFIX =
 endif
 
 # Static library prefix and file extension
-LIBSICU = lib$(LIBPREFIX)$(STATIC_PREFIX)$(ICUPREFIX)
+LIBSICU = $(LIBPREFIX)$(STATIC_PREFIX)$(ICUPREFIX)
 A = a
 
 ## An import library is needed for z/OS and MSVC
 IMPORT_LIB_EXT = .dll.a
-
-LIBPREFIX=
 
 # Change the stubnames so that poorly working FAT disks and installation programs can work.
 # This is also for backwards compatibility.

--- a/mozjs/js/src/gc/RootMarking.cpp
+++ b/mozjs/js/src/gc/RootMarking.cpp
@@ -126,7 +126,7 @@ JS::AutoIdArray::trace(JSTracer *trc)
     gc::MarkIdRange(trc, idArray->length, idArray->vector, "JSAutoIdArray.idArray");
 }
 
-inline void
+void
 AutoGCRooter::trace(JSTracer *trc)
 {
     switch (tag_) {

--- a/mozjs/js/src/jspubtd.h
+++ b/mozjs/js/src/jspubtd.h
@@ -221,7 +221,7 @@ class JS_PUBLIC_API(AutoGCRooter)
     }
 
     /* Implemented in gc/RootMarking.cpp. */
-    inline void trace(JSTracer *trc);
+    void trace(JSTracer *trc);
     static void traceAll(JSTracer *trc);
     static void traceAllWrappers(JSTracer *trc);
 

--- a/mozjs/python/mozbuild/mozbuild/milestone.py
+++ b/mozjs/python/mozbuild/mozbuild/milestone.py
@@ -1,3 +1,4 @@
+#!env python
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.


### PR DESCRIPTION
This is a set of changes needed to build mozjs under msys2/mingw64.

Core changes:
- Allow building with msys make
- Don't strip "lib" prefix from library names
- Use system nspr with correct lib names (nspr-config gives incorrect values)
- Force using native win32 python instead of the mingw64/msys python

I'm not really happy with these changes since these are all basically core m-c js files, and I don't think we could take some of these changes in m-c.  But, the majority of changes are correct or are resolving deeper issues in the m-c build system (e.g. the need to use the native win32 python instead of the msys one).

The ICU libprefix stuff can probably be resolved a different way, I just wasn't sure how to go about it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/mozjs/54)
<!-- Reviewable:end -->
