### PR TITLE
Make it compile for Android x86 (i686)

### DIFF
--- a/makefile.cargo
+++ b/makefile.cargo
@@ -18,10 +18,15 @@ AR ?= $(TARGET)-ar
 
 CONFIGURE_FLAGS += --target=$(TARGET) --disable-gold
 
-	ifeq (androideabi,$(findstring androideabi,$(TARGET)))
+	ifeq (android,$(findstring android,$(TARGET)))
 		CONFIGURE_FLAGS += \
 			--with-android-ndk=$(ANDROID_NDK) \
 			--with-android-toolchain=$(ANDROID_TOOLCHAIN) \
+			$(NULL)
+	endif
+
+	ifeq (androideabi,$(findstring androideabi,$(TARGET)))
+		CONFIGURE_FLAGS += \
 			--with-arch=armv7-a \
 			--with-fpu=neon \
 			$(NULL)


### PR DESCRIPTION
For Android x86 the `ANDROID_NDK` environment variable isn't passed
on correctly. Without this change it's not possible to compile the
`mozjs_sys` crate for Android x86, it would fail with:

    Reexecuting in the virtualenv
    checking for a shell... /bin/sh
    checking for host system type... x86_64-pc-linux-gnu
    checking for target system type... i686-pc-linux-android
    checking for the Android toolchain directory... not found
    ...
    configure: error: not found. Please check your NDK. With the current configuration, it should be in /platforms/android-9/arch-x86

With this change it's possible to compile it successfully for Android
x86 with:

    PATH=$PATH:<x86-toolchain>/bin ANDROID_NDK=<android-ndk-r12b> cargo build --target i686-linux-android --verbose

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/mozjs/115)
<!-- Reviewable:end -->
