### PR TITLE
Disable use of the gold linker on cross-targets

### DIFF
--- a/makefile.cargo
+++ b/makefile.cargo
@@ -7,7 +7,7 @@ CPP ?= $(TARGET)-gcc -E
 CXX ?= $(TARGET)-g++
 AR ?= $(TARGET)-ar
 
-CONFIGURE_FLAGS += --target=$(TARGET) --without-intl-api
+CONFIGURE_FLAGS += --target=$(TARGET) --without-intl-api --disable-gold
 
 	ifeq (androideabi,$(findstring androideabi,$(TARGET)))
 		CONFIGURE_FLAGS += \


### PR DESCRIPTION
r? @Ms2ger @jdm 

The gold linker often either produces errors or incorrect binaries in cross-target builds. This is currently breaking the ARM64 builder.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/mozjs/75)
<!-- Reviewable:end -->
