### PR TITLE
Update bindgen and bump the minimum Rust version to 1.25

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rust:
   - nightly
   - beta
   - stable
+  - 1.25.0
 sudo: 9000
 dist: trusty
 os:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository = "https://github.com/servo/mozjs/"
-version = "0.60.1"
+version = "1.60.0"
 authors = ["Mozilla"]
 links = "mozjs"
 build = "build.rs"
@@ -26,5 +26,5 @@ libc = "0.2"
 libz-sys = "1.0"
 
 [build-dependencies]
-bindgen = "0.37"
+bindgen = "0.39"
 cc = "1.0"

--- a/build.rs
+++ b/build.rs
@@ -171,10 +171,10 @@ fn build_jsapi_bindings() {
     // so their symbols aren't available. Adding the -fkeep-inlined-functions option
     // causes the jsapi library to bloat from 500M to 6G, so that's not an option.
     let mut config = bindgen::CodegenConfig::all();
-    config.constructors = false;
-    config.destructors = false;
-    config.methods = false;
-    
+    config &= !bindgen::CodegenConfig::CONSTRUCTORS;
+    config &= !bindgen::CodegenConfig::DESTRUCTORS;
+    config &= !bindgen::CodegenConfig::METHODS;
+
     let mut builder = bindgen::builder()
         .rust_target(bindgen::RustTarget::Stable_1_19)
         .header("./src/jsglue.hpp")

--- a/build.rs
+++ b/build.rs
@@ -176,7 +176,7 @@ fn build_jsapi_bindings() {
     config &= !bindgen::CodegenConfig::METHODS;
 
     let mut builder = bindgen::builder()
-        .rust_target(bindgen::RustTarget::Stable_1_19)
+        .rust_target(bindgen::RustTarget::Stable_1_25)
         .header("./src/jsglue.hpp")
         // Translate every enum with the "rustified enum" strategy. We should
         // investigate switching to the "constified module" strategy, which has

--- a/src/jsval.rs
+++ b/src/jsval.rs
@@ -79,8 +79,6 @@ const JSVAL_PAYLOAD_MASK: u64 = 0x00007FFFFFFFFFFF;
 #[inline(always)]
 fn AsJSVal(val: u64) -> JSVal {
     JSVal {
-	#[cfg(all(target_os = "android", target_arch = "x86"))]
-	__bindgen_align: [],
         data: Value_layout {
             asBits: val,
         }


### PR DESCRIPTION
This lets bindgen use `#[repr(align = …)]`, which removes the need for dummy `__bindgen_align` zero-size array fields.

This field was only present with some versions of libclang (presumably), which could cause build failures like:

```rust
error[E0560]: struct `generated::root::JS::Value` has no field named `__bindgen_align`sys
  --> /home/simon/projects/mozjs/src/jsval.rs:83:2
   |
83 |     __bindgen_align: [],
   |     ^^^^^^^^^^^^^^^ `generated::root::JS::Value` does not have this field
```