### PR TITLE
Correct MOZTOOLS_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Under Windows:
 
 3. Set the `MOZTOOLS_PATH` environment variable to point to the tools from the Mozilla Build Package:
 ```
-set MOZTOOLS_PATH=C:\mozilla-build\msys\bin;C:\mozilla-build\mozmake;C:\mozilla-build\yasm
+set MOZTOOLS_PATH=C:\mozilla-build\msys\bin;C:\mozilla-build\bin
 ```
 
 4. Download and install Clang for Windows (64 bit) from https://releases.llvm.org/download.html


### PR DESCRIPTION
The proposed `MOZTOOLS_PATH` no longer seems to be correct, as the current [MozillaBuild Package](https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Windows_Prerequisites#MozillaBuild) doesn't create either `C:\mozilla-build\mozmake` or `C:\mozilla-build\yasm` directories. `mozmake.exe` and `yasm.exe` do exist in `C:\mozilla-build\bin`, though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/mozjs/145)
<!-- Reviewable:end -->
