### PR TITLE
Add RegExp bindings

### DIFF
--- a/src/jsglue.hpp
+++ b/src/jsglue.hpp
@@ -25,6 +25,7 @@
 #include "js/Promise.h"
 #include "js/PropertySpec.h"
 #include "js/Realm.h"
+#include "js/RegExp.h"
 #include "js/SavedFrameAPI.h"
 #include "js/SourceText.h"
 #include "js/Stream.h"


### PR DESCRIPTION
I finally got around to finishing [form validation](https://github.com/servo/servo/pull/25447) in Servo and it looks like RegExp bindings got lost after SpiderMonkey update. This PR adds `js/RegExp.h` to `jsglue.hpp`.