### PR TITLE
Added Symbol Functions

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -88,7 +88,7 @@ fn find_make() -> OsString {
                 } else {
                     OsStr::new("make").to_os_string()
                 }
-            },
+            }
             Err(_) => OsStr::new("make").to_os_string(),
         }
     }

--- a/src/jsgc.rs
+++ b/src/jsgc.rs
@@ -130,7 +130,7 @@ impl GCMethods for *mut JS::Symbol {
     unsafe fn initial() -> *mut JS::Symbol {
         ptr::null_mut()
     }
-    unsafe fn post_barrier(_: *mut *mut JS::Symbol, prev: *mut JS::Symbol, next: *mut JS::Symbol) {}
+    unsafe fn post_barrier(_: *mut *mut JS::Symbol, _: *mut JS::Symbol, _: *mut JS::Symbol) {}
 }
 
 impl GCMethods for *mut JSScript {


### PR DESCRIPTION
Added `SymbolValue` and `Value::to_symbol` for converting to and from symbols and values.
Tested with an in-dev version of spiderfire and it seemed to work fine.