### PR TITLE
Added mozjs/third_party/python/psutil/build and tmp to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ js/src/builtin/jsmin.pyc
 js/src/build/ConfigStatus.pyc
 js/src/config/Preprocessor.pyc
 mozjs/python/psutil/build
+mozjs/third_party/python/psutil/build
+mozjs/third_party/python/psutil/tmp
 /doc
 /target
 /Cargo.lock


### PR DESCRIPTION
Makes `cargo publish` happier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/mozjs/157)
<!-- Reviewable:end -->
