### PR TITLE
Whitelist JSREG constants

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -325,6 +325,7 @@ const WHITELIST_VARS: &'static [&'static str] = &[
     "JSFUN_.*",
     "JSITER_.*",
     "JSPROP_.*",
+    "JSREG_.*",
     "JS_.*",
 ];
 


### PR DESCRIPTION
This adds RegExp flags to be used in JS_NewRegExpObject and JS_NewUCRegExpObject. Fixes #223.