### PR TITLE
Updated to support macOS 11.1

### DIFF
--- a/mozjs/build/moz.configure/toolchain.configure
+++ b/mozjs/build/moz.configure/toolchain.configure
@@ -141,7 +141,7 @@ with only_when(host_is_osx | target_is_osx):
     @imports(_from='biplist', _import='readPlist')
     def macos_sdk(sdk, host):
         sdk_min_version = Version('10.11')
-        sdk_max_version = Version('10.15.6')
+        sdk_max_version = Version('11.1')
 
         if sdk:
             sdk = sdk[0]


### PR DESCRIPTION
Based on [this issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1682608), it looks like we can update mozjs to support up to macOS 11.1.