### PR TITLE
Get Windows CI builds working again

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install deps on windows
       if: startsWith(matrix.os, 'windows')
       run: |
-        Start-BitsTransfer -Source https://ftp.mozilla.org/pub/mozilla/libraries/win32/MozillaBuildSetup-Latest.exe -Destination ./MozillaBuildSetup.exe
+        Start-BitsTransfer -Source https://ftp.mozilla.org/pub/mozilla/libraries/win32/MozillaBuildSetup-3.4.exe -Destination ./MozillaBuildSetup.exe
         .\MozillaBuildSetup.exe /S | Out-Null
         iwr -useb get.scoop.sh -outfile 'install.ps1'
         .\install.ps1 -RunAsAdmin

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,12 +40,7 @@ jobs:
         .\install.ps1 -RunAsAdmin
         scoop install llvm --global
         echo "C:\ProgramData\scoop\shims;C:\Users\runneradmin\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        dir "C:\ProgramData\scoop\apps\llvm\current\lib"
-        dir "C:\ProgramData\scoop\apps\llvm\current\bin"
-        dir "C:\Program Files\LLVM\lib\clang\13.0.1"
-        dir "C:\Program Files\LLVM\lib\clang\13.0.1\lib"
-        dir "C:\Program Files\LLVM"
-        dir "C:\Program Files\LLVM\bin"
+        dir "C:\Program Files\LLVM\lib\clang\13.0.1\lib\windows"
     - uses: actions-rs/toolchain@v1
       with:
           profile: minimal
@@ -77,7 +72,7 @@ jobs:
         CXX: "clang-cl.exe"
         NATIVE_WIN32_PYTHON: "C:\\mozilla-build\\python2\\python.exe"
         PYTHON3: "C:\\mozilla-build\\python3\\python3.exe"
-        LIBCLANG_PATH: "C:\\Program Files\\LLVM\\lib\\clang\\13.0.1\\lib"
+        LIBCLANG_PATH: 'C:\Program Files\LLVM\lib\clang\13.0.1\lib\windows'
       run: |
         cargo test --verbose --verbose ${{ matrix.features }} --lib
   Integrity:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,9 +15,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest]
-        rust: [stable]
-        features: [""]
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        rust: [beta, stable]
+        features: ["--features debugmozjs", ""]
         exclude:
           - os: windows-latest
             rust: beta

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,7 +36,8 @@ jobs:
       run: |
         Start-BitsTransfer -Source https://ftp.mozilla.org/pub/mozilla/libraries/win32/MozillaBuildSetup-Latest.exe -Destination ./MozillaBuildSetup.exe
         .\MozillaBuildSetup.exe /S | Out-Null
-        iwr -useb get.scoop.sh | iex
+        iwr -useb get.scoop.sh -outfile 'install.ps1'
+        .\install.ps1 -RunAsAdmin
         scoop install llvm --global
         echo "C:\ProgramData\scoop\shims;C:\Users\runneradmin\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,9 +15,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
-        rust: [beta, stable]
-        features: ["--features debugmozjs", ""]
+        os: [windows-latest]
+        rust: [stable]
+        features: [""]
         exclude:
           - os: windows-latest
             rust: beta
@@ -40,6 +40,11 @@ jobs:
         .\install.ps1 -RunAsAdmin
         scoop install llvm --global
         echo "C:\ProgramData\scoop\shims;C:\Users\runneradmin\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        dir "C:\ProgramData\scoop\apps\llvm\current\lib"
+        dir "C:\ProgramData\scoop\apps\llvm\current\bin"
+        dir "C:\Program Files\LLVM\lib\clang\13.0.1"
+        dir "C:\Program Files\LLVM\lib\clang\13.0.1\bin"
+        dir "C:\Program Files\LLVM\lib\clang\13.0.1\lib"
     - uses: actions-rs/toolchain@v1
       with:
           profile: minimal

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,7 +71,7 @@ jobs:
         CXX: "clang-cl.exe"
         NATIVE_WIN32_PYTHON: "C:\\mozilla-build\\python2\\python.exe"
         PYTHON3: "C:\\mozilla-build\\python3\\python3.exe"
-        LIBCLANG_PATH: "C:\\ProgramData\\scoop\\apps\\llvm\\current\\lib"
+        LIBCLANG_PATH: "C:\\Program Files\\LLVM\\lib\\clang\\13.0.1\\lib"
       run: |
         cargo test --verbose --verbose ${{ matrix.features }} --lib
   Integrity:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,8 +43,9 @@ jobs:
         dir "C:\ProgramData\scoop\apps\llvm\current\lib"
         dir "C:\ProgramData\scoop\apps\llvm\current\bin"
         dir "C:\Program Files\LLVM\lib\clang\13.0.1"
-        dir "C:\Program Files\LLVM\lib\clang\13.0.1\bin"
         dir "C:\Program Files\LLVM\lib\clang\13.0.1\lib"
+        dir "C:\Program Files\LLVM"
+        dir "C:\Program Files\LLVM\bin"
     - uses: actions-rs/toolchain@v1
       with:
           profile: minimal

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,9 +38,8 @@ jobs:
         .\MozillaBuildSetup.exe /S | Out-Null
         iwr -useb get.scoop.sh -outfile 'install.ps1'
         .\install.ps1 -RunAsAdmin
-        scoop install llvm --global
+        scoop install llvm@13.0.1 --global
         echo "C:\ProgramData\scoop\shims;C:\Users\runneradmin\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        dir "C:\Program Files\LLVM\lib\clang\13.0.1\lib\windows"
     - uses: actions-rs/toolchain@v1
       with:
           profile: minimal
@@ -72,7 +71,7 @@ jobs:
         CXX: "clang-cl.exe"
         NATIVE_WIN32_PYTHON: "C:\\mozilla-build\\python2\\python.exe"
         PYTHON3: "C:\\mozilla-build\\python3\\python3.exe"
-        LIBCLANG_PATH: 'C:\Program Files\LLVM\lib\clang\13.0.1\lib\windows'
+        LIBCLANG_PATH: "C:\\ProgramData\\scoop\\apps\\llvm\\current\\lib"
       run: |
         cargo test --verbose --verbose ${{ matrix.features }} --lib
   Integrity:


### PR DESCRIPTION
They were broken by changes to Scoop (https://github.com/ScoopInstaller/Install#for-admin) and the release of a new MozillaBuild environment (https://github.com/servo/mozjs/issues/300).