### PR TITLE
Support to get PromiseIsHandled internal slot in Promise

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository = "https://github.com/servo/mozjs/"
-version = "0.61.0"
+version = "0.61.1"
 authors = ["Mozilla"]
 links = "mozjs"
 build = "build.rs"

--- a/etc/patches/is_handled.patch
+++ b/etc/patches/is_handled.patch
@@ -1,0 +1,36 @@
+diff --git a/mozjs/js/src/jsapi.cpp b/mozjs/js/src/jsapi.cpp
+index 94ef1b3ed..06be95062 100644
+--- a/mozjs/js/src/jsapi.cpp
++++ b/mozjs/js/src/jsapi.cpp
+@@ -5162,6 +5162,14 @@ JS::GetPromiseResult(JS::HandleObject promiseObj)
+     return promise->state() == JS::PromiseState::Fulfilled ? promise->value() : promise->reason();
+ }
+ 
++JS_PUBLIC_API(bool)
++JS::GetPromiseIsHandled(JS::HandleObject promiseObj)
++{
++    PromiseObject* promise = &promiseObj->as<PromiseObject>();
++    MOZ_ASSERT(promise->state() == JS::PromiseState::Rejected);
++    return !promise->isUnhandled();
++}
++
+ JS_PUBLIC_API(JSObject*)
+ JS::GetPromiseAllocationSite(JS::HandleObject promise)
+ {
+diff --git a/mozjs/js/src/jsapi.h b/mozjs/js/src/jsapi.h
+index c7f92e273..5c5e9abc5 100644
+--- a/mozjs/js/src/jsapi.h
++++ b/mozjs/js/src/jsapi.h
+@@ -4390,6 +4390,12 @@ GetPromiseID(JS::HandleObject promise);
+ extern JS_PUBLIC_API(JS::Value)
+ GetPromiseResult(JS::HandleObject promise);
+ 
++/**
++ * Returns thhe given Promise's internal slot of `isHandled`.
++ */
++extern JS_PUBLIC_API(bool)
++GetPromiseIsHandled(JS::HandleObject promise);
++
+ /**
+  * Returns a js::SavedFrame linked list of the stack that lead to the given
+  * Promise's allocation.

--- a/mozjs/js/src/jsapi.cpp
+++ b/mozjs/js/src/jsapi.cpp
@@ -5162,6 +5162,14 @@ JS::GetPromiseResult(JS::HandleObject promiseObj)
     return promise->state() == JS::PromiseState::Fulfilled ? promise->value() : promise->reason();
 }
 
+JS_PUBLIC_API(bool)
+JS::GetPromiseIsHandled(JS::HandleObject promiseObj)
+{
+    PromiseObject* promise = &promiseObj->as<PromiseObject>();
+    MOZ_ASSERT(promise->state() == JS::PromiseState::Rejected);
+    return !promise->isUnhandled();
+}
+
 JS_PUBLIC_API(JSObject*)
 JS::GetPromiseAllocationSite(JS::HandleObject promise)
 {

--- a/mozjs/js/src/jsapi.h
+++ b/mozjs/js/src/jsapi.h
@@ -4391,6 +4391,12 @@ extern JS_PUBLIC_API(JS::Value)
 GetPromiseResult(JS::HandleObject promise);
 
 /**
+ * Returns thhe given Promise's internal slot of `isHandled`.
+ */
+extern JS_PUBLIC_API(bool)
+GetPromiseIsHandled(JS::HandleObject promise);
+
+/**
  * Returns a js::SavedFrame linked list of the stack that lead to the given
  * Promise's allocation.
  */


### PR DESCRIPTION
When trying to implement unhandled rejection in servo/servo#20755, I'd need to check the internal slot of Promise which is the step 4.1.1 for the spec of [notify about rejected promises](https://html.spec.whatwg.org/multipage/webappapis.html#notify-about-rejected-promises).
So, this PR will add the API to add the `GetPromiseIsHandled` method.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/mozjs/150)
<!-- Reviewable:end -->
