### PR TITLE
Pass the appropriate `-stdlib` C++ compiler flag to the configure script.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -101,6 +101,10 @@ fn build_jsapi() {
         cmd.env("MAKEFLAGS", makeflags);
     }
 
+    if target.contains("apple") || target.contains("freebsd") {
+        cmd.env("CXXFLAGS", "-stdlib=libc++");
+    }
+
     let result = cmd.args(&["-R", "-f", "makefile.cargo"])
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())


### PR DESCRIPTION
We were already choosing the appropriate flag when compiling `jsglue.cpp`, but
we didn't pass the flag along to `configure`, so on macOS Mojave the configure
script would detect a seemingly-broken C++ compiler and abort.

r? @jdm