### PR TITLE
Add `exclude` to `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,13 @@ authors = ["Mozilla"]
 links = "mozjs"
 build = "build.rs"
 license = "MPL-2.0"
+exclude = [
+  "mozjs/js/src/tests/**",
+  "mozjs/js/src/octane/**",
+  "mozjs/js/src/jit-test/**",
+  "mozjs/js/src/jsapi-tests/**",
+  "mozjs/js/src/doc/**",
+]
 
 [features]
 debugmozjs = []


### PR DESCRIPTION
Excludes tests and documentation, which isn't necessary to build, and therefore not necessary for the .crate tarball.

Excluding ICU causes the build to fail. We can investigate this later, if we feel the need. We now have a 50M limit for our crate on crates.io, so we should be able to publish now either way.

r? @SimonSapin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/mozjs/128)
<!-- Reviewable:end -->
