### PR TITLE
More portable way to set SHELL to bash.

### DIFF
--- a/makefile.cargo
+++ b/makefile.cargo
@@ -1,6 +1,6 @@
 # We need to use bash here, as there are a couple of targets below
 # that use [[ to do conditional things
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 
 # Default flags
 CONFIGURE_FLAGS := \


### PR DESCRIPTION
This is the only problem I found while trying to build on NixOS (the usual problem from the unpatched virtualenv that SpiderMonkey bundles seems to have fixed itself so 🎉).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/mozjs/109)
<!-- Reviewable:end -->
