### PR TITLE
Support building with native UWP rustc targets.

### DIFF
--- a/etc/patches/uwp-target-native.patch
+++ b/etc/patches/uwp-target-native.patch
@@ -1,0 +1,79 @@
+commit c72b3f5fdf38e3b4013c9a3aec71f8fe2158f9a8
+Author: Josh Matthews <josh@joshmatthews.net>
+Date:   Wed Sep 11 11:09:10 2019 -0400
+
+    Build changes to support new UWP rustc target.
+
+diff --git a/makefile.cargo b/makefile.cargo
+index ab2b8295e4..37005597e1 100644
+--- a/makefile.cargo
++++ b/makefile.cargo
+@@ -203,5 +203,6 @@ maybe-configure:
+ 	  AS="$(AS)" AR="$(AR)" \
+ 	  STLPORT_LIBS="$(STLPORT_LIBS)" \
+ 	  RUST_TARGET="$(TARGET)" RUST_HOST="$(HOST)" \
++	  RUST_SYSROOT="${RUST_SYSROOT}" \
+ 	  $(JSSRC)/configure $(strip $(CONFIGURE_FLAGS)) || (cat config.log && exit 1) ; \
+ 	fi
+diff --git a/mozjs/build/moz.configure/rust.configure b/mozjs/build/moz.configure/rust.configure
+index 6c129579e0..b75bf4a471 100644
+--- a/mozjs/build/moz.configure/rust.configure
++++ b/mozjs/build/moz.configure/rust.configure
+@@ -15,6 +15,12 @@ rustc = check_prog('RUSTC', ['rustc'], paths=toolchain_search_path,
+ cargo = check_prog('CARGO', ['cargo'], paths=toolchain_search_path,
+                    input='CARGO', allow_missing=True)
+ 
++option(env='RUST_SYSROOT', nargs=1, help='Path to the rustc sysroot')
++
++@depends('RUST_SYSROOT')
++def rust_sysroot(value):
++    if value:
++        return value[0]
+ 
+ @depends_if(rustc)
+ @checking('rustc version', lambda info: info.version)
+@@ -153,7 +159,7 @@ def rust_triple_alias(host_or_target, last_resort):
+     assert host_or_target in {host, target}
+ 
+     @depends(rustc, host_or_target, c_compiler, rust_supported_targets,
+-             last_resort, when=rust_compiler)
++             last_resort, rust_sysroot, when=rust_compiler)
+     @imports('os')
+     @imports('subprocess')
+     @imports(_from='mozbuild.configure.util', _import='LineIO')
+@@ -161,7 +167,7 @@ def rust_triple_alias(host_or_target, last_resort):
+     @imports(_from='tempfile', _import='mkstemp')
+     @imports(_from='textwrap', _import='dedent')
+     def rust_target(rustc, host_or_target, compiler_info,
+-                    rust_supported_targets, last_resort):
++                    rust_supported_targets, last_resort, rust_sysroot):
+         # Rust's --target options are similar to, but not exactly the same
+         # as, the autoconf-derived targets we use.  An example would be that
+         # Rust uses distinct target triples for targetting the GNU C++ ABI
+@@ -220,6 +226,8 @@ def rust_triple_alias(host_or_target, last_resort):
+                 '-o', out_path,
+                 in_path,
+             ]
++            if rust_sysroot:
++                cmd += ['--sysroot', rust_sysroot]
+ 
+             def failed():
+                 die(dedent('''\
+@@ -262,6 +270,8 @@ rust_host_triple = rust_triple_alias(host, rust_host)
+ @depends(host, rust_host_triple, rustc_info.host)
+ def validate_rust_host_triple(host, rust_host, rustc_host):
+     if rust_host != rustc_host:
++        if host.machine == 'uwp' and rustc_host.machine == 'pc':
++            return
+         if host.alias == rust_host:
+             configure_host = host.alias
+         else:
+@@ -346,6 +356,8 @@ def rustc_natvis_ldflags(target, compiler_info, rustc):
+     if target.kernel == 'WINNT' and compiler_info.type == 'clang-cl':
+         sysroot = check_cmd_output(rustc, '--print', 'sysroot').strip()
+         etc = os.path.join(sysroot, 'lib/rustlib/etc')
++        if not os.path.exists(etc):
++            return []
+         ldflags = []
+         for f in os.listdir(etc):
+             if f.endswith('.natvis'):

--- a/makefile.cargo
+++ b/makefile.cargo
@@ -203,5 +203,6 @@ maybe-configure:
 	  AS="$(AS)" AR="$(AR)" \
 	  STLPORT_LIBS="$(STLPORT_LIBS)" \
 	  RUST_TARGET="$(TARGET)" RUST_HOST="$(HOST)" \
+	  RUST_SYSROOT="${RUST_SYSROOT}" \
 	  $(JSSRC)/configure $(strip $(CONFIGURE_FLAGS)) || (cat config.log && exit 1) ; \
 	fi

--- a/mozjs/build/moz.configure/rust.configure
+++ b/mozjs/build/moz.configure/rust.configure
@@ -15,6 +15,12 @@ rustc = check_prog('RUSTC', ['rustc'], paths=toolchain_search_path,
 cargo = check_prog('CARGO', ['cargo'], paths=toolchain_search_path,
                    input='CARGO', allow_missing=True)
 
+option(env='RUST_SYSROOT', nargs=1, help='Path to the rustc sysroot')
+
+@depends('RUST_SYSROOT')
+def rust_sysroot(value):
+    if value:
+        return value[0]
 
 @depends_if(rustc)
 @checking('rustc version', lambda info: info.version)
@@ -153,7 +159,7 @@ def rust_triple_alias(host_or_target, last_resort):
     assert host_or_target in {host, target}
 
     @depends(rustc, host_or_target, c_compiler, rust_supported_targets,
-             last_resort, when=rust_compiler)
+             last_resort, rust_sysroot, when=rust_compiler)
     @imports('os')
     @imports('subprocess')
     @imports(_from='mozbuild.configure.util', _import='LineIO')
@@ -161,7 +167,7 @@ def rust_triple_alias(host_or_target, last_resort):
     @imports(_from='tempfile', _import='mkstemp')
     @imports(_from='textwrap', _import='dedent')
     def rust_target(rustc, host_or_target, compiler_info,
-                    rust_supported_targets, last_resort):
+                    rust_supported_targets, last_resort, rust_sysroot):
         # Rust's --target options are similar to, but not exactly the same
         # as, the autoconf-derived targets we use.  An example would be that
         # Rust uses distinct target triples for targetting the GNU C++ ABI
@@ -220,6 +226,8 @@ def rust_triple_alias(host_or_target, last_resort):
                 '-o', out_path,
                 in_path,
             ]
+            if rust_sysroot:
+                cmd += ['--sysroot', rust_sysroot]
 
             def failed():
                 die(dedent('''\
@@ -262,6 +270,8 @@ rust_host_triple = rust_triple_alias(host, rust_host)
 @depends(host, rust_host_triple, rustc_info.host)
 def validate_rust_host_triple(host, rust_host, rustc_host):
     if rust_host != rustc_host:
+        if host.machine == 'uwp' and rustc_host.machine == 'pc':
+            return
         if host.alias == rust_host:
             configure_host = host.alias
         else:
@@ -346,6 +356,8 @@ def rustc_natvis_ldflags(target, compiler_info, rustc):
     if target.kernel == 'WINNT' and compiler_info.type == 'clang-cl':
         sysroot = check_cmd_output(rustc, '--print', 'sysroot').strip()
         etc = os.path.join(sysroot, 'lib/rustlib/etc')
+        if not os.path.exists(etc):
+            return []
         ldflags = []
         for f in os.listdir(etc):
             if f.endswith('.natvis'):


### PR DESCRIPTION
This allows builds to complete when using aarch64-uwp-windows-msvc and x86_64-uwp-windows-msvc, which are more compatible with the corresponding pc targets than the SM build system would like to believe.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/mozjs/210)
<!-- Reviewable:end -->
