### PR TITLE
Don't install clang-8 package on CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,10 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - llvm-toolchain-xenial-8
     packages:
       - autoconf2.13
       - gcc-7
       - g++-7
-      - clang-8
   homebrew:
     update: true
     packages:


### PR DESCRIPTION
Something changed in the TravisCI xenial environment recently that breaks bindgen when both the base clang-7 and clang-8 packages are installed. Compilation succeeds when clang-8 isn't installed.