### PR TITLE
Support Rust configure when UWP targets are present

### DIFF
--- a/etc/patches/uwp-pc-triple.patch
+++ b/etc/patches/uwp-pc-triple.patch
@@ -1,0 +1,116 @@
+commit 81ce1668dc07897b832af74f00a3a3dbc83b337c
+Author: Josh Matthews <josh@joshmatthews.net>
+Date:   Mon Aug 19 12:43:43 2019 -0400
+
+    Support Rust configure when UWP targets are present.
+
+diff --git a/mozjs/build/moz.configure/init.configure b/mozjs/build/moz.configure/init.configure
+index 1ee8d267f0..b1b8d95163 100644
+--- a/mozjs/build/moz.configure/init.configure
++++ b/mozjs/build/moz.configure/init.configure
+@@ -639,9 +639,10 @@ def split_triplet(triplet, allow_unknown=False):
+     #   CPU_TYPE-OPERATING_SYSTEM
+     parts = triplet.split('-', 2)
+     if len(parts) == 3:
+-        cpu, _, os = parts
++        cpu, vendor, os = parts
+     elif len(parts) == 2:
+         cpu, os = parts
++        vendor = ''
+     else:
+         raise ValueError("Unexpected triplet string: %s" % triplet)
+ 
+@@ -757,6 +758,7 @@ def split_triplet(triplet, allow_unknown=False):
+         kernel=sanitize(Kernel, canonical_kernel),
+         os=sanitize(OS, canonical_os),
+         endianness=sanitize(Endianness, endianness),
++        vendor=vendor,
+         raw_cpu=cpu,
+         raw_os=os,
+         # Toolchains, most notably for cross compilation may use cpu-os
+diff --git a/mozjs/build/moz.configure/rust.configure b/mozjs/build/moz.configure/rust.configure
+index 2330ae8454..6c129579e0 100644
+--- a/mozjs/build/moz.configure/rust.configure
++++ b/mozjs/build/moz.configure/rust.configure
+@@ -127,7 +127,7 @@ def rust_supported_targets(rustc):
+         if key in per_os:
+             previous = per_os[key]
+             per_raw_os[(previous.cpu, previous.endianness,
+-                        previous.raw_os)] = previous
++                        previous.vendor, previous.raw_os)] = previous
+             del per_os[key]
+             ambiguous.add(key)
+         if key in ambiguous:
+@@ -138,14 +138,14 @@ def rust_supported_targets(rustc):
+             # normalize.
+             if raw_os == 'androideabi':
+                 raw_os = 'linux-androideabi'
+-            per_raw_os[(t.cpu, t.endianness, raw_os)] = t
++            per_raw_os[(t.cpu, t.endianness, t.vendor, raw_os)] = t
+         else:
+             per_os[key] = t
+     return namespace(per_os=per_os, per_raw_os=per_raw_os)
+ 
+ 
+ @template
+-def rust_triple_alias(host_or_target):
++def rust_triple_alias(host_or_target, last_resort):
+     """Template defining the alias used for rustc's --target flag.
+     `host_or_target` is either `host` or `target` (the @depends functions
+     from init.configure).
+@@ -153,7 +153,7 @@ def rust_triple_alias(host_or_target):
+     assert host_or_target in {host, target}
+ 
+     @depends(rustc, host_or_target, c_compiler, rust_supported_targets,
+-             when=rust_compiler)
++             last_resort, when=rust_compiler)
+     @imports('os')
+     @imports('subprocess')
+     @imports(_from='mozbuild.configure.util', _import='LineIO')
+@@ -161,7 +161,7 @@ def rust_triple_alias(host_or_target):
+     @imports(_from='tempfile', _import='mkstemp')
+     @imports(_from='textwrap', _import='dedent')
+     def rust_target(rustc, host_or_target, compiler_info,
+-                    rust_supported_targets):
++                    rust_supported_targets, last_resort):
+         # Rust's --target options are similar to, but not exactly the same
+         # as, the autoconf-derived targets we use.  An example would be that
+         # Rust uses distinct target triples for targetting the GNU C++ ABI
+@@ -187,7 +187,12 @@ def rust_triple_alias(host_or_target):
+         if rustc_target is None:
+             rustc_target = rust_supported_targets.per_raw_os.get(
+                 (host_or_target.cpu, host_or_target.endianness,
+-                 host_or_target_raw_os))
++                 host_or_target.vendor, host_or_target_raw_os))
++
++        if not rustc_target and last_resort:
++            rustc_target = rust_supported_targets.per_raw_os.get(
++                (last_resort.cpu, last_resort.endianness,
++                last_resort.vendor, host_or_target_raw_os))
+ 
+         if rustc_target is None:
+             die("Don't know how to translate {} for rustc".format(
+@@ -237,8 +242,21 @@ def rust_triple_alias(host_or_target):
+     return rust_target
+ 
+ 
+-rust_target_triple = rust_triple_alias(target)
+-rust_host_triple = rust_triple_alias(host)
++option(env='RUST_TARGET', nargs=1, help='Target for rustc invocations')
++option(env='RUST_HOST', nargs=1, help='Host for rustc invocations')
++
++@depends('RUST_TARGET')
++def rust_target(value):
++    if value:
++        return split_triplet(value[0], allow_unknown=True)
++
++@depends('RUST_HOST')
++def rust_host(value):
++    if value:
++        return split_triplet(value[0], allow_unknown=True)
++
++rust_target_triple = rust_triple_alias(target, rust_target)
++rust_host_triple = rust_triple_alias(host, rust_host)
+ 
+ 
+ @depends(host, rust_host_triple, rustc_info.host)

--- a/makefile.cargo
+++ b/makefile.cargo
@@ -194,5 +194,6 @@ maybe-configure:
 	  CXX="$(CXX)" CXXFLAGS="$(CXXFLAGS)" \
 	  AS="$(AS)" AR="$(AR)" \
 	  STLPORT_LIBS="$(STLPORT_LIBS)" \
+	  RUST_TARGET="$(TARGET)" RUST_HOST="$(HOST)" \
 	  $(JSSRC)/configure $(strip $(CONFIGURE_FLAGS)) || (cat config.log && exit 1) ; \
 	fi

--- a/mozjs/build/moz.configure/init.configure
+++ b/mozjs/build/moz.configure/init.configure
@@ -639,9 +639,10 @@ def split_triplet(triplet, allow_unknown=False):
     #   CPU_TYPE-OPERATING_SYSTEM
     parts = triplet.split('-', 2)
     if len(parts) == 3:
-        cpu, _, os = parts
+        cpu, vendor, os = parts
     elif len(parts) == 2:
         cpu, os = parts
+        vendor = ''
     else:
         raise ValueError("Unexpected triplet string: %s" % triplet)
 
@@ -757,6 +758,7 @@ def split_triplet(triplet, allow_unknown=False):
         kernel=sanitize(Kernel, canonical_kernel),
         os=sanitize(OS, canonical_os),
         endianness=sanitize(Endianness, endianness),
+        vendor=vendor,
         raw_cpu=cpu,
         raw_os=os,
         # Toolchains, most notably for cross compilation may use cpu-os

--- a/mozjs/build/moz.configure/rust.configure
+++ b/mozjs/build/moz.configure/rust.configure
@@ -127,7 +127,7 @@ def rust_supported_targets(rustc):
         if key in per_os:
             previous = per_os[key]
             per_raw_os[(previous.cpu, previous.endianness,
-                        previous.raw_os)] = previous
+                        previous.vendor, previous.raw_os)] = previous
             del per_os[key]
             ambiguous.add(key)
         if key in ambiguous:
@@ -138,14 +138,14 @@ def rust_supported_targets(rustc):
             # normalize.
             if raw_os == 'androideabi':
                 raw_os = 'linux-androideabi'
-            per_raw_os[(t.cpu, t.endianness, raw_os)] = t
+            per_raw_os[(t.cpu, t.endianness, t.vendor, raw_os)] = t
         else:
             per_os[key] = t
     return namespace(per_os=per_os, per_raw_os=per_raw_os)
 
 
 @template
-def rust_triple_alias(host_or_target):
+def rust_triple_alias(host_or_target, last_resort):
     """Template defining the alias used for rustc's --target flag.
     `host_or_target` is either `host` or `target` (the @depends functions
     from init.configure).
@@ -153,7 +153,7 @@ def rust_triple_alias(host_or_target):
     assert host_or_target in {host, target}
 
     @depends(rustc, host_or_target, c_compiler, rust_supported_targets,
-             when=rust_compiler)
+             last_resort, when=rust_compiler)
     @imports('os')
     @imports('subprocess')
     @imports(_from='mozbuild.configure.util', _import='LineIO')
@@ -161,7 +161,7 @@ def rust_triple_alias(host_or_target):
     @imports(_from='tempfile', _import='mkstemp')
     @imports(_from='textwrap', _import='dedent')
     def rust_target(rustc, host_or_target, compiler_info,
-                    rust_supported_targets):
+                    rust_supported_targets, last_resort):
         # Rust's --target options are similar to, but not exactly the same
         # as, the autoconf-derived targets we use.  An example would be that
         # Rust uses distinct target triples for targetting the GNU C++ ABI
@@ -187,7 +187,12 @@ def rust_triple_alias(host_or_target):
         if rustc_target is None:
             rustc_target = rust_supported_targets.per_raw_os.get(
                 (host_or_target.cpu, host_or_target.endianness,
-                 host_or_target_raw_os))
+                 host_or_target.vendor, host_or_target_raw_os))
+
+        if not rustc_target and last_resort:
+            rustc_target = rust_supported_targets.per_raw_os.get(
+                (last_resort.cpu, last_resort.endianness,
+                last_resort.vendor, host_or_target_raw_os))
 
         if rustc_target is None:
             die("Don't know how to translate {} for rustc".format(
@@ -237,8 +242,21 @@ def rust_triple_alias(host_or_target):
     return rust_target
 
 
-rust_target_triple = rust_triple_alias(target)
-rust_host_triple = rust_triple_alias(host)
+option(env='RUST_TARGET', nargs=1, help='Target for rustc invocations')
+option(env='RUST_HOST', nargs=1, help='Host for rustc invocations')
+
+@depends('RUST_TARGET')
+def rust_target(value):
+    if value:
+        return split_triplet(value[0], allow_unknown=True)
+
+@depends('RUST_HOST')
+def rust_host(value):
+    if value:
+        return split_triplet(value[0], allow_unknown=True)
+
+rust_target_triple = rust_triple_alias(target, rust_target)
+rust_host_triple = rust_triple_alias(host, rust_host)
 
 
 @depends(host, rust_host_triple, rustc_info.host)


### PR DESCRIPTION
The existing code that attempts to detect if a given target will allow compiling Rust code assumes that if multiple Rust targets target the same CPU that the triple's OS value will be unique (ie. x86_64-pc-windows-msvc vs. x86_64-pc-windows-gnu). This is no longer true with the introduction of x86_64-uwp-windows-msvc, but it's not enough to include the vendor string in the checks - the configure script is passed a different target (x86_64-windows-mingw32), and the python configuration code needs to reverse-engineer a Rust triple from it to use when compiling Rust code as part of the mozjs build. We bypass this issue by storing the target and host triples that Cargo makes available in the build script and using those value when the python configuration heuristics fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/mozjs/195)
<!-- Reviewable:end -->
