### PR TITLE
Restore support for macOS 11.1

### DIFF
--- a/mozjs/build/moz.configure/toolchain.configure
+++ b/mozjs/build/moz.configure/toolchain.configure
@@ -152,7 +152,7 @@ with only_when(host_is_osx | target_is_osx):
     @imports("plistlib")
     def macos_sdk(sdk, host):
         sdk_min_version = Version("10.11")
-        sdk_max_version = Version("11.0")
+        sdk_max_version = Version("11.1")
 
         if sdk:
             sdk = sdk[0]


### PR DESCRIPTION
Originally introduce by #258, but seems to be overwritten by accident by #265.