### PR TITLE
Hook spidermonkey into rust's allocator

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -17,8 +17,8 @@ fn main() {
     assert!(result.success());
     println!("cargo:rustc-link-search=native={}/dist/lib", out_dir);
     println!("cargo:rustc-link-lib=static=js_static");
+    println!("cargo:rustc-link-lib=static=mozglue");
     if target.contains("windows") {
-        println!("cargo:rustc-link-lib=static=mozglue");
         println!("cargo:rustc-link-lib=winmm");
         println!("cargo:rustc-link-lib=psapi");
     }

--- a/makefile.cargo
+++ b/makefile.cargo
@@ -1,4 +1,7 @@
-CONFIGURE_FLAGS := --disable-jemalloc
+SRC_DIR := $(shell pwd)
+
+CONFIGURE_FLAGS := --disable-jemalloc --disable-shared-js
+CPPFLAGS := -DJS_USE_CUSTOM_ALLOCATOR=1 -I$(SRC_DIR)/rust_mem
 
 ifneq ($(HOST),$(TARGET))
 
@@ -63,25 +66,26 @@ ifeq ($(MSYSTEM),MINGW64)
 	$(error Can't find native Win32 python)
 	endif
 
-	CONFIGURE_FLAGS += --disable-shared-js --disable-export-js
+	CONFIGURE_FLAGS += --disable-export-js
 
 endif
-
-SRC_DIR = $(shell pwd)
 
 .PHONY : all
 ifneq (,$(FORCED_PYTHON))
-all:
+all: $(OUT_DIR)/fake_rustalloc.o
 	cd $(OUT_DIR) && \
 	PYTHON="$(FORCED_PYTHON)" \
-	MOZ_TOOLS="$(MOZ_TOOLS)" CC="$(CC)" CPP="$(CPP)" CXX="$(CXX)" AR="$(AR)" \
+	MOZ_TOOLS="$(MOZ_TOOLS)" CC="$(CC)" CPP="$(CPP)" CXX="$(CXX)" AR="$(AR)" CPPFLAGS="$(CPPFLAGS)" LDFLAGS="$(LDFLAGS)" \
 	$(SRC_DIR)/mozjs/js/src/configure $(strip $(CONFIGURE_FLAGS))
 	cd $(OUT_DIR) && make -f Makefile -j$(NUM_JOBS)
 else
-all:
+all: $(OUT_DIR)/fake_rustalloc.o
 	cd $(OUT_DIR) && \
-	MOZ_TOOLS="$(MOZ_TOOLS)" CC="$(CC)" CPP="$(CPP)" CXX="$(CXX)" AR="$(AR)" \
+	MOZ_TOOLS="$(MOZ_TOOLS)" CC="$(CC)" CPP="$(CPP)" CXX="$(CXX)" AR="$(AR)" CPPFLAGS="$(CPPFLAGS)" LDFLAGS="$(LDFLAGS)" \
 	$(SRC_DIR)/mozjs/js/src/configure $(strip $(CONFIGURE_FLAGS))
 	cd $(OUT_DIR) && make -f Makefile -j$(NUM_JOBS)
 endif
 
+LDFLAGS := $(OUT_DIR)/fake_rustalloc.o
+$(OUT_DIR)/fake_rustalloc.o: rust_mem/fake_rustalloc.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $< -o $@ -c

--- a/rust_mem/fake_rustalloc.cpp
+++ b/rust_mem/fake_rustalloc.cpp
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <stdlib.h>
+
+extern "C" {
+
+void*  __rust_allocate(size_t bytes, size_t align)
+{
+    return malloc(bytes);
+}
+
+void* __rust_reallocate(void* p, size_t old_size, size_t size, size_t align)
+{
+    return realloc(p, size);
+}
+
+void __rust_deallocate(void* ptr, size_t old_size, size_t align)
+{
+    free(ptr);
+}
+
+}

--- a/rust_mem/jscustomallocator.h
+++ b/rust_mem/jscustomallocator.h
@@ -31,6 +31,18 @@ static inline void* js_calloc(size_t nmemb, size_t size)
 {
     size_t bytes = size * nmemb;
     void* buf = __rust_allocate(bytes, 0);
+    // TODO: Do overflow checking when we have gcc >= 5
+#if 0
+    size_t bytes = 0;
+    void* buf;
+    if (__builtin_umull_overflow(nmemb, size, &bytes)) {
+        buf = NULL;
+        errno = ENOMEM;
+    } else {
+        buf = __rust_allocate(bytes, 0);
+    }
+#endif
+
     if (bytes && buf) {
         memset(buf, 0, bytes);
     }

--- a/rust_mem/jscustomallocator.h
+++ b/rust_mem/jscustomallocator.h
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#define JS_OOM_POSSIBLY_FAIL() do {} while(0)
+#define JS_OOM_POSSIBLY_FAIL_BOOL() do {} while(0)
+
+namespace js {
+namespace oom {
+static inline bool IsSimulatedOOMAllocation() { return false; }
+static inline bool ShouldFailWithOOM() { return false; }
+} /* namespace oom */
+} /* namespace js */
+
+extern "C" void*  __rust_allocate(size_t bytes, size_t align);
+static inline void* js_malloc(size_t bytes)
+{
+    return __rust_allocate(bytes, 0);
+}
+
+static inline void* js_calloc(size_t bytes)
+{
+    void* buf = __rust_allocate(bytes, 0);
+    if (bytes && buf) {
+        memset(buf, 0, bytes);
+    }
+    return buf;
+}
+
+static inline void* js_calloc(size_t nmemb, size_t size)
+{
+    size_t bytes = size * nmemb;
+    void* buf = __rust_allocate(bytes, 0);
+    if (bytes && buf) {
+        memset(buf, 0, bytes);
+    }
+    return buf;
+}
+
+extern "C" void* __rust_reallocate(void* p, size_t old_size, size_t size, size_t align);
+static inline void* js_realloc(void* p, size_t bytes)
+{
+    // XXX not actually safe, but no rust allocator uses the old size right now
+    return __rust_reallocate(p, 0, bytes, 0);
+}
+
+extern "C" void __rust_deallocate(void* ptr, size_t old_size, size_t align);
+static inline void js_free(void* p)
+{
+    __rust_deallocate(p, 0, 0);
+}
+
+static inline char* js_strdup(const char* s)
+{
+    size_t len = strlen(s);
+    char* buf = (char*)__rust_allocate(len + 1, 0);
+    if (buf) {
+        memcpy(buf, s, len);
+        buf[len] = 0;
+    }
+
+    return buf;
+}
+


### PR DESCRIPTION
This is the alternative to https://github.com/servo/mozjs/pull/61 . Rust doesn't quite provide all the APIs necessary to do this fully - there is no calloc equivalent, but it's probably fine in most cases.

fake_rustalloc is provided to link the js shell and tests, but isn't used anywhere else.

@asajeffrey - do you mind seeing if this works as well as turning on jemalloc?

r? @Manishearth

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/mozjs/72)

<!-- Reviewable:end -->
