### PR TITLE
Use python2 for the build whenever possible and bump the version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository = "https://github.com/servo/mozjs/"
-version = "0.50.0"
+version = "0.50.1"
 authors = ["Mozilla"]
 links = "mozjs"
 build = "build.rs"

--- a/makefile.cargo
+++ b/makefile.cargo
@@ -50,7 +50,14 @@ ifeq (,$(VCINSTALLDIR))
 		CXX ?= g++
 	endif
 AR ?= ar
+
+# check if python2 is a valid Python executable, otherwise fall back to python
+ifeq (, $(findstring Python 2.,$(shell python2 --version 2> /dev/null)))
+PYTHON ?= python2
+else
 PYTHON ?= python
+endif 
+
 endif
 
 endif


### PR DESCRIPTION
If python2 seems to be a valid Python 2 interpreter, the configure
script will use it. Otherwise, it will fall back to python, as
previously.

We also bump the crate version so that this change can be propagated
further the dependency tree.

Closes #129.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/mozjs/132)
<!-- Reviewable:end -->
