### PR TITLE
Fix spurious rebuilds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,7 @@
 # Keep this in sync with ignore() in build.rs
 
 *.pyc
+*.o
 *.so
 *.dll
 *.dylib
-psutil/build
-psutil/tmp

--- a/build.rs
+++ b/build.rs
@@ -410,16 +410,9 @@ fn ignore(path: &Path) -> bool {
         return true;
     }
 
-    let ignored_extensions = ["pyc", "so", "dll", "dylib"];
-    let ignored_trailing_paths = [["psutil", "build"], ["psutil", "tmp"]];
+    let ignored_extensions = ["pyc", "o", "so", "dll", "dylib"];
 
     path.extension().map_or(false, |extension| {
         ignored_extensions.iter().any(|&ignored| extension == ignored)
-    }) ||
-    ignored_trailing_paths.iter().any(|trailing| {
-        let mut components = path.components().rev();
-        trailing.iter().rev().all(|&ignored| {
-            components.next().map_or(false, |component| component.as_os_str() == ignored)
-        })
     })
 }


### PR DESCRIPTION
Before this commit, running `cargo build` twice in a row runs the build script again. If with `CARGO_LOG=cargo::core::compiler::fingerprint=info`, the second run prints:

```
[2020-04-23T15:42:13Z INFO  cargo::core::compiler::fingerprint] stale: changed "/home/simon/projects/mozjs/mozjs/third_party/python/psutil/tmp/tmpc2PSEG.o"
[2020-04-23T15:42:13Z INFO  cargo::core::compiler::fingerprint]           (vs) "/home/simon/projects/mozjs/target/debug/build/mozjs_sys-9c51e5274ae91753/output"
[2020-04-23T15:42:13Z INFO  cargo::core::compiler::fingerprint]                FileTime { seconds: 1587656386, nanos: 37363833 } != FileTime { seconds: 1587656387, nanos: 633368104 }
[2020-04-23T15:42:13Z INFO  cargo::core::compiler::fingerprint] fingerprint error for mozjs_sys v0.68.1 (/home/simon/projects/mozjs)/Build/Target { doctest: false, ..: lib_target("mozjs_sys", ["lib"], "/home/simon/projects/mozjs/src/lib.rs", Edition2015) }
[2020-04-23T15:42:13Z INFO  cargo::core::compiler::fingerprint]     err: current filesystem status shows we're outdated
[2020-04-23T15:42:13Z INFO  cargo::core::compiler::fingerprint] fingerprint error for mozjs_sys v0.68.1 (/home/simon/projects/mozjs)/RunCustomBuild/Target { ..: custom_build_target("build-script-build", "/home/simon/projects/mozjs/build.rs", Edition2015) }
[2020-04-23T15:42:13Z INFO  cargo::core::compiler::fingerprint]     err: current filesystem status shows we're outdated
```

The relevant part is:

```
stale: changed "mozjs/third_party/python/psutil/tmp/tmpc2PSEG.o"
```

We already had an `ignore` function for this, but its checking of trailing paths was incorrect: `psutil/tmp/` is not at the end of this path. Adding `.o` to the list of ignored extensions turns out to be sufficient.