### PR TITLE
Implemented Methods for PropertyKey

### DIFF
--- a/mozjs/src/jsgc.rs
+++ b/mozjs/src/jsgc.rs
@@ -9,12 +9,12 @@ use jsapi::JSScript;
 use jsapi::JSString;
 use jsapi::JSTracer;
 use jsapi::JS;
-use jsid::JSID_VOID;
 
 use std::cell::UnsafeCell;
 use std::mem;
 use std::os::raw::c_void;
 use std::ptr;
+use jsid::VoidId;
 
 /// A trait for JS types that can be registered as roots.
 pub trait RootKind {
@@ -144,7 +144,7 @@ impl GCMethods for *mut JSScript {
 
 impl GCMethods for jsid {
     unsafe fn initial() -> jsid {
-        JSID_VOID
+        VoidId()
     }
     unsafe fn post_barrier(_: *mut jsid, _: jsid, _: jsid) {}
 }

--- a/mozjs/src/jsid.rs
+++ b/mozjs/src/jsid.rs
@@ -57,7 +57,7 @@ impl jsid {
 
 	#[inline(always)]
 	pub fn is_int(&self) -> bool {
-		(self.asBits() & JSID_TYPE_MASK) == (PropertyKeyTag::Int as usize)
+		(self.asBits() & (PropertyKeyTag::Int as usize)) != 0
 	}
 
 	#[inline(always)]

--- a/mozjs/src/jsid.rs
+++ b/mozjs/src/jsid.rs
@@ -2,9 +2,114 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use jsapi::jsid;
+#![allow(non_snake_case)]
 
-// No symbol generated for implicitly initialized constexpr, so we
-// need to duplicate the necessary values.
-pub const JSID_TYPE_VOID: usize = 0x02;
-pub const JSID_VOID: jsid = jsid { asBits: JSID_TYPE_VOID };
+use libc::c_void;
+use jsapi::{jsid, JSString};
+use jsapi::JS::Symbol;
+
+#[deprecated]
+pub const JSID_VOID: jsid = VoidId();
+
+const JSID_TYPE_MASK: usize = 0x7;
+
+#[repr(usize)]
+enum PropertyKeyTag {
+	Int = 0x1,
+	String = 0x0,
+	Void = 0x2,
+	Symbol = 0x4,
+}
+
+#[inline(always)]
+const fn AsPropertyKey(bits: usize) -> jsid {
+	jsid { asBits: bits }
+}
+
+#[inline(always)]
+pub const fn VoidId() -> jsid {
+	AsPropertyKey(PropertyKeyTag::Void as usize)
+}
+
+#[inline(always)]
+pub fn IntId(i: i32) -> jsid {
+	assert!(i >= 0);
+	AsPropertyKey((((i as u32) << 1) as usize) | (PropertyKeyTag::Int as usize))
+}
+
+#[inline(always)]
+pub fn SymbolId(symbol: *mut Symbol) -> jsid {
+	assert!(!symbol.is_null());
+	assert_eq!((symbol as usize) & JSID_TYPE_MASK, 0);
+	AsPropertyKey((symbol as usize) | (PropertyKeyTag::Symbol as usize))
+}
+
+impl jsid {
+	#[inline(always)]
+	fn asBits(&self) -> usize {
+		self.asBits
+	}
+
+	#[inline(always)]
+	pub fn is_void(&self) -> bool {
+		self.asBits() == (PropertyKeyTag::Void as usize)
+	}
+
+	#[inline(always)]
+	pub fn is_int(&self) -> bool {
+		(self.asBits() & JSID_TYPE_MASK) == (PropertyKeyTag::Int as usize)
+	}
+
+	#[inline(always)]
+	pub fn is_string(&self) -> bool {
+		(self.asBits() & JSID_TYPE_MASK) == (PropertyKeyTag::String as usize)
+	}
+
+	#[inline(always)]
+	pub fn is_symbol(&self) -> bool {
+		(self.asBits() & JSID_TYPE_MASK) == (PropertyKeyTag::Symbol as usize)
+	}
+
+	#[inline(always)]
+	pub fn is_gcthing(&self) -> bool {
+		self.is_string() && self.is_symbol()
+	}
+
+	#[inline(always)]
+	pub fn to_int(&self) -> i32 {
+		assert!(self.is_int());
+		((self.asBits() as u32) >> 1) as i32
+	}
+
+	#[inline(always)]
+	pub fn to_string(&self) -> *mut JSString {
+		assert!(self.is_string());
+		(self.asBits() ^ (PropertyKeyTag::String as usize)) as *mut JSString
+	}
+
+	#[inline(always)]
+	pub fn to_symbol(&self) -> *mut Symbol {
+		assert!(self.is_symbol());
+		(self.asBits() ^ (PropertyKeyTag::Symbol as usize)) as *mut Symbol
+	}
+
+	#[inline(always)]
+	pub fn to_gcthing(&self) -> *mut c_void {
+		assert!(self.is_gcthing());
+		(self.asBits() ^ JSID_TYPE_MASK) as *mut c_void
+	}
+}
+
+#[test]
+fn test_representation() {
+	let id = VoidId();
+	assert!(id.is_void());
+
+	let id = IntId(0);
+	assert!(id.is_int());
+	assert_eq!(id.to_int(), 0);
+
+	let id = IntId(i32::MAX);
+	assert!(id.is_int());
+	assert_eq!(id.to_int(), i32::MAX);
+}

--- a/mozjs/src/jsimpls.rs
+++ b/mozjs/src/jsimpls.rs
@@ -18,7 +18,7 @@ use jsapi::JSPropertySpec;
 use jsapi::JSPropertySpec_Name;
 use jsapi::JS;
 use jsgc::RootKind;
-use jsid::JSID_VOID;
+use jsid::VoidId;
 use jsval::UndefinedValue;
 
 use std::ops::Deref;
@@ -50,7 +50,7 @@ impl<T> DerefMut for JS::MutableHandle<T> {
 
 impl Default for jsid {
     fn default() -> Self {
-        JSID_VOID
+        VoidId()
     }
 }
 

--- a/rust-mozjs/src/glue.rs
+++ b/rust-mozjs/src/glue.rs
@@ -412,12 +412,19 @@ extern "C" {
     pub fn SetProxyReservedSlot(obj: *mut JSObject, slot: u32, val: *const JS::Value);
     pub fn SetProxyPrivate(obj: *mut JSObject, expando: *const JS::Value);
 
+    #[deprecated]
     pub fn RUST_JSID_IS_INT(id: HandleId) -> bool;
+    #[deprecated]
     pub fn RUST_JSID_TO_INT(id: HandleId) -> i32;
+    #[deprecated]
     pub fn int_to_jsid(i: i32, id: MutableHandleId);
+    #[deprecated]
     pub fn RUST_JSID_IS_STRING(id: HandleId) -> bool;
+    #[deprecated]
     pub fn RUST_JSID_TO_STRING(id: HandleId) -> *mut JSString;
+    #[deprecated]
     pub fn RUST_SYMBOL_TO_JSID(sym: *mut Symbol, id: MutableHandleId);
+    #[deprecated]
     pub fn RUST_JSID_IS_VOID(id: HandleId) -> bool;
     pub fn SetBuildId(buildId: *mut JS::BuildIdCharVector, chars: *const u8, len: usize) -> bool;
     pub fn RUST_SET_JITINFO(func: *mut JSFunction, info: *const JSJitInfo);

--- a/rust-mozjs/tests/enumerate.rs
+++ b/rust-mozjs/tests/enumerate.rs
@@ -7,7 +7,6 @@ extern crate mozjs;
 
 use std::ptr;
 
-use mozjs::glue::{RUST_JSID_IS_STRING, RUST_JSID_TO_STRING};
 use mozjs::jsapi::{GetPropertyKeys, JS_NewGlobalObject, JS_StringEqualsAscii, OnNewGlobalHookOption};
 use mozjs::jsapi::JSITER_OWNONLY;
 use mozjs::jsval::UndefinedValue;
@@ -54,8 +53,8 @@ fn enumerate() {
         assert_eq!(ids.len(), 1);
         rooted!(in(context) let id = ids[0]);
 
-        assert!(RUST_JSID_IS_STRING(id.handle().into()));
-        rooted!(in(context) let id = RUST_JSID_TO_STRING(id.handle().into()));
+        assert!(id.is_string());
+        rooted!(in(context) let id = id.to_string());
 
         let mut matches = false;
         assert!(JS_StringEqualsAscii(


### PR DESCRIPTION
Resolves servo/rust-mozjs#544

There are a few inconsistent names in `jsid.rs` because `PropertyKey` and `jsid` are both names for the same thing, so I can change any of those if requested.
I have also deprecated the old functions which are in `mozjs::glue`, in favour of the new methods.

This also serves as preparation for future versions as stated in the [Migration Guide](https://github.com/mozilla-spidermonkey/spidermonkey-embedding-examples/blob/8dd70287d6214f24f7fcd1abd9d4f326ba7b4f62/docs/Migration%20Guide.md#property-keys).