### PR TITLE
Compile targeting modern ARM processors on Android for hardfloat

### DIFF
--- a/makefile.cargo
+++ b/makefile.cargo
@@ -13,6 +13,8 @@ CONFIGURE_FLAGS += --target=$(TARGET) --without-intl-api
 		CONFIGURE_FLAGS += \
 			--with-android-ndk=$(ANDROID_NDK) \
 			--with-android-toolchain=$(ANDROID_TOOLCHAIN) \
+			--with-arch=armv7-a \
+			--with-fpu=neon \
 			$(NULL)
 	endif
 else


### PR DESCRIPTION
r? @Ms2ger 

This ensures that when SM has any floating point operations on Android in the C code, they're compiled to use SIMD instructions and/or FP registers instead of integer registers or fallback code. Big perf win.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/mozjs/74)
<!-- Reviewable:end -->
