### PR TITLE
Work around Windows arm64 crash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,4 @@ libz-sys = "1.0"
 [build-dependencies]
 bindgen = "0.49.0"
 cc = "1.0"
+walkdir = "2"

--- a/build.rs
+++ b/build.rs
@@ -4,6 +4,7 @@
 
 extern crate bindgen;
 extern crate cc;
+extern crate walkdir;
 
 use std::env;
 use std::path::PathBuf;
@@ -126,6 +127,10 @@ fn build_jsapi() {
     }
     println!("cargo:outdir={}", out_dir);
     println!("cargo:rerun-if-changed=makefile.cargo");
+    for entry in walkdir::WalkDir::new("mozjs") {
+        let entry = entry.unwrap();
+        println!("{}", format!("cargo:rerun-if-changed={}", entry.path().display()));
+    }
 }
 
 

--- a/src/jsglue.cpp
+++ b/src/jsglue.cpp
@@ -14,9 +14,13 @@ bool JS_Init() {
     return ::JS_Init();
 }
 
-JS::RealmOptions JS_NewRealmOptions() {
-    JS::RealmOptions result;
+JS::RealmOptions* JS_NewRealmOptions() {
+    JS::RealmOptions* result = new JS::RealmOptions;
     return result;
+}
+
+void DeleteRealmOptions(JS::RealmOptions* options) {
+	delete options;
 }
 
 JS::OwningCompileOptions JS_NewOwningCompileOptions(JSContext* cx) {

--- a/src/jsglue.hpp
+++ b/src/jsglue.hpp
@@ -36,7 +36,8 @@ namespace glue {
 
 bool JS_Init();
 
-JS::RealmOptions JS_NewRealmOptions();
+JS::RealmOptions* JS_NewRealmOptions();
+void DeleteRealmOptions(JS::RealmOptions* options);
 JS::OwningCompileOptions JS_NewOwningCompileOptions(JSContext* cx);
 
 JS::StackCapture JS_StackCapture_AllFrames();

--- a/src/jsimpls.rs
+++ b/src/jsimpls.rs
@@ -13,7 +13,6 @@ use jsapi::JSJitSetterCallArgs;
 use jsapi::JSNativeWrapper;
 use jsapi::JSObject;
 use jsapi::JSPropertySpec;
-use jsapi::glue::JS_NewRealmOptions;
 use jsapi::glue::JS_ForOfIteratorInit;
 use jsapi::glue::JS_ForOfIteratorNext;
 use jsapi::jsid;
@@ -53,12 +52,6 @@ impl<T> DerefMut for JS::MutableHandle<T> {
 
 impl Default for jsid {
     fn default() -> Self { JSID_VOID }
-}
-
-impl Default for JS::RealmOptions {
-    fn default() -> Self {
-        unsafe { JS_NewRealmOptions() }
-    }
 }
 
 impl Default for JS::PropertyDescriptor {


### PR DESCRIPTION
Running Servo's UWP app on an arm64 device, I encountered crashes creating global options where the app segfaulted when creating RealmOptions values. The crashes disappear when we allocate them on the heap instead of returning them by value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/mozjs/191)
<!-- Reviewable:end -->
