### PR TITLE
build: also verify that gmake command successed

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -82,7 +82,13 @@ fn find_make() -> OsString {
         make
     } else {
         match Command::new("gmake").status() {
-            Ok(_) => OsStr::new("gmake").to_os_string(),
+            Ok(gmake) => {
+                if gmake.success() {
+                    OsStr::new("gmake").to_os_string()
+                } else {
+                    OsStr::new("make").to_os_string()
+                }
+            },
             Err(_) => OsStr::new("make").to_os_string(),
         }
     }


### PR DESCRIPTION
Seems like on aarch64 system, where gmake is missing shell return 127 [1]
as for missing binary, which isn't handled by Err exception.

[1] Exit code 127 means job's command can not be found or executed

Fixes: https://github.com/servo/servo/issues/28387

Signed-off-by: David Heidelberg <david@ixit.cz>