### PR TITLE
Don't return mozilla::Variant by value.

### DIFF
--- a/src/jsglue.cpp
+++ b/src/jsglue.cpp
@@ -36,16 +36,16 @@ JS::CallArgs JS_CallArgsFromVp(unsigned argc, JS::Value* vp) {
     return JS::CallArgsFromVp(argc, vp);
 }
 
-JS::StackCapture JS_StackCapture_AllFrames() {
-    return JS::StackCapture(JS::AllFrames());
+void JS_StackCapture_AllFrames(JS::StackCapture* capture) {
+    *capture = JS::StackCapture(JS::AllFrames());
 }
 
-JS::StackCapture JS_StackCapture_MaxFrames(uint32_t max) {
-    return JS::StackCapture(JS::MaxFrames(max));
+void JS_StackCapture_MaxFrames(uint32_t max, JS::StackCapture* capture) {
+    *capture = JS::StackCapture(JS::MaxFrames(max));
 }
 
-JS::StackCapture JS_StackCapture_FirstSubsumedFrame(JSContext* cx, bool ignoreSelfHostedFrames) {
-    return JS::StackCapture(JS::FirstSubsumedFrame(cx, ignoreSelfHostedFrames));
+void JS_StackCapture_FirstSubsumedFrame(JSContext* cx, bool ignoreSelfHostedFrames, JS::StackCapture* capture) {
+    *capture = JS::StackCapture(JS::FirstSubsumedFrame(cx, ignoreSelfHostedFrames));
 }
 
 // Reexport some methods

--- a/src/jsglue.hpp
+++ b/src/jsglue.hpp
@@ -44,9 +44,9 @@ JS::RealmOptions* JS_NewRealmOptions();
 void DeleteRealmOptions(JS::RealmOptions* options);
 JS::OwningCompileOptions JS_NewOwningCompileOptions(JSContext* cx);
 
-JS::StackCapture JS_StackCapture_AllFrames();
-JS::StackCapture JS_StackCapture_MaxFrames(uint32_t max);
-JS::StackCapture JS_StackCapture_FirstSubsumedFrame(JSContext* cx, bool ignoreSelfHostedFrames);
+void JS_StackCapture_AllFrames(JS::StackCapture*);
+void JS_StackCapture_MaxFrames(uint32_t max, JS::StackCapture*);
+void JS_StackCapture_FirstSubsumedFrame(JSContext* cx, bool ignoreSelfHostedFrames, JS::StackCapture*);
 
 bool JS_ForOfIteratorInit(JS::ForOfIterator* iterator, JS::HandleValue iterable, JS::ForOfIterator::NonIterableBehavior nonIterableBehavior);
 bool JS_ForOfIteratorNext(JS::ForOfIterator* iterator, JS::MutableHandleValue val, bool* done);


### PR DESCRIPTION
This yields invalid codegen on Windows arm64 and causes crashes.