### PR TITLE
Update deprecated python imports

### DIFF
--- a/etc/patches/0022-py10.patch
+++ b/etc/patches/0022-py10.patch
@@ -1,0 +1,60 @@
+commit aa23c65f311a075da8d72d3beea06c25c5d76df6
+Author: Max von Forell <max@vonforell.de>
+Date:   Sun Dec 26 17:35:59 2021 +0100
+
+    Update deprecated python imports
+
+diff --git a/python/mozbuild/mozbuild/backend/configenvironment.py b/python/mozbuild/mozbuild/backend/configenvironment.py
+index bfc1a29f1c..bf1474755e 100644
+--- a/python/mozbuild/mozbuild/backend/configenvironment.py
++++ b/python/mozbuild/mozbuild/backend/configenvironment.py
+@@ -9,7 +9,8 @@ import six
+ import sys
+ import json
+ 
+-from collections import Iterable, OrderedDict
++from collections import OrderedDict
++from collections.abc import Iterable
+ from types import ModuleType
+ 
+ import mozpack.path as mozpath
+diff --git a/python/mozbuild/mozbuild/makeutil.py b/python/mozbuild/mozbuild/makeutil.py
+index cef0942b9a..97b6c368cb 100644
+--- a/python/mozbuild/mozbuild/makeutil.py
++++ b/python/mozbuild/mozbuild/makeutil.py
+@@ -7,7 +7,7 @@ from __future__ import absolute_import, print_function, unicode_literals
+ import os
+ import re
+ import six
+-from collections import Iterable
++from collections.abc import Iterable
+ 
+ 
+ class Makefile(object):
+diff --git a/python/mozbuild/mozbuild/util.py b/python/mozbuild/mozbuild/util.py
+index 2434bef959..82da8e4c60 100644
+--- a/python/mozbuild/mozbuild/util.py
++++ b/python/mozbuild/mozbuild/util.py
+@@ -809,7 +809,7 @@ class HierarchicalStringList(object):
+         self._strings = StrictOrderingOnAppendList()
+         self._children = {}
+ 
+-    class StringListAdaptor(collections.Sequence):
++    class StringListAdaptor(collections.abc.Sequence):
+         def __init__(self, hsl):
+             self._hsl = hsl
+ 
+diff --git a/testing/mozbase/manifestparser/manifestparser/filters.py b/testing/mozbase/manifestparser/manifestparser/filters.py
+index 017b298d8d..a002c53c47 100644
+--- a/testing/mozbase/manifestparser/manifestparser/filters.py
++++ b/testing/mozbase/manifestparser/manifestparser/filters.py
+@@ -12,7 +12,8 @@ from __future__ import absolute_import, division
+ 
+ import itertools
+ import os
+-from collections import defaultdict, MutableSequence
++from collections import defaultdict
++from collections.abc import MutableSequence
+ 
+ import six
+ from six import string_types

--- a/mozjs/python/mozbuild/mozbuild/backend/configenvironment.py
+++ b/mozjs/python/mozbuild/mozbuild/backend/configenvironment.py
@@ -9,7 +9,8 @@ import six
 import sys
 import json
 
-from collections import Iterable, OrderedDict
+from collections import OrderedDict
+from collections.abc import Iterable
 from types import ModuleType
 
 import mozpack.path as mozpath

--- a/mozjs/python/mozbuild/mozbuild/makeutil.py
+++ b/mozjs/python/mozbuild/mozbuild/makeutil.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import os
 import re
 import six
-from collections import Iterable
+from collections.abc import Iterable
 
 
 class Makefile(object):

--- a/mozjs/python/mozbuild/mozbuild/util.py
+++ b/mozjs/python/mozbuild/mozbuild/util.py
@@ -809,7 +809,7 @@ class HierarchicalStringList(object):
         self._strings = StrictOrderingOnAppendList()
         self._children = {}
 
-    class StringListAdaptor(collections.Sequence):
+    class StringListAdaptor(collections.abc.Sequence):
         def __init__(self, hsl):
             self._hsl = hsl
 

--- a/mozjs/testing/mozbase/manifestparser/manifestparser/filters.py
+++ b/mozjs/testing/mozbase/manifestparser/manifestparser/filters.py
@@ -12,7 +12,8 @@ from __future__ import absolute_import, division
 
 import itertools
 import os
-from collections import defaultdict, MutableSequence
+from collections import defaultdict
+from collections.abc import MutableSequence
 
 import six
 from six import string_types


### PR DESCRIPTION
The abstract base classes in Python's collections module were moved to collections.abc. Importing them from collections is deprecated. With Python 3.10, importing them from collections does not work anymore.

Based on #292.