### PR TITLE
Implemented GCMethods for Symbol

### DIFF
--- a/src/jsgc.rs
+++ b/src/jsgc.rs
@@ -99,19 +99,21 @@ pub trait GCMethods {
     unsafe fn post_barrier(v: *mut Self, prev: Self, next: Self);
 }
 
-impl GCMethods for jsid {
-    unsafe fn initial() -> jsid {
-        JSID_VOID
-    }
-    unsafe fn post_barrier(_: *mut jsid, _: jsid, _: jsid) {}
-}
-
 impl GCMethods for *mut JSObject {
     unsafe fn initial() -> *mut JSObject {
         ptr::null_mut()
     }
     unsafe fn post_barrier(v: *mut *mut JSObject, prev: *mut JSObject, next: *mut JSObject) {
         JS::HeapObjectWriteBarriers(v, prev, next);
+    }
+}
+
+impl GCMethods for *mut JSFunction {
+    unsafe fn initial() -> *mut JSFunction {
+        ptr::null_mut()
+    }
+    unsafe fn post_barrier(v: *mut *mut JSFunction, prev: *mut JSFunction, next: *mut JSFunction) {
+        JS::HeapObjectWriteBarriers(mem::transmute(v), mem::transmute(prev), mem::transmute(next));
     }
 }
 
@@ -124,6 +126,13 @@ impl GCMethods for *mut JSString {
     }
 }
 
+impl GCMethods for *mut JS::Symbol {
+    unsafe fn initial() -> *mut Symbol {
+        ptr::null_mut()
+    }
+    unsafe fn post_barrier(_: *mut *mut Symbol, prev: *mut Symbol, next: *mut Symbol) {}
+}
+
 impl GCMethods for *mut JSScript {
     unsafe fn initial() -> *mut JSScript {
         ptr::null_mut()
@@ -133,13 +142,11 @@ impl GCMethods for *mut JSScript {
     }
 }
 
-impl GCMethods for *mut JSFunction {
-    unsafe fn initial() -> *mut JSFunction {
-        ptr::null_mut()
+impl GCMethods for jsid {
+    unsafe fn initial() -> jsid {
+        JSID_VOID
     }
-    unsafe fn post_barrier(v: *mut *mut JSFunction, prev: *mut JSFunction, next: *mut JSFunction) {
-        JS::HeapObjectWriteBarriers(mem::transmute(v), mem::transmute(prev), mem::transmute(next));
-    }
+    unsafe fn post_barrier(_: *mut jsid, _: jsid, _: jsid) {}
 }
 
 impl GCMethods for JS::Value {

--- a/src/jsgc.rs
+++ b/src/jsgc.rs
@@ -127,10 +127,10 @@ impl GCMethods for *mut JSString {
 }
 
 impl GCMethods for *mut JS::Symbol {
-    unsafe fn initial() -> *mut Symbol {
+    unsafe fn initial() -> *mut JS::Symbol {
         ptr::null_mut()
     }
-    unsafe fn post_barrier(_: *mut *mut Symbol, prev: *mut Symbol, next: *mut Symbol) {}
+    unsafe fn post_barrier(_: *mut *mut JS::Symbol, prev: *mut JS::Symbol, next: *mut JS::Symbol) {}
 }
 
 impl GCMethods for *mut JSScript {


### PR DESCRIPTION
Resolves #306

- Adds GCMethods Implementation for `*mut Symbol`
- Rearranges GCMethods Implementations to follow order of RootKind Implementations

`ptr::null_mut()` as `GCMethods::initial` should not affect anything
