### PR TITLE
Add _LIBCPP_INLINE_VISIBILITY environment variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
       - llvm-toolchain-xenial-5.0
     packages:
       - autoconf2.13
+      - gcc-6
       - g++-6
       - clang-5.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository = "https://github.com/servo/mozjs/"
-version = "0.61.12"
+version = "0.61.13"
 authors = ["Mozilla"]
 links = "mozjs"
 build = "build.rs"

--- a/etc/patches/libcpp-visibility-envvar.patch
+++ b/etc/patches/libcpp-visibility-envvar.patch
@@ -1,0 +1,21 @@
+diff --git a/mozjs/build/moz.configure/toolchain.configure b/mozjs/build/moz.configure/toolchain.configure
+index a1e443019..613ce94aa 100755
+--- a/mozjs/build/moz.configure/toolchain.configure
++++ b/mozjs/build/moz.configure/toolchain.configure
+@@ -1199,8 +1199,14 @@ set_config('COLOR_CFLAGS', color_cflags)
+ # hidden visibility.
+ 
+ 
+-@depends(c_compiler, target)
+-def libcxx_override_visibility(c_compiler, target):
++option(env='_LIBCPP_INLINE_VISIBILITY',
++       nargs=1,
++       help='Visibility of libc++ inlines')
++
++@depends('_LIBCPP_INLINE_VISIBILITY', c_compiler, target)
++def libcxx_override_visibility(value, c_compiler, target):
++    if len(value):
++        return value[0]
+     if c_compiler.type == 'clang' and target.os == 'Android':
+         return ''
+ 

--- a/mozjs/build/moz.configure/toolchain.configure
+++ b/mozjs/build/moz.configure/toolchain.configure
@@ -1199,8 +1199,14 @@ set_config('COLOR_CFLAGS', color_cflags)
 # hidden visibility.
 
 
-@depends(c_compiler, target)
-def libcxx_override_visibility(c_compiler, target):
+option(env='_LIBCPP_INLINE_VISIBILITY',
+       nargs=1,
+       help='Visibility of libc++ inlines')
+
+@depends('_LIBCPP_INLINE_VISIBILITY', c_compiler, target)
+def libcxx_override_visibility(value, c_compiler, target):
+    if len(value):
+        return value[0]
     if c_compiler.type == 'clang' and target.os == 'Android':
         return ''
 


### PR DESCRIPTION
This patch allows the `_LIBCPP_INLINE_VISIBILITY` variable to be set by an environment variable, rather than just basing it on the compiler and target OS. It's needed for builds for Android targets which use the usual `libc++`, such as magicleap.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/mozjs/180)
<!-- Reviewable:end -->
