### PR TITLE
Only set target-specific CC and AR for cross-compile

### DIFF
--- a/makefile.cargo
+++ b/makefile.cargo
@@ -1,6 +1,6 @@
 CONFIGURE_FLAGS := --disable-jemalloc
 
-ifeq (eabi,$(findstring eabi,$(TARGET)))
+ifneq ($(HOST),$(TARGET))
 
 CC ?= $(TARGET)-gcc
 CPP ?= $(TARGET)-gcc -E


### PR DESCRIPTION
Checking for "eabi" in $TARGET causes failure to build natively on ARM systems.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/mozjs/59)
<!-- Reviewable:end -->
