### PR TITLE
Skip `cargo:rerun-if-changed` for directories and everything in `.gitignore` (fixes #202)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,12 @@
-*.pyc
-*.so
-*~
-js/src/config/Expression.pyc
-js/src/config/expandlibs.pyc
-js/src/builtin/js2c.pyc
-js/src/builtin/jsmin.pyc
-js/src/build/ConfigStatus.pyc
-js/src/config/Preprocessor.pyc
-mozjs/python/psutil/build
-mozjs/third_party/python/psutil/build
-mozjs/third_party/python/psutil/tmp
 /doc
 /target
 /Cargo.lock
+
+# Keep this in sync with ignore() in build.rs
+
+*.pyc
+*.so
+*.dll
+*.dylib
+psutil/build
+psutil/tmp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,6 @@ libc = "0.2"
 libz-sys = "1.0"
 
 [build-dependencies]
-bindgen = "0.51.1"
+bindgen = { version = "0.51.1", default-features = false, features = ["which-rustfmt"] }
 cc = "1.0"
 walkdir = "2"

--- a/build.rs
+++ b/build.rs
@@ -130,7 +130,7 @@ fn build_jsapi() {
     }
     println!("cargo:outdir={}", out_dir);
     println!("cargo:rerun-if-changed=makefile.cargo");
-    for entry in walkdir::WalkDir::new("mozjs") {
+    for entry in walkdir::WalkDir::new("mozjs").into_iter().filter_entry(|e| !e.path().ends_with("tmp")) {
         let entry = entry.unwrap();
         println!("{}", format!("cargo:rerun-if-changed={}", entry.path().display()));
     }

--- a/build.rs
+++ b/build.rs
@@ -149,7 +149,9 @@ fn build_jsapi() {
     println!("cargo:rerun-if-changed=makefile.cargo");
     for entry in walkdir::WalkDir::new("mozjs").into_iter().filter_entry(|e| !ignore(e.path())) {
         let entry = entry.unwrap();
-        println!("{}", format!("cargo:rerun-if-changed={}", entry.path().display()));
+        if !entry.file_type().is_dir() {
+            println!("{}", format!("cargo:rerun-if-changed={}", entry.path().display()));
+        }
     }
 }
 


### PR DESCRIPTION
The actual fix should live in psutil, but this is a good workaround meanwhile.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/mozjs/203)
<!-- Reviewable:end -->
