### PR TITLE
Force VS 2017 to be used on Windows.

### DIFF
--- a/makefile.cargo
+++ b/makefile.cargo
@@ -14,8 +14,9 @@ CONFIGURE_FLAGS := \
 ifeq (windows,$(findstring windows,$(TARGET)))
 	WINDOWS := 1
 	# Override any attempt to use the debug CRT when building with debug.
-	CFLAGS += "-MD"
-	CXXFLAGS += "-MD"
+	CFLAGS += -MD
+	CXXFLAGS += -MD
+	CONFIGURE_FLAGS += --with-visual-studio-version=2017
 else
 	WINDOWS :=
 endif


### PR DESCRIPTION
This is important when there are multiple versions of VS installed that the build system might end up trying to use. 2017 is the only supported version for building SpiderMonkey.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/mozjs/197)
<!-- Reviewable:end -->
