### PR TITLE
Bump bindgen version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository = "https://github.com/servo/mozjs/"
-version = "0.61.8"
+version = "0.61.9"
 authors = ["Mozilla"]
 links = "mozjs"
 build = "build.rs"
@@ -27,5 +27,5 @@ libc = "0.2"
 libz-sys = "1.0"
 
 [build-dependencies]
-bindgen = "0.46"
+bindgen = "0.49.0"
 cc = "1.0"


### PR DESCRIPTION
This is part of improving cross compiling support for Servo. See servo/servo#22571.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/mozjs/174)
<!-- Reviewable:end -->
