### PR TITLE
Even more portable way to set SHELL to bash

### DIFF
--- a/makefile.cargo
+++ b/makefile.cargo
@@ -1,6 +1,6 @@
 # We need to use bash here, as there are a couple of targets below
 # that use [[ to do conditional things
-SHELL := /usr/bin/env bash
+SHELL := bash
 
 # Default flags
 CONFIGURE_FLAGS := \


### PR DESCRIPTION
While a NixOS system doesn't have /bin/bash but does have
/usr/bin/env, a Nix _builder_ has neither!
As pointed out by @Ms2ger in
https://github.com/servo/mozjs/pull/109#issuecomment-268814475
make will do a path search for you if only the executable
name is specified.