### PR TITLE
More explicit error if `make` isn't installed

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -39,7 +39,7 @@ fn main() {
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
         .status()
-        .unwrap();
+        .expect("Failed to run `make`");
     assert!(result.success());
     println!("cargo:rustc-link-search=native={}/js/src", out_dir);
     if target.contains("windows") {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/mozjs/121)
<!-- Reviewable:end -->
