### PR TITLE
Fix rustfmt.toml path in build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -34,7 +34,7 @@ const ENV_VARS: &'static [&'static str] = &[
 
 const EXTRA_FILES: &'static [&'static str] = &[
     "makefile.cargo",
-    "rustfmt.toml",
+    "src/rustfmt.toml",
     "src/jsglue.hpp",
     "src/jsglue.cpp",
 ];
@@ -234,7 +234,7 @@ fn build_jsglue(build_dir: &Path) {
 /// To add or remove which functions, types, and variables get bindings
 /// generated, see the `const` configuration variables below.
 fn build_jsapi_bindings(build_dir: &Path) {
-    let rustfmt_config = Some(PathBuf::from("rustfmt.toml"));
+    let rustfmt_config = Some(PathBuf::from("src/rustfmt.toml"));
 
     // By default, constructors, destructors and methods declared in .h files are inlined,
     // so their symbols aren't available. Adding the -fkeep-inlined-functions option


### PR DESCRIPTION
This bug caused needless rebuilds, because the (wrong)
rustfmt.toml path appears in a rerun-if-changed command,
triggering a rebuild even when nothing changed.