### PR TITLE
Remove patch for libloading.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,3 @@ libz-sys = "1.0"
 [build-dependencies]
 bindgen = "0.36.1"
 cc = "1.0"
-
-[patch.crates-io]
-libloading = { git = "https://github.com/servo/rust_libloading", branch = "mac-crash-revert" }


### PR DESCRIPTION
This prevents publishing the crate and is unnecessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/mozjs/140)
<!-- Reviewable:end -->
