### PR TITLE
Use a more recent stable version of Rust.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rust:
   - nightly
   - beta
   - stable
-  - 1.25.0
+  - 1.26.0
 sudo: 9000
 dist: trusty
 os:


### PR DESCRIPTION
This works around #152 by upgrading to a version of Rust that can build the most recent release of libz-sys.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/mozjs/153)
<!-- Reviewable:end -->
