### PR TITLE
Disable travis builds using nightly rustc.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - nightly
+  #- nightly
   - beta
   - stable
 sudo: 9000


### PR DESCRIPTION
We're prevented from merging any changes as long as there's no rustfmt available on nightly (https://rust-lang.github.io/rustup-components-history/).