### PR TITLE
Reexported jsid

### DIFF
--- a/rust-mozjs/src/lib.rs
+++ b/rust-mozjs/src/lib.rs
@@ -59,6 +59,7 @@ pub mod panic;
 pub mod typedarray;
 
 pub use consts::*;
+pub use mozjs_sys::jsid;
 pub use mozjs_sys::jsval;
 
 pub use jsval::JS_ARGV;


### PR DESCRIPTION
Allows `VoidId`, `IntId` and `SymbolId` to be used from `mozjs` directly.