### PR TITLE
Disable winheap.cpp compilation.

### DIFF
--- a/etc/patches/0023-no-winheap.patch
+++ b/etc/patches/0023-no-winheap.patch
@@ -1,0 +1,17 @@
+diff --git a/mozjs/memory/mozalloc/moz.build b/mozjs/memory/mozalloc/moz.build
+index fed4239764..c7b95205cb 100644
+--- a/mozjs/memory/mozalloc/moz.build
++++ b/mozjs/memory/mozalloc/moz.build
+@@ -21,12 +21,6 @@ if CONFIG["WRAP_STL_INCLUDES"]:
+             "msvc_raise_wrappers.cpp",
+         ]
+ 
+-if CONFIG["OS_TARGET"] == "WINNT":
+-    # Keep this file separate to avoid #include'ing windows.h everywhere.
+-    SOURCES += [
+-        "winheap.cpp",
+-    ]
+-
+ UNIFIED_SOURCES += [
+     "mozalloc.cpp",
+     "mozalloc_oom.cpp",

--- a/mozjs/memory/mozalloc/moz.build
+++ b/mozjs/memory/mozalloc/moz.build
@@ -21,12 +21,6 @@ if CONFIG["WRAP_STL_INCLUDES"]:
             "msvc_raise_wrappers.cpp",
         ]
 
-if CONFIG["OS_TARGET"] == "WINNT":
-    # Keep this file separate to avoid #include'ing windows.h everywhere.
-    SOURCES += [
-        "winheap.cpp",
-    ]
-
 UNIFIED_SOURCES += [
     "mozalloc.cpp",
     "mozalloc_oom.cpp",


### PR DESCRIPTION
Attempting to work around #312. Based on https://bugzilla.mozilla.org/show_bug.cgi?id=1280578 and https://bugzilla.mozilla.org/show_bug.cgi?id=1514122, it's unclear if we need it or not.