### PR TITLE
Enabled jemalloc.

### DIFF
--- a/makefile.cargo
+++ b/makefile.cargo
@@ -1,4 +1,4 @@
-CONFIGURE_FLAGS := --disable-jemalloc
+CONFIGURE_FLAGS := --enable-jemalloc
 
 ifneq ($(HOST),$(TARGET))
 

--- a/mozjs/js/src/moz.build
+++ b/mozjs/js/src/moz.build
@@ -502,6 +502,12 @@ if CONFIG['ENABLE_INTL_API']:
         'icu',
     ]
 
+# https://bugzilla.mozilla.org/show_bug.cgi?id=1134039
+if CONFIG['MOZ_MEMORY']:
+    USE_LIBS += [
+        'memory',
+    ]
+
 USE_LIBS += [
     'nspr',
     'zlib',


### PR DESCRIPTION
The --disable-jemalloc flag in makefile.cargo is replaced by --enable-jemalloc.

The memory library is loaded (as discussed in https://bugzilla.mozilla.org/show_bug.cgi?id=1134039).

This speeds up SM performance significantly (about 2x on some Dromaeo JS tests).