### PR TITLE
README: add instructions for building on NixOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,22 @@ In order to upgrade to a new version of SpiderMonkey:
 5. Update `etc/COMMIT` with the commit number.
 
 6. Build and test the bindings as above, then submit a PR!
+
+NixOS users
+===========
+
+To get a dev environment with shell.nix:
+
+```sh
+$ nix-shell
+```
+
+To configure rust-analyzer in Visual Studio Code:
+
+```json
+{
+    "rust-analyzer.check.overrideCommand": ["nix-shell", "--run", "cargo check --message-format=json"],
+    "rust-analyzer.cargo.buildScripts.overrideCommand": ["nix-shell", "--run", "cargo check --message-format=json"],
+    "rust-analyzer.rustfmt.overrideCommand": ["nix-shell", "--run", "cargo fmt"],
+}
+```

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,31 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.clangStdenv.mkDerivation {
+  name = "mozjs-shell";
+
+  shellHook = ''
+    export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [
+      pkgs.zlib
+      pkgs.libclang
+    ]}
+
+    # standalone as(1) doesn’t treat -DNDEBUG as -D NDEBUG (define), but rather -D (produce
+    # assembler debugging messages) + -N (invalid option); see also <https://bugs.gentoo.org/732190>
+    # /nix/store/a64w6zy8w9hcj6b4g5nz0dl6zyd24c1x-gcc-wrapper-11.3.0/bin/as: invalid option -- 'N'
+    # make[4]: *** [/path/to/mozjs/mozjs/mozjs/config/rules.mk:664: icu_data.o] Error 1
+    # make[3]: *** [/path/to/mozjs/mozjs/mozjs/config/recurse.mk:72: config/external/icu/data/target-objects] Error 2
+    export AS="$CC -c"
+  '';
+
+  buildInputs = [
+      pkgs.rustup
+      pkgs.python3
+      pkgs.perl
+
+      pkgs.llvmPackages.bintools-unwrapped
+      pkgs.pkg-config
+      pkgs.gnum4
+
+      pkgs.zlib
+      pkgs.libclang
+  ];
+}


### PR DESCRIPTION
This patch makes it easier for NixOS users to work on mozjs by adding a shell.nix that should be exhaustive (it compiles ok under nix-shell --pure), and some advice to the README about Visual Studio Code and rust-analyzer.