### PR TITLE
Prepend MOZTOOLS_BIN to PATH, not append

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -26,8 +26,9 @@ fn main() {
     // Put MOZTOOLS_PATH at the beginning of PATH if specified
     if let Some(moztools) = env::var_os("MOZTOOLS_PATH") {
         let path = env::var_os("PATH").unwrap();
+        let moztools_str = moztools.into_string().unwrap();
         let mut paths = env::split_paths(&path).collect::<Vec<_>>();
-        paths.push(PathBuf::from(moztools));
+        paths.insert(0, PathBuf::from(moztools_str.clone()));
         let new_path = env::join_paths(paths).unwrap();
         env::set_var("PATH", &new_path);
         make = OsStr::new("mozmake").to_os_string();

--- a/makefile.cargo
+++ b/makefile.cargo
@@ -91,9 +91,9 @@ endif
 # Windows, do it here
 ifeq ($(NEED_WIN_PYTHON),1)
 	ifneq (,$(NATIVE_WIN32_PYTHON))
-		PYTHON := "$(NATIVE_WIN32_PYTHON)"
+		PYTHON := $(NATIVE_WIN32_PYTHON)
 	else ifneq (,$(wildcard c:/python27/python.exe))
-		PYTHON := "c:/python27/python.exe"
+		PYTHON := c:/python27/python.exe
 	else
 		$(message You must either have the Native Win32 python installed in C:/python27, or set NATIVE_WIN32_PYTHON to point to the appropriate python.exe.)
 		$(message Download the Python installer from  https://www.python.org/downloads/release/python-2710/)


### PR DESCRIPTION
We need the moz tools to be at the start of the path, to not pick up random things along the way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/mozjs/88)
<!-- Reviewable:end -->
