### PR TITLE
Remove the requirement for MSVC 2017.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ exclude = [
 debugmozjs = []
 profilemozjs = []
 uwp = []
-vslatestinstalled = []
 
 [lib]
 name = "mozjs_sys"

--- a/makefile.cargo
+++ b/makefile.cargo
@@ -20,9 +20,6 @@ ifeq (windows,$(findstring windows,$(TARGET)))
 	# Override any attempt to use the debug CRT when building with debug.
 	CFLAGS += -MD
 	CXXFLAGS += -MD
-	ifeq (,$(CARGO_FEATURE_VSLATESTINSTALLED))
-		CONFIGURE_FLAGS += --with-visual-studio-version=2017
-	endif
 	ifneq (,$(CARGO_FEATURE_UWP))
 		CONFIGURE_FLAGS += --enable-uwp --without-intl-api --disable-vtune
 		CFLAGS += -DWINAPI_FAMILY=WINAPI_FAMILY_APP


### PR DESCRIPTION
This makes it easier to build with MSVC 2019 in the future.