### PR TITLE
Add GC barriers for JSString and JSScript heap values.

### DIFF
--- a/src/jsgc.rs
+++ b/src/jsgc.rs
@@ -98,12 +98,16 @@ impl GCMethods for *mut JSObject {
 
 impl GCMethods for *mut JSString {
     unsafe fn initial() -> *mut JSString { ptr::null_mut() }
-    unsafe fn post_barrier(_: *mut *mut JSString, _: *mut JSString, _: *mut JSString) {}
+    unsafe fn post_barrier(v: *mut *mut JSString, prev: *mut JSString, next: *mut JSString) {
+        JS::HeapStringWriteBarriers(v, prev, next);
+    }
 }
 
 impl GCMethods for *mut JSScript {
     unsafe fn initial() -> *mut JSScript { ptr::null_mut() }
-    unsafe fn post_barrier(_: *mut *mut JSScript, _: *mut JSScript, _: *mut JSScript) { }
+    unsafe fn post_barrier(v: *mut *mut JSScript, prev: *mut JSScript, next: *mut JSScript) {
+        JS::HeapScriptWriteBarriers(v, prev, next);
+    }
 }
 
 impl GCMethods for *mut JSFunction {


### PR DESCRIPTION
The lack of these barriers can cause memory corruption when these values are stored on the heap while a minor GC occurs.