### PR TITLE
Allow building with 10.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ addons:
 
 env:
   - FEATURES=""
-  - FEATURES="--features debugmozjs"
+  - FEATURES="debugmozjs"
 
 before_script:
   - rustup component add rustfmt-preview
@@ -41,8 +41,8 @@ before_script:
 
 script:
   - ccache -z
-  - CCACHE=$(which ccache) travis_wait 30 cargo build --verbose $FEATURES
-  - CCACHE=$(which ccache) RUST_BACKTRACE=1 cargo test --lib --verbose $FEATURES
+  - CCACHE=$(which ccache) travis_wait 30 cargo build --verbose --features "$FEATURES"
+  - CCACHE=$(which ccache) RUST_BACKTRACE=1 cargo test --lib --verbose --features "$FEATURES"
   - ccache -s
 
 cache: ccache

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository = "https://github.com/servo/mozjs/"
-version = "0.68.0"
+version = "0.68.1"
 authors = ["Mozilla"]
 links = "mozjs"
 build = "build.rs"

--- a/etc/patches/0019-Bug-1583854-Allow-builds-with-the-10.15-macOS-SDK.-r.patch
+++ b/etc/patches/0019-Bug-1583854-Allow-builds-with-the-10.15-macOS-SDK.-r.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Stephen A Pohl <spohl.mozilla.bugs@gmail.com>
+Date: Wed, 26 Feb 2020 20:32:13 +0000
+Subject: [PATCH 2/2] Bug 1583854: Allow builds with the 10.15 macOS SDK.
+ r=mshal
+
+Depends on D64447
+
+Differential Revision: https://phabricator.services.mozilla.com/D64448
+
+--HG--
+extra : moz-landing-system : lando
+
+diff --git a/build/moz.configure/toolchain.configure b/build/moz.configure/toolchain.configure
+index 4957278cc90d..fc5d2bdf8342 100755
+--- a/build/moz.configure/toolchain.configure
++++ b/build/moz.configure/toolchain.configure
+@@ -141,7 +141,7 @@ with only_when(host_is_osx | target_is_osx):
+     @imports(_from='biplist', _import='readPlist')
+     def macos_sdk(sdk, host):
+         sdk_min_version = Version('10.11')
+-        sdk_max_version = Version('10.14')
++        sdk_max_version = Version('10.15')
+ 
+         if sdk:
+             sdk = sdk[0]

--- a/mozjs/build/moz.configure/toolchain.configure
+++ b/mozjs/build/moz.configure/toolchain.configure
@@ -141,7 +141,7 @@ with only_when(host_is_osx | target_is_osx):
     @imports(_from='biplist', _import='readPlist')
     def macos_sdk(sdk, host):
         sdk_min_version = Version('10.11')
-        sdk_max_version = Version('10.14')
+        sdk_max_version = Version('10.15')
 
         if sdk:
             sdk = sdk[0]


### PR DESCRIPTION
Only one patch from upstream is relevant, the other is for a fix in a module that we don't use.

https://bugzilla.mozilla.org/show_bug.cgi?id=1583854