### PR TITLE
Fix makefile style and fallback to general cc commands & temp windows builds fix

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,6 +78,7 @@ jobs:
       if: contains(matrix.target, 'uwp')
       shell: cmd
       env:
+        TOOLCHAIN: nightly-2023-02-02
         MOZTOOLS_PATH: 'C:\mozilla-build\msys\bin;C:\mozilla-build\bin'
         AUTOCONF: "C:/mozilla-build/msys/local/bin/autoconf-2.13"
         LINKER: "lld-link.exe"
@@ -87,8 +88,8 @@ jobs:
         PYTHON3: "C:\\mozilla-build\\python3\\python3.exe"
         LIBCLANG_PATH: "C:\\ProgramData\\scoop\\apps\\llvm\\current\\lib"
       run: |
-        rustup install nightly-2022-11-20
-        rustup default nightly-2022-11-20
+        rustup install ${{ env.TOOLCHAIN }}
+        rustup default ${{ env.TOOLCHAIN }}
         rustup component add rust-src
         rustc --version --verbose
         cargo build --verbose ${{ matrix.features }} -Z build-std=std,panic_abort --target ${{ matrix.target }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -90,9 +90,9 @@ jobs:
       run: |
         rustup install ${{ env.TOOLCHAIN }}
         rustup default ${{ env.TOOLCHAIN }}
-        rustup component add rust-src
+        rustup component add rust-src --toolchain ${{ env.TOOLCHAIN }}-x86_64-pc-windows-msvc
         rustc --version --verbose
-        cargo build --verbose ${{ matrix.features }} -Z build-std=std,panic_abort --target ${{ matrix.target }}
+        cargo +${{ env.TOOLCHAIN }} build --verbose ${{ matrix.features }} -Z build-std=std,panic_abort --target ${{ matrix.target }}
     - name: Build Windows
       if: contains(matrix.target, 'uwp') != true
       shell: cmd

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,7 +73,7 @@ jobs:
         .\install.ps1 -RunAsAdmin
         scoop install llvm@15.0.7 --global
         echo "C:\ProgramData\scoop\shims;C:\Users\runneradmin\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-    - uses: dtolnay/rust-toolchain@stable
+    - uses: dtolnay/rust-toolchain@1.66
     - name: Build uwp
       if: contains(matrix.target, 'uwp')
       shell: cmd

--- a/mozjs/makefile.cargo
+++ b/mozjs/makefile.cargo
@@ -79,37 +79,37 @@ ifneq ($(HOST),$(TARGET))
 		endif
 	endif
 
-ifeq ($(WINDOWS),)
-	CC ?= $(TARGET)-gcc
-	CPP ?= $(TARGET)-gcc -E
-	CXX ?= $(TARGET)-g++
-	AR ?= $(TARGET)-ar
-	CONFIGURE_FLAGS += --target=$(TARGET) --disable-gold
-endif
-
-else
-
-ifeq (,$(WINDOWS))
-	ifeq (freebsd,$(findstring freebsd,$(TARGET)))
-		# Does not symlink clang as "gcc" like macOS does
-		CC ?= clang
-		CPP ?= clang -E
-		CXX ?= clang++
-	else
-		CC ?= gcc
-		CPP ?= gcc -E
-		CXX ?= g++
+	ifeq ($(WINDOWS),)
+		CC ?= $(TARGET)-gcc
+		CPP ?= $(TARGET)-gcc -E
+		CXX ?= $(TARGET)-g++
+		AR ?= $(TARGET)-ar
+		CONFIGURE_FLAGS += --target=$(TARGET) --disable-gold
 	endif
-AR ?= ar
 
-# check if python2 is a valid Python executable, otherwise fall back to python
-ifeq (, $(findstring Python 2.,$(shell python2 --version 2> /dev/null)))
-PYTHON ?= python2
 else
-PYTHON ?= python
-endif 
 
-endif
+	ifeq (,$(WINDOWS))
+		ifeq (freebsd,$(findstring freebsd,$(TARGET)))
+			# Does not symlink clang as "gcc" like macOS does
+			CC ?= clang
+			CPP ?= clang -E
+			CXX ?= clang++
+		else
+			CC ?= cc
+			CPP ?= cc -E
+			CXX ?= c++
+		endif
+		AR ?= ar
+
+		# check if python2 is a valid Python executable, otherwise fall back to python
+		ifeq (, $(findstring Python 2.,$(shell python2 --version 2> /dev/null)))
+		PYTHON ?= python2
+		else
+		PYTHON ?= python
+		endif 
+
+	endif
 
 endif
 


### PR DESCRIPTION
- use `cc` instead of `gcc` and `c++` instead of `g++` for fallback on linux
- format makefile
- pin window ci to rust 1.66 due to #334
- update nightly version used for UWP