### PR TITLE
Support --features vslatestinstalled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ exclude = [
 debugmozjs = []
 profilemozjs = []
 uwp = []
+vslatestinstalled = []
 
 [lib]
 name = "mozjs_sys"

--- a/makefile.cargo
+++ b/makefile.cargo
@@ -16,7 +16,9 @@ ifeq (windows,$(findstring windows,$(TARGET)))
 	# Override any attempt to use the debug CRT when building with debug.
 	CFLAGS += -MD
 	CXXFLAGS += -MD
-	CONFIGURE_FLAGS += --with-visual-studio-version=2017
+	ifeq (,$(CARGO_FEATURE_VSLATESTINSTALLED))
+		CONFIGURE_FLAGS += --with-visual-studio-version=2017
+	endif
 	ifneq (,$(CARGO_FEATURE_UWP))
 		CONFIGURE_FLAGS += --enable-uwp --without-intl-api
 		CFLAGS += -DWINAPI_FAMILY=WINAPI_FAMILY_APP


### PR DESCRIPTION
Closes #204 

This supports opting out `--with-visual-studio-version=2017` by `--features vslatestinstalled`.

The name is from the script behavior:

https://github.com/servo/mozjs/blob/b2f83932fe9d361face14efd03f2465b9262e687/mozjs/build/moz.configure/toolchain.configure#L650-L652

(My original idea was to do `--with-visual-studio-version=2019` but the option currently only support `2017` as its value.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/mozjs/205)
<!-- Reviewable:end -->
