### PR TITLE
Update to support latest macOS SDK

### DIFF
--- a/mozjs/build/moz.configure/toolchain.configure
+++ b/mozjs/build/moz.configure/toolchain.configure
@@ -93,7 +93,7 @@ with only_when(host_is_osx | target_is_osx):
         # installation docs:
         # https://firefox-source-docs.mozilla.org/setup/macos_build.html#macos-sdk-is-unsupported
         sdk_min_version = Version("10.12")
-        sdk_max_version = Version("11.1")
+        sdk_max_version = Version("11.3")
 
         if sdk:
             sdk = sdk[0]


### PR DESCRIPTION
Compilation with SDK version 11.3 is successful on my machine.

Without this commit, you get this error:

`ERROR: SDK version "11.3" is unsupported. Please downgrade to version 11.1.`

As the Xcode and macOS SDK version are constantly changing, I also propose to remove the check for the maximum supported SDK completely.

The maximum version check seems to be a constant source of problems when building from source. See

 - https://github.com/servo/servo/issues/28244
 - https://github.com/servo/servo/issues/25919
 - https://github.com/servo/servo/issues/26040

This should also fix https://github.com/servo/servo/issues/28244