### PR TITLE
Fix windows llvm installation in CI.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -69,8 +69,6 @@ jobs:
       if: startsWith(matrix.os, 'windows')
       shell: cmd
       env:
-        MAKE: 'gmake'
-        MOZTOOLS_PATH: 'C:\mozilla-build\msys\bin;C:\mozilla-build\bin'
         AUTOCONF: "C:/mozilla-build/msys/local/bin/autoconf-2.13"
         LINKER: "lld-link.exe"
         CC: "clang-cl.exe"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,6 +66,7 @@ jobs:
       if: startsWith(matrix.os, 'windows')
       shell: cmd
       env:
+        MAKE: "gmake"
         MOZTOOLS_PATH: 'C:\mozilla-build\msys\bin;C:\mozilla-build\bin'
         AUTOCONF: "C:/mozilla-build/msys/local/bin/autoconf-2.13"
         LINKER: "lld-link.exe"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-2019]
+        os: [windows-2019]
         rust: [beta, stable]
         features: ["--features debugmozjs", ""]
         exclude:
@@ -44,6 +44,9 @@ jobs:
         .\install.ps1 -RunAsAdmin
         scoop install llvm --global
         echo "C:\ProgramData\scoop\shims;C:\Users\runneradmin\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        dir c:\msys64\usr\bin
+        dir C:\mozilla-build\msys\bin
+        dir C:\mozilla-build\bin
     - uses: actions-rs/toolchain@v1
       with:
           profile: minimal

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,9 +44,8 @@ jobs:
         .\install.ps1 -RunAsAdmin
         scoop install llvm --global
         echo "C:\ProgramData\scoop\shims;C:\Users\runneradmin\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        dir C:\mozilla-build\msys2
         dir c:\msys64\usr\bin
-        dir C:\mozilla-build\bin
-        dir C:\mozilla-build\
     - uses: actions-rs/toolchain@v1
       with:
           profile: minimal
@@ -71,7 +70,7 @@ jobs:
       if: startsWith(matrix.os, 'windows')
       shell: cmd
       env:
-        MAKE: 'C:\msys64\usr\bin\make.exe'
+        MAKE: 'C:/msys64/usr/bin/make.exe'
         MOZTOOLS_PATH: 'C:\mozilla-build\msys\bin;C:\mozilla-build\bin'
         AUTOCONF: "C:/mozilla-build/msys/local/bin/autoconf-2.13"
         LINKER: "lld-link.exe"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,7 +66,7 @@ jobs:
       if: startsWith(matrix.os, 'windows')
       shell: cmd
       env:
-        MAKE: "C:\mozilla-build\msys\bin\make"
+        MAKE: 'C:\mozilla-build\msys\bin\make'
         MOZTOOLS_PATH: 'C:\mozilla-build\msys\bin;C:\mozilla-build\bin'
         AUTOCONF: "C:/mozilla-build/msys/local/bin/autoconf-2.13"
         LINKER: "lld-link.exe"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,6 +33,8 @@ jobs:
         sudo apt install autoconf2.13 gcc-7 g++-7 ccache llvm -y
     - uses: msys2/setup-msys2@v2
       if: startsWith(matrix.os, 'windows')    
+      with:
+        install: base-devel
     - name: Install deps on windows
       if: startsWith(matrix.os, 'windows')
       run: |
@@ -66,7 +68,7 @@ jobs:
       if: startsWith(matrix.os, 'windows')
       shell: cmd
       env:
-        MAKE: 'C:\mozilla-build\msys\bin\make'
+        MAKE: 'C:\msys64\usr\bin\make.exe'
         MOZTOOLS_PATH: 'C:\mozilla-build\msys\bin;C:\mozilla-build\bin'
         AUTOCONF: "C:/mozilla-build/msys/local/bin/autoconf-2.13"
         LINKER: "lld-link.exe"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,7 +45,7 @@ jobs:
         scoop install llvm --global
         echo "C:\ProgramData\scoop\shims;C:\Users\runneradmin\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         dir c:\msys64\usr\bin
-        dir C:\mozilla-build\msys\bin
+        dir C:\mozilla-build\msys\local\bin\
         dir C:\mozilla-build\bin
     - uses: actions-rs/toolchain@v1
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
         rust: [beta, stable]
         features: ["--features debugmozjs", ""]
         exclude:
-          - os: windows-latest
+          - os: windows-2019
             rust: beta
     steps:
     - uses: actions/checkout@v2
@@ -66,7 +66,7 @@ jobs:
       if: startsWith(matrix.os, 'windows')
       shell: cmd
       env:
-        MAKE: "gmake"
+        MAKE: "C:\mozilla-build\msys\bin\make"
         MOZTOOLS_PATH: 'C:\mozilla-build\msys\bin;C:\mozilla-build\bin'
         AUTOCONF: "C:/mozilla-build/msys/local/bin/autoconf-2.13"
         LINKER: "lld-link.exe"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -69,6 +69,7 @@ jobs:
       if: startsWith(matrix.os, 'windows')
       shell: cmd
       env:
+        MAKE: 'gmake'
         MOZTOOLS_PATH: 'C:\mozilla-build\msys\bin;C:\mozilla-build\bin'
         AUTOCONF: "C:/mozilla-build/msys/local/bin/autoconf-2.13"
         LINKER: "lld-link.exe"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,7 +37,8 @@ jobs:
         Start-BitsTransfer -Source https://ftp.mozilla.org/pub/mozilla/libraries/win32/MozillaBuildSetup-Latest.exe -Destination ./MozillaBuildSetup.exe
         .\MozillaBuildSetup.exe /S | Out-Null
         iwr -useb get.scoop.sh -outfile 'install.ps1'
-        .\install.ps1 -RunAsAdmin llvm --global
+        .\install.ps1 -RunAsAdmin
+        scoop install llvm --global
         echo "C:\ProgramData\scoop\shims;C:\Users\runneradmin\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - uses: actions-rs/toolchain@v1
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,8 +45,8 @@ jobs:
         scoop install llvm --global
         echo "C:\ProgramData\scoop\shims;C:\Users\runneradmin\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         dir c:\msys64\usr\bin
-        dir C:\mozilla-build\msys\local\bin\
         dir C:\mozilla-build\bin
+        dir C:\mozilla-build\
     - uses: actions-rs/toolchain@v1
       with:
           profile: minimal

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest, windows-2019]
         rust: [beta, stable]
         features: ["--features debugmozjs", ""]
         exclude:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,8 +36,8 @@ jobs:
       run: |
         Start-BitsTransfer -Source https://ftp.mozilla.org/pub/mozilla/libraries/win32/MozillaBuildSetup-Latest.exe -Destination ./MozillaBuildSetup.exe
         .\MozillaBuildSetup.exe /S | Out-Null
-        iwr -useb get.scoop.sh | iex
-        scoop install llvm --global
+        iwr -useb get.scoop.sh -outfile 'install.ps1'
+        .\install.ps1 -RunAsAdmin llvm --global
         echo "C:\ProgramData\scoop\shims;C:\Users\runneradmin\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - uses: actions-rs/toolchain@v1
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,8 +44,7 @@ jobs:
         .\install.ps1 -RunAsAdmin
         scoop install llvm --global
         echo "C:\ProgramData\scoop\shims;C:\Users\runneradmin\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        dir C:\mozilla-build\msys2
-        dir c:\msys64\usr\bin
+        echo "C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - uses: actions-rs/toolchain@v1
       with:
           profile: minimal
@@ -70,7 +69,6 @@ jobs:
       if: startsWith(matrix.os, 'windows')
       shell: cmd
       env:
-        MAKE: 'C:/msys64/usr/bin/make.exe'
         MOZTOOLS_PATH: 'C:\mozilla-build\msys\bin;C:\mozilla-build\bin'
         AUTOCONF: "C:/mozilla-build/msys/local/bin/autoconf-2.13"
         LINKER: "lld-link.exe"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,6 +31,8 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu')
       run: |
         sudo apt install autoconf2.13 gcc-7 g++-7 ccache llvm -y
+    - uses: msys2/setup-msys2@v2
+      if: startsWith(matrix.os, 'windows')    
     - name: Install deps on windows
       if: startsWith(matrix.os, 'windows')
       run: |


### PR DESCRIPTION
The CI environment changed recently to include a version of scoop that disallows running in admin environments. Following https://github.com/ScoopInstaller/Install#for-admin we should be able to get around this.