### PR TITLE
Change makefile.cargo to work with Build Tools

### DIFF
--- a/makefile.cargo
+++ b/makefile.cargo
@@ -28,7 +28,7 @@ CONFIGURE_FLAGS += --target=$(TARGET) --disable-gold
 	endif
 else
 
-ifeq (,$(VSINSTALLDIR))
+ifeq (,$(VCINSTALLDIR))
 CC ?= gcc
 CPP ?= gcc -E
 CXX ?= g++
@@ -50,7 +50,7 @@ ifneq (,$(CCACHE))
 	CONFIGURE_FLAGS += --with-ccache=$(CCACHE)
 endif
 
-ifneq ($(VSINSTALLDIR),)
+ifneq ($(VCINSTALLDIR),)
 	# Visual Studio build
 	NEED_WIN_PYTHON := 1
 


### PR DESCRIPTION
The Visual C++ Build Tools package (which is freely provided by Microsoft) does not set `VSINSTALLDIR`. On the other hand, `VCINSTALLDIR` should as long as you have Visual C++ in any form.

https://social.msdn.microsoft.com/Forums/vstudio/en-US/198f6382-c5d2-4651-9135-0fde236793e7/environment-variables-in-visual-studio?forum=vcgeneral

Everything else is building, so close servo/servo#13325

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/mozjs/111)
<!-- Reviewable:end -->
