### PR TITLE
Made building under Windows easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Under Windows:
 set MOZTOOLS_PATH=C:\mozilla-build\msys\bin;C:\mozilla-build\mozmake;C:\mozilla-build\yasm
 ```
 
+4. Download and install Clang for Windows (64 bit) from https://releases.llvm.org/download.html
+   and set the `LIBCLANG_PATH` environment variable to its `lib` directory:
+```
+set LIBCLANG_PATH=C:\Program Files\LLVM\lib
+```
+
 You can now build and test the crate using cargo:
 ```
 cargo build

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Under Windows:
 "c:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
 ```
 
-3. Set the `MOZTOOLS_PATH` environement variable to point to the tools from the Mozilla Build Package:
+3. Set the `MOZTOOLS_PATH` environment variable to point to the tools from the Mozilla Build Package:
 ```
 set MOZTOOLS_PATH=C:\mozilla-build\msys\bin;C:\mozilla-build\mozmake;C:\mozilla-build\yasm
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Under Windows:
 "c:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
 ```
 
-3. Set the `MOZTOOLS` environement variable to point to the tools from the Mozilla Build Package:
+3. Set the `MOZTOOLS_PATH` environement variable to point to the tools from the Mozilla Build Package:
 ```
 set MOZTOOLS_PATH=C:\mozilla-build\msys\bin;C:\mozilla-build\mozmake;C:\mozilla-build\yasm
 ```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,34 @@ The bindings are in the [rust-mozjs repository][r-m].
 
 [r-m]: https://github.com/servo/rust-mozjs/
 
+Building
+========
+
+Under Windows:
+
+1. Follow the directions at
+   https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Windows_Prerequisites
+
+2. Open up a shell configured to use Visual Studio. This could be the
+   one included with Visual Studio (e.g. Visual Studio 2017 / X64 Native
+   Tools Command Prompt for VS 2017) or a shell in which you have run
+```
+"c:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+```
+
+3. Set the `MOZTOOLS` environement variable to point to the tools from the Mozilla Build Package:
+```
+set MOZTOOLS_PATH=C:\mozilla-build\msys\bin;C:\mozilla-build\mozmake;C:\mozilla-build\yasm
+```
+
+You can now build and test the crate using cargo:
+```
+cargo build
+cargo test
+cargo build --features debugmozjs
+cargo test --features debugmozjs
+```
+
 Upgrading
 =========
 

--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use std::env;
-use std::path::PathBuf;
 use std::ffi::{OsStr, OsString};
 use std::process::{Command, Stdio};
 
@@ -26,9 +25,9 @@ fn main() {
     // Put MOZTOOLS_PATH at the beginning of PATH if specified
     if let Some(moztools) = env::var_os("MOZTOOLS_PATH") {
         let path = env::var_os("PATH").unwrap();
-        let moztools_str = moztools.into_string().unwrap();
-        let mut paths = env::split_paths(&path).collect::<Vec<_>>();
-        paths.insert(0, PathBuf::from(moztools_str.clone()));
+        let mut paths = Vec::new();
+        paths.extend(env::split_paths(&moztools));
+        paths.extend(env::split_paths(&path));
         let new_path = env::join_paths(paths).unwrap();
         env::set_var("PATH", &new_path);
         make = OsStr::new("mozmake").to_os_string();


### PR DESCRIPTION
Added some documentation on building under Windows, and allowed `MOZTOOLS_PATH` to contain multiple entries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/mozjs/133)
<!-- Reviewable:end -->
