### PR TITLE
Configure the Android NDK

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository = "https://github.com/servo/mozjs/"
-version = "0.61.1"
+version = "0.61.2"
 authors = ["Mozilla"]
 links = "mozjs"
 build = "build.rs"

--- a/build.rs
+++ b/build.rs
@@ -197,9 +197,7 @@ fn build_jsapi_bindings() {
 
     if let Ok(flags) = env::var("CXXFLAGS") {
         for flag in flags.split_whitespace() {
-            if !flag.starts_with("--sysroot") {
-                builder = builder.clang_arg(flag);
-            }
+            builder = builder.clang_arg(flag);
         }
     }
 

--- a/etc/patches/bionic-glue-android-api-not-version.patch
+++ b/etc/patches/bionic-glue-android-api-not-version.patch
@@ -1,0 +1,22 @@
+diff --git a/mozjs/mozglue/build/BionicGlue.cpp b/mozjs/mozglue/build/BionicGlue.cpp
+index b9b882166..710d01f2e 100644
+--- a/mozjs/mozglue/build/BionicGlue.cpp
++++ b/mozjs/mozglue/build/BionicGlue.cpp
+@@ -17,7 +17,7 @@
+ 
+ #define NS_EXPORT __attribute__ ((visibility("default")))
+ 
+-#if ANDROID_VERSION < 17 || defined(MOZ_WIDGET_ANDROID)
++#if __ANDROID_API__ < 17 || defined(MOZ_WIDGET_ANDROID)
+ /* Android doesn't have pthread_atfork(), so we need to use our own. */
+ struct AtForkFuncs {
+   void (*prepare)(void);
+@@ -64,7 +64,7 @@ private:
+ static std::vector<AtForkFuncs, SpecialAllocator<AtForkFuncs> > atfork;
+ #endif
+ 
+-#if ANDROID_VERSION < 17 || defined(MOZ_WIDGET_ANDROID)
++#if __ANDROID_API__ < 17 || defined(MOZ_WIDGET_ANDROID)
+ extern "C" NS_EXPORT int
+ pthread_atfork(void (*prepare)(void), void (*parent)(void), void (*child)(void))
+ {

--- a/etc/patches/configure-override-android-ndk-paths.patch
+++ b/etc/patches/configure-override-android-ndk-paths.patch
@@ -1,0 +1,87 @@
+diff --git a/mozjs/build/moz.configure/android-ndk.configure b/mozjs/build/moz.configure/android-ndk.configure
+index 5193332f3..21f7e2767 100644
+--- a/mozjs/build/moz.configure/android-ndk.configure
++++ b/mozjs/build/moz.configure/android-ndk.configure
+@@ -8,6 +8,15 @@
+ js_option('--with-android-ndk', nargs=1,
+           help='location where the Android NDK can be found')
+ 
++js_option('--with-android-ndk-version', nargs=1,
++          help='android NDK version')
++
++js_option('--with-android-platform', nargs=1,
++          help='location of the Android platform')
++
++js_option('--with-android-clang', nargs=1,
++          help='location of the Android clang compiler')
++
+ js_option('--with-android-toolchain', nargs=1,
+           help='location of the Android toolchain')
+ 
+@@ -66,13 +75,17 @@ set_config('ANDROID_NDK', ndk)
+ add_old_configure_assignment('android_ndk', ndk)
+ 
+ 
+-@depends(ndk)
++@depends('--with-android-ndk-version', ndk)
+ @checking('for android ndk version')
+ @imports(_from='__builtin__', _import='open')
+-def ndk_version(ndk):
++def ndk_version(value, ndk):
+     if not ndk:
+         # Building 'js/src' for non-Android.
+         return
++
++    if value:
++        return value[0]
++
+     with open(os.path.join(ndk, 'source.properties'), 'r') as f:
+         for line in f:
+             if not line.startswith('Pkg.Revision'):
+@@ -112,13 +125,16 @@ def ndk_minor_version(ndk_version):
+ set_config('ANDROID_NDK_MINOR_VERSION', ndk_minor_version)
+ 
+ 
+-@depends(target, android_version, ndk, '--help')
++@depends('--with-android-platform', target, android_version, ndk, '--help')
+ @checking('for android platform directory')
+ @imports(_from='os.path', _import='isdir')
+-def android_platform(target, android_version, ndk, _):
++def android_platform(value, target, android_version, ndk, _):
+     if target.os != 'Android':
+         return
+ 
++    if value:
++        return value[0]
++
+     if 'mips' in target.cpu:
+         target_dir_name = 'mips'
+     elif 'aarch64' == target.cpu:
+@@ -257,7 +273,7 @@ option(env='STLPORT_CPPFLAGS',
+ @imports(_from='os.path', _import='isdir')
+ def stlport_cppflags(value, ndk, _):
+     if value and len(value):
+-        return value.split()
++        return value[0].split()
+     if not ndk:
+         return
+ 
+@@ -339,13 +355,16 @@ def bindgen_cflags_defaults(toolchain_flags, toolchain, toolchain_prefix, _):
+                             os.path.join(gcc_include, 'include-fixed'))
+ 
+ 
+-@depends(host, ndk)
++@depends('--with-android-clang', host, ndk)
+ @imports(_from='os.path', _import='exists')
+ @imports(_from='os.path', _import='isdir')
+-def android_clang_compiler(host, ndk):
++def android_clang_compiler(value, host, ndk):
+     if not ndk:
+         return
+ 
++    if value:
++        return value[0]
++
+     llvm_path = '%s/toolchains/llvm/prebuilt/%s-%s/bin' % (ndk,
+                                                            host.kernel.lower(),
+                                                            host.cpu)

--- a/makefile.cargo
+++ b/makefile.cargo
@@ -22,11 +22,27 @@ ifneq ($(HOST),$(TARGET))
 	endif
 
 	ifeq (android,$(findstring android,$(TARGET)))
-		CONFIGURE_FLAGS += \
-			--with-android-ndk=$(ANDROID_NDK) \
-			--with-android-toolchain=$(ANDROID_TOOLCHAIN) \
-			--with-android-version=$(NDK_ANDROID_VERSION) \
-			$(NULL)
+		ifneq (,$(STLPORT_CPPFLAGS))
+			CONFIGURE_FLAGS += STLPORT_CPPFLAGS="$(STLPORT_CPPFLAGS)"
+		endif
+		ifneq (,$(ANDROID_NDK))
+			CONFIGURE_FLAGS += --with-android-ndk=$(ANDROID_NDK)
+		endif
+		ifneq (,$(ANDROID_NDK_VERSION))
+			CONFIGURE_FLAGS += --with-android-ndk-version=$(ANDROID_NDK_VERSION)
+		endif
+		ifneq (,$(ANDROID_VERSION))
+			CONFIGURE_FLAGS += --with-android-version=$(ANDROID_VERSION)
+		endif
+		ifneq (,$(ANDROID_PLATFORM_DIR))
+			CONFIGURE_FLAGS += --with-android-platform=$(ANDROID_PLATFORM_DIR)
+		endif
+		ifneq (,$(ANDROID_TOOLCHAIN_DIR))
+			CONFIGURE_FLAGS += --with-android-toolchain=$(ANDROID_TOOLCHAIN_DIR)
+		endif
+		ifneq (,$(ANDROID_CLANG))
+			CONFIGURE_FLAGS += --with-android-clang=$(ANDROID_CLANG)
+		endif
 	endif
 
 CC ?= $(TARGET)-gcc
@@ -143,6 +159,10 @@ maybe-configure:
 	if [[ $(JSSRC)/configure -nt $(OUT_DIR)/config.status ]] ; then \
 	  cd $(OUT_DIR) && \
 	  PYTHON="$(PYTHON)" MOZ_TOOLS="$(MOZ_TOOLS)" \
-	  CC="$(CC)" CPP="$(CPP)" CXX="$(CXX)" AR="$(AR)" \
+	  CC="$(CC)" CFLAGS="$(CFLAGS)" \
+	  CPP="$(CPP)" CPPFLAGS="$(CPPFLAGS)" \
+	  CXX="$(CXX)" CXXFLAGS="$(CXXFLAGS)" \
+	  AS="$(AS)" AR="$(AR)" \
+	  STLPORT_LIBS="$(STLPORT_LIBS)" \
 	  $(JSSRC)/configure $(strip $(CONFIGURE_FLAGS)) || (cat config.log && exit 1) ; \
 	fi

--- a/mozjs/build/moz.configure/android-ndk.configure
+++ b/mozjs/build/moz.configure/android-ndk.configure
@@ -8,6 +8,15 @@
 js_option('--with-android-ndk', nargs=1,
           help='location where the Android NDK can be found')
 
+js_option('--with-android-ndk-version', nargs=1,
+          help='android NDK version')
+
+js_option('--with-android-platform', nargs=1,
+          help='location of the Android platform')
+
+js_option('--with-android-clang', nargs=1,
+          help='location of the Android clang compiler')
+
 js_option('--with-android-toolchain', nargs=1,
           help='location of the Android toolchain')
 
@@ -66,13 +75,17 @@ set_config('ANDROID_NDK', ndk)
 add_old_configure_assignment('android_ndk', ndk)
 
 
-@depends(ndk)
+@depends('--with-android-ndk-version', ndk)
 @checking('for android ndk version')
 @imports(_from='__builtin__', _import='open')
-def ndk_version(ndk):
+def ndk_version(value, ndk):
     if not ndk:
         # Building 'js/src' for non-Android.
         return
+
+    if value:
+        return value[0]
+
     with open(os.path.join(ndk, 'source.properties'), 'r') as f:
         for line in f:
             if not line.startswith('Pkg.Revision'):
@@ -112,12 +125,15 @@ def ndk_minor_version(ndk_version):
 set_config('ANDROID_NDK_MINOR_VERSION', ndk_minor_version)
 
 
-@depends(target, android_version, ndk, '--help')
+@depends('--with-android-platform', target, android_version, ndk, '--help')
 @checking('for android platform directory')
 @imports(_from='os.path', _import='isdir')
-def android_platform(target, android_version, ndk, _):
+def android_platform(value, target, android_version, ndk, _):
     if target.os != 'Android':
         return
+
+    if value:
+        return value[0]
 
     if 'mips' in target.cpu:
         target_dir_name = 'mips'
@@ -257,7 +273,7 @@ option(env='STLPORT_CPPFLAGS',
 @imports(_from='os.path', _import='isdir')
 def stlport_cppflags(value, ndk, _):
     if value and len(value):
-        return value.split()
+        return value[0].split()
     if not ndk:
         return
 
@@ -339,12 +355,15 @@ def bindgen_cflags_defaults(toolchain_flags, toolchain, toolchain_prefix, _):
                             os.path.join(gcc_include, 'include-fixed'))
 
 
-@depends(host, ndk)
+@depends('--with-android-clang', host, ndk)
 @imports(_from='os.path', _import='exists')
 @imports(_from='os.path', _import='isdir')
-def android_clang_compiler(host, ndk):
+def android_clang_compiler(value, host, ndk):
     if not ndk:
         return
+
+    if value:
+        return value[0]
 
     llvm_path = '%s/toolchains/llvm/prebuilt/%s-%s/bin' % (ndk,
                                                            host.kernel.lower(),

--- a/mozjs/mozglue/build/BionicGlue.cpp
+++ b/mozjs/mozglue/build/BionicGlue.cpp
@@ -17,7 +17,7 @@
 
 #define NS_EXPORT __attribute__ ((visibility("default")))
 
-#if ANDROID_VERSION < 17 || defined(MOZ_WIDGET_ANDROID)
+#if __ANDROID_API__ < 17 || defined(MOZ_WIDGET_ANDROID)
 /* Android doesn't have pthread_atfork(), so we need to use our own. */
 struct AtForkFuncs {
   void (*prepare)(void);
@@ -64,7 +64,7 @@ private:
 static std::vector<AtForkFuncs, SpecialAllocator<AtForkFuncs> > atfork;
 #endif
 
-#if ANDROID_VERSION < 17 || defined(MOZ_WIDGET_ANDROID)
+#if __ANDROID_API__ < 17 || defined(MOZ_WIDGET_ANDROID)
 extern "C" NS_EXPORT int
 pthread_atfork(void (*prepare)(void), void (*parent)(void), void (*child)(void))
 {


### PR DESCRIPTION
This patch adds configuration for the Android NDK directory layout. It's used when building for the Magic Leap, which uses a very similar, but not quite identical, NDK.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/mozjs/158)
<!-- Reviewable:end -->
