### PR TITLE
Backport of bug 1224722 - Enable executing multiple embedding-provided inputs as self-hosted JS during runtime startup

### DIFF
--- a/mozjs/js/src/builtin/TestingFunctions.cpp
+++ b/mozjs/js/src/builtin/TestingFunctions.cpp
@@ -2440,6 +2440,22 @@ DumpStringRepresentation(JSContext *cx, unsigned argc, Value *vp)
 }
 #endif
 
+static bool
+GetSelfHostedValue(JSContext* cx, unsigned argc, Value* vp)
+{
+    CallArgs args = CallArgsFromVp(argc, vp);
+
+    if (args.length() != 1 || !args[0].isString()) {
+        JS_ReportError(cx, "First argument should be a string");
+        return false;
+    }
+    RootedAtom srcAtom(cx, ToAtom<CanGC>(cx, args[0]));
+    if (!srcAtom)
+        return false;
+    RootedPropertyName srcName(cx, srcAtom->asPropertyName());
+    return cx->runtime()->cloneSelfHostedValue(cx, srcName, args.rval());
+}
+
 static const JSFunctionSpecWithHelp TestingFunctions[] = {
     JS_FN_HELP("gc", ::GC, 0, 0,
 "gc([obj] | 'compartment' [, 'shrinking'])",
@@ -2821,6 +2837,12 @@ gc::ZealModeHelpText),
 "dumpStringRepresentation(str)",
 "  Print a human-readable description of how the string |str| is represented.\n"),
 #endif
+
+JS_FN_HELP("getSelfHostedValue", GetSelfHostedValue, 1, 0,
+"getSelfHostedValue()",
+"  Get a self-hosted value by its name. Note that these values don't get \n"
+"  cached, so repeatedly getting the same value creates multiple distinct clones."),
+
 
     JS_FS_HELP_END
 };

--- a/mozjs/js/src/jsapi-tests/moz.build
+++ b/mozjs/js/src/jsapi-tests/moz.build
@@ -26,6 +26,7 @@ UNIFIED_SOURCES += [
     'testDefinePropertyIgnoredAttributes.cpp',
     'testEnclosingFunction.cpp',
     'testErrorCopying.cpp',
+    'testEvaluateSelfHosted.cpp',
     'testException.cpp',
     'testExternalStrings.cpp',
     'testFindSCCs.cpp',

--- a/mozjs/js/src/jsapi-tests/testEvaluateSelfHosted.cpp
+++ b/mozjs/js/src/jsapi-tests/testEvaluateSelfHosted.cpp
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "builtin/TestingFunctions.h"
+
+#include "jsapi-tests/tests.h"
+
+static bool contentGlobalFunctionCalled = false;
+
+static bool
+ContentGlobalFunction(JSContext* cx, unsigned argc, JS::Value* vp)
+{
+    JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
+    contentGlobalFunctionCalled = true;
+    args.rval().setUndefined();
+    return true;
+}
+
+BEGIN_TEST(testEvaluateSelfHosted)
+{
+    CHECK(js::DefineTestingFunctions(cx, global, false));
+    CHECK(JS_DefineFunction(cx, global, "contentGlobalFunction", ContentGlobalFunction, 0, 0));
+
+    JS::RootedValue v(cx);
+    EVAL("getSelfHostedValue('customSelfHostedFunction')();", &v);
+    CHECK(!JS_IsExceptionPending(cx));
+    CHECK(contentGlobalFunctionCalled == true);
+
+    return true;
+}
+
+virtual JSContext* createContext() override {
+    JSContext* cx = JS_NewContext(rt, 8192);
+    if (!cx)
+        return nullptr;
+    const char* selfHostedCode = "function customSelfHostedFunction()"
+                                 "{global.contentGlobalFunction()}";
+    if (!JS::EvaluateSelfHosted(rt, selfHostedCode, strlen(selfHostedCode), "testing-sh"))
+    {
+        return nullptr;
+    }
+    return cx;
+}
+END_TEST(testEvaluateSelfHosted)

--- a/mozjs/js/src/jsapi-tests/testStructuredClone.cpp
+++ b/mozjs/js/src/jsapi-tests/testStructuredClone.cpp
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "builtin/TestingFunctions.h"
 #include "js/StructuredClone.h"
 
 #include "jsapi-tests/tests.h"

--- a/mozjs/js/src/jsapi.cpp
+++ b/mozjs/js/src/jsapi.cpp
@@ -1874,6 +1874,11 @@ JS_NewGlobalObject(JSContext *cx, const JSClass *clasp, JSPrincipals *principals
     AssertHeapIsIdle(cx);
     CHECK_REQUEST(cx);
 
+    if (!cx->runtime()->hasContentGlobals) {
+        if (!cx->runtime()->completeInitialization(cx))
+            return nullptr;
+    }
+
     return GlobalObject::new_(cx, Valueify(clasp), principals, hookOption, options);
 }
 
@@ -4091,6 +4096,7 @@ ExecuteScript(JSContext *cx, HandleObject obj, HandleScript scriptArg, jsval *rv
     RootedScript script(cx, scriptArg);
 
     MOZ_ASSERT(!cx->runtime()->isAtomsCompartment(cx->compartment()));
+    MOZ_ASSERT(!cx->runtime()->isSelfHostingCompartment(cx->compartment()));
     AssertHeapIsIdle(cx);
     CHECK_REQUEST(cx);
     assertSameCompartment(cx, obj, scriptArg);
@@ -4285,6 +4291,37 @@ JS::Evaluate(JSContext *cx, const ReadOnlyCompileOptions &optionsArg,
              const char *filename, MutableHandleValue rval)
 {
     return ::Evaluate(cx, optionsArg, filename, rval);
+}
+
+JS_PUBLIC_API(bool)
+JS::EvaluateSelfHosted(JSRuntime* rt, const char16_t* chars, size_t length, const char* filename)
+{
+    return rt->evaluateSelfHosted(chars, length, filename);
+}
+
+JS_PUBLIC_API(bool)
+JS::EvaluateSelfHosted(JSRuntime* rt, const char* bytes, size_t length, const char* filename)
+{
+    JSContext* cx = rt->contextList.getFirst();
+    char16_t* chars = UTF8CharsToNewTwoByteCharsZ(cx, JS::UTF8Chars(bytes, length), &length).get();
+    if (!chars)
+        return false;
+    return EvaluateSelfHosted(rt, chars, length, filename);
+}
+
+JS_PUBLIC_API(bool)
+JS::EvaluateSelfHosted(JSRuntime* rt, const char* filename)
+{
+    JSContext* cx = rt->contextList.getFirst();
+    FileContents buffer(cx);
+    {
+        AutoFile file;
+        if (!file.open(cx, filename) || !file.readAll(cx, buffer))
+            return false;
+    }
+    char* bytes = buffer.begin();
+    size_t length = buffer.length();
+    return EvaluateSelfHosted(rt, bytes, length, filename);
 }
 
 JS_PUBLIC_API(bool)

--- a/mozjs/js/src/jsapi.h
+++ b/mozjs/js/src/jsapi.h
@@ -3800,6 +3800,33 @@ extern JS_PUBLIC_API(bool)
 Evaluate(JSContext *cx, const ReadOnlyCompileOptions &options,
          const char *filename, JS::MutableHandleValue rval);
 
+/**
+ * Evaluate the given character buffer as self-hosted JS.
+ *
+ * Can only be used in a process' main runtime and before the first global
+ * object is created, because the self-hosting compartment is shared between
+ * all runtimes in a process, and frozen upon creation of the first content
+ * global in the main runtime.
+ */
+extern JS_PUBLIC_API(bool)
+EvaluateSelfHosted(JSRuntime* rt, const char16_t* chars, size_t length, const char* filename);
+
+/**
+ * Evaluate the given byte buffer as UTF8-encoded self-hosted JS.
+ *
+ * See comment in the char16_t buffer-taking overload above.
+ */
+extern JS_PUBLIC_API(bool)
+EvaluateSelfHosted(JSRuntime* rt, const char* bytes, size_t length, const char* filename);
+
+/**
+ * Load and evaluate the given file path as UTF8-encoded self-hosted JS.
+ *
+ * See comment in the char16_t buffer-taking overload above.
+ */
+extern JS_PUBLIC_API(bool)
+EvaluateSelfHosted(JSRuntime* rt, const char* filename);
+
 } /* namespace JS */
 
 extern JS_PUBLIC_API(bool)

--- a/mozjs/js/src/jsatom.cpp
+++ b/mozjs/js/src/jsatom.cpp
@@ -388,14 +388,15 @@ js::AtomizeString(ExclusiveContext *cx, JSString *str,
         AtomHasher::Lookup lookup(&atom);
 
         /* Likewise, permanent atoms are always interned. */
-        MOZ_ASSERT(cx->isPermanentAtomsInitialized());
-        AtomSet::Ptr p = cx->permanentAtoms().readonlyThreadsafeLookup(lookup);
-        if (p)
-            return &atom;
+        if (cx->isPermanentAtomsInitialized()) {
+            AtomSet::Ptr p = cx->permanentAtoms().readonlyThreadsafeLookup(lookup);
+            if (p)
+                return &atom;
+        }
 
         AutoLockForExclusiveAccess lock(cx);
 
-        p = cx->atoms().lookup(lookup);
+        AtomSet::Ptr p = cx->atoms().lookup(lookup);
         MOZ_ASSERT(p); /* Non-static atom must exist in atom state set. */
         MOZ_ASSERT(p->asPtr() == &atom);
         MOZ_ASSERT(ib == InternAtom);

--- a/mozjs/js/src/jscntxt.cpp
+++ b/mozjs/js/src/jscntxt.cpp
@@ -125,10 +125,6 @@ js::NewContext(JSRuntime *rt, size_t stackChunkSize)
         bool ok = rt->initializeAtoms(cx);
         if (ok)
             ok = rt->initSelfHosting(cx);
-
-        if (ok && !rt->parentRuntime)
-            ok = rt->transformToPermanentAtoms(cx);
-
         JS_EndRequest(cx);
 
         if (!ok) {

--- a/mozjs/js/src/jsscript.cpp
+++ b/mozjs/js/src/jsscript.cpp
@@ -3068,7 +3068,7 @@ js::CloneScript(JSContext *cx, HandleObject enclosingScope, HandleFunction fun, 
     if (cx->runtime()->isSelfHostingCompartment(src->compartment())) {
         if (!cx->compartment()->selfHostingScriptSource) {
             CompileOptions options(cx);
-            FillSelfHostingCompileOptions(options);
+            FillSelfHostingCompileOptions(options, "self-hosted");
 
             ScriptSourceObject *obj = frontend::CreateScriptSourceObject(cx, options);
             if (!obj)

--- a/mozjs/js/src/vm/Runtime.cpp
+++ b/mozjs/js/src/vm/Runtime.cpp
@@ -336,6 +336,21 @@ JSRuntime::init(uint32_t maxbytes, uint32_t maxNurseryBytes)
     return true;
 }
 
+bool
+JSRuntime::completeInitialization(JSContext* cx)
+{
+    MOZ_ASSERT(!hasContentGlobals);
+    hasContentGlobals = true;
+    if (parentRuntime)
+        return true;
+
+    MOZ_ASSERT(!parentRuntime);
+    MOZ_ASSERT(!permanentAtoms);
+    MOZ_ASSERT(selfHostingGlobal_);
+    JSAutoRequest ar(cx);
+    return transformToPermanentAtoms(cx);
+}
+
 JSRuntime::~JSRuntime()
 {
     MOZ_ASSERT(!isHeapBusy());

--- a/mozjs/js/src/vm/Runtime.h
+++ b/mozjs/js/src/vm/Runtime.h
@@ -871,8 +871,7 @@ struct JSRuntime : public JS::shadow::Runtime,
      */
     js::NativeObject *selfHostingGlobal_;
 
-    static js::GlobalObject *
-    createSelfHostingGlobal(JSContext *cx);
+    static js::GlobalObject * createSelfHostingGlobal(JSContext *cx);
 
     /* Space for interpreter frames. */
     js::InterpreterStack interpreterStack_;
@@ -898,7 +897,16 @@ struct JSRuntime : public JS::shadow::Runtime,
     //-------------------------------------------------------------------------
 
     bool initSelfHosting(JSContext *cx);
+    bool evaluateSelfHosted(const char16_t* chars, size_t length, const char* filename);
     void finishSelfHosting();
+    /*
+     * Completes the runtime's initialization by freezing the initial set of
+     * atoms. To be invoked before creating the first content global, and
+     * delayed until then to enable execution of multiple self-hosted scripts
+     * before the self-hosting compartment is frozen to be shared with child
+     * runtimes.
+     */
+    bool completeInitialization(JSContext* cx);
     void markSelfHostingGlobal(JSTracer *trc);
     bool isSelfHostingGlobal(JSObject *global) {
         return global == selfHostingGlobal_;
@@ -1055,6 +1063,9 @@ struct JSRuntime : public JS::shadow::Runtime,
 
     /* A context has been created on this runtime. */
     bool                haveCreatedContext;
+
+    /* At least one content global has been created on this runtime. */
+    bool                hasContentGlobals;
 
     /*
      * Allow relazifying functions in compartments that are active. This is

--- a/mozjs/js/src/vm/SelfHosting.cpp
+++ b/mozjs/js/src/vm/SelfHosting.cpp
@@ -1074,7 +1074,7 @@ static const JSFunctionSpec intrinsic_functions[] = {
 };
 
 void
-js::FillSelfHostingCompileOptions(CompileOptions &options)
+js::FillSelfHostingCompileOptions(CompileOptions &options, const char* filename)
 {
     /*
      * In self-hosting mode, scripts use JSOP_GETINTRINSIC instead of
@@ -1091,7 +1091,7 @@ js::FillSelfHostingCompileOptions(CompileOptions &options)
      * |receiver| as the this-object and ...args as the arguments.
      */
     options.setIntroductionType("self-hosted");
-    options.setFileAndLine("self-hosted", 1);
+    options.setFileAndLine(filename, 1);
     options.setSelfHostingMode(true);
     options.setCanLazilyParse(false);
     options.setVersion(JSVERSION_LATEST);
@@ -1162,40 +1162,48 @@ JSRuntime::initSelfHosting(JSContext *cx)
     if (!shg)
         return false;
 
-    JSAutoCompartment ac(cx, shg);
+    char* filename = getenv("MOZ_SELFHOSTEDJS");
+    if (filename)
+        return JS::EvaluateSelfHosted(this, filename);
+
+    uint32_t srcLen = GetRawScriptsSize();
+    const unsigned char* compressed = compressedSources;
+    uint32_t compressedLen = GetCompressedSize();
+    ScopedJSFreePtr<char> src(selfHostingGlobal_->zone()->pod_malloc<char>(srcLen));
+    if (!src || !DecompressString(compressed, compressedLen,
+                                  reinterpret_cast<unsigned char*>(src.get()), srcLen))
+    {
+        return false;
+    }
+    return JS::EvaluateSelfHosted(this, src, srcLen, "self-hosted");
+}
+
+bool
+JSRuntime::evaluateSelfHosted(const char16_t* chars, size_t length, const char* filename)
+{
+    MOZ_ASSERT(hasContexts());
+    MOZ_ASSERT(selfHostingGlobal_);
+    MOZ_ASSERT(!parentRuntime);
+    MOZ_ASSERT(!hasContentGlobals);
+
+    JSContext* cx = this->contextList.getFirst();
+    JSAutoRequest ar(cx);
+    JSAutoCompartment ac(cx, selfHostingGlobal_);
 
     CompileOptions options(cx);
-    FillSelfHostingCompileOptions(options);
+    FillSelfHostingCompileOptions(options, filename);
 
     /*
      * Set a temporary error reporter printing to stderr because it is too
      * early in the startup process for any other reporter to be registered
      * and we don't want errors in self-hosted code to be silently swallowed.
      */
-    JSErrorReporter oldReporter = JS_SetErrorReporter(cx->runtime(), selfHosting_ErrorReporter);
+    JSErrorReporter oldReporter = JS_SetErrorReporter(this, selfHosting_ErrorReporter);
+
     RootedValue rv(cx);
-    bool ok = true;
+    bool ok = Evaluate(cx, options, chars, length, &rv);
 
-    char *filename = getenv("MOZ_SELFHOSTEDJS");
-    if (filename) {
-        RootedScript script(cx);
-        if (Compile(cx, options, filename, &script))
-            ok = Execute(cx, script, *shg.get(), rv.address());
-    } else {
-        uint32_t srcLen = GetRawScriptsSize();
-
-        const unsigned char *compressed = compressedSources;
-        uint32_t compressedLen = GetCompressedSize();
-        ScopedJSFreePtr<char> src(selfHostingGlobal_->zone()->pod_malloc<char>(srcLen));
-        if (!src || !DecompressString(compressed, compressedLen,
-                                      reinterpret_cast<unsigned char *>(src.get()), srcLen))
-        {
-            ok = false;
-        }
-
-        ok = ok && Evaluate(cx, options, src, srcLen, &rv);
-    }
-    JS_SetErrorReporter(cx->runtime(), oldReporter);
+    JS_SetErrorReporter(this, oldReporter);
     return ok;
 }
 

--- a/mozjs/js/src/vm/SelfHosting.h
+++ b/mozjs/js/src/vm/SelfHosting.h
@@ -21,7 +21,7 @@ bool IsSelfHostedFunctionWithName(JSFunction *fun, JSAtom *name);
 
 /* Get the compile options used when compiling self hosted code. */
 void
-FillSelfHostingCompileOptions(JS::CompileOptions &options);
+FillSelfHostingCompileOptions(JS::CompileOptions &options, const char* filename);
 
 } /* namespace js */
 


### PR DESCRIPTION
@michaelwu wanted to use this in his self-hosting experiments.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/mozjs/65)
<!-- Reviewable:end -->
