### PR TITLE
Added GC Tracing Infrastructure

### DIFF
--- a/mozjs/src/jsgc.rs
+++ b/mozjs/src/jsgc.rs
@@ -494,7 +494,7 @@ unsafe impl<A: Traceable, B: Traceable, C: Traceable, D: Traceable> Traceable fo
     }
 }
 
-struct RootedTraceableSet {
+pub struct RootedTraceableSet {
     set: Vec<*const dyn Traceable>,
 }
 
@@ -507,13 +507,13 @@ impl RootedTraceableSet {
         RootedTraceableSet { set: Vec::new() }
     }
 
-    unsafe fn add(traceable: *const dyn Traceable) {
+    pub unsafe fn add(traceable: *const dyn Traceable) {
         ROOTED_TRACEABLES.with(|traceables| {
             traceables.borrow_mut().set.push(traceable);
         });
     }
 
-    unsafe fn remove(traceable: *const dyn Traceable) {
+    pub unsafe fn remove(traceable: *const dyn Traceable) {
         ROOTED_TRACEABLES.with(|traceables| {
             let mut traceables = traceables.borrow_mut();
             let idx = match traceables.set.iter().rposition(|x| *x as *const () == traceable as *const ()) {

--- a/mozjs/src/jsgc.rs
+++ b/mozjs/src/jsgc.rs
@@ -2,19 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use jsapi::jsid;
-use jsapi::JSFunction;
-use jsapi::JSObject;
-use jsapi::JSScript;
-use jsapi::JSString;
-use jsapi::JSTracer;
+use jsapi::glue::{
+    CallFunctionTracer, CallIdTracer, CallObjectTracer, CallScriptTracer, CallStringTracer,
+    CallValueTracer
+};
 use jsapi::JS;
+use jsapi::JS::Value;
+use jsapi::{jsid, JSFunction, JSObject, JSScript, JSString, JSTracer};
 
 use jsid::VoidId;
-use std::cell::UnsafeCell;
+use std::cell::{Cell, RefCell, UnsafeCell};
+use std::ffi::c_void;
 use std::mem;
-use std::os::raw::c_void;
 use std::ptr;
+
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
+use std::hash::{BuildHasher, Hash};
+use std::rc::Rc;
+use std::sync::Arc;
 
 /// A trait for JS types that can be registered as roots.
 pub trait RootKind {
@@ -265,6 +270,271 @@ impl<T: GCMethods + Copy + PartialEq> PartialEq for Heap<T> {
     fn eq(&self, other: &Self) -> bool {
         self.get() == other.get()
     }
+}
+
+// Creates a C string literal `$str`.
+#[macro_export]
+macro_rules! c_str {
+    ($str:expr) => {
+        concat!($str, "\0").as_ptr() as *const ::std::os::raw::c_char
+    };
+}
+
+/// Types that can be traced.
+///
+/// This trait is unsafe; if it is implemented incorrectly, the GC may end up collecting objects
+/// that are still reachable.
+pub unsafe trait Traceable {
+    /// Trace `self`.
+    unsafe fn trace(&self, trc: *mut JSTracer);
+}
+
+unsafe impl Traceable for Heap<*mut JSFunction> {
+    #[inline]
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        if self.get().is_null() {
+            return;
+        }
+        CallFunctionTracer(trc, self as *const _ as *mut Self, c_str!("function"));
+    }
+}
+
+unsafe impl Traceable for Heap<*mut JSObject> {
+    #[inline]
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        if self.get().is_null() {
+            return;
+        }
+        CallObjectTracer(trc, self as *const _ as *mut Self, c_str!("object"));
+    }
+}
+
+unsafe impl Traceable for Heap<*mut JSScript> {
+    #[inline]
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        if self.get().is_null() {
+            return;
+        }
+        CallScriptTracer(trc, self as *const _ as *mut Self, c_str!("script"));
+    }
+}
+
+unsafe impl Traceable for Heap<*mut JSString> {
+    #[inline]
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        if self.get().is_null() {
+            return;
+        }
+        CallStringTracer(trc, self as *const _ as *mut Self, c_str!("string"));
+    }
+}
+
+unsafe impl Traceable for Heap<Value> {
+    #[inline]
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        CallValueTracer(trc, self as *const _ as *mut Self, c_str!("value"));
+    }
+}
+
+unsafe impl Traceable for Heap<jsid> {
+    #[inline]
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        CallIdTracer(trc, self as *const _ as *mut Self, c_str!("id"));
+    }
+}
+
+unsafe impl<T: Traceable> Traceable for Rc<T> {
+    #[inline]
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        (**self).trace(trc);
+    }
+}
+
+unsafe impl<T: Traceable> Traceable for Arc<T> {
+    #[inline]
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        (**self).trace(trc);
+    }
+}
+
+unsafe impl<T: Traceable> Traceable for Box<T> {
+    #[inline]
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        (**self).trace(trc);
+    }
+}
+
+unsafe impl<T: Traceable + Copy> Traceable for Cell<T> {
+    #[inline]
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        self.get().trace(trc);
+    }
+}
+
+unsafe impl<T: Traceable> Traceable for UnsafeCell<T> {
+    #[inline]
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        (*self.get()).trace(trc);
+    }
+}
+
+unsafe impl<T: Traceable> Traceable for RefCell<T> {
+    #[inline]
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        (*self).borrow().trace(trc);
+    }
+}
+
+unsafe impl<T: Traceable> Traceable for Option<T> {
+    #[inline]
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        self.as_ref().map(|t| t.trace(trc));
+    }
+}
+
+unsafe impl<T: Traceable, E: Traceable> Traceable for Result<T, E> {
+    #[inline]
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        match self {
+            Ok(t) => t.trace(trc),
+            Err(e) => e.trace(trc),
+        }
+    }
+}
+
+unsafe impl<T: Traceable> Traceable for [T] {
+    #[inline]
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        for t in self.iter() {
+            t.trace(trc);
+        }
+    }
+}
+
+unsafe impl<T: Traceable> Traceable for Vec<T> {
+    #[inline]
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        for t in &*self {
+            t.trace(trc);
+        }
+    }
+}
+
+unsafe impl<T: Traceable> Traceable for VecDeque<T> {
+    #[inline]
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        for t in &*self {
+            t.trace(trc);
+        }
+    }
+}
+
+unsafe impl<K: Traceable + Eq + Hash, V: Traceable, S: BuildHasher> Traceable for HashMap<K, V, S> {
+    #[inline]
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        for (k, v) in &*self {
+            k.trace(trc);
+            v.trace(trc);
+        }
+    }
+}
+
+unsafe impl<T: Traceable + Eq + Hash, S: BuildHasher> Traceable for HashSet<T, S> {
+    #[inline]
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        for t in &*self {
+            t.trace(trc);
+        }
+    }
+}
+
+unsafe impl<K: Traceable + Eq + Hash, V: Traceable> Traceable for BTreeMap<K, V> {
+    #[inline]
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        for (k, v) in &*self {
+            k.trace(trc);
+            v.trace(trc);
+        }
+    }
+}
+
+unsafe impl<T: Traceable> Traceable for BTreeSet<T> {
+    #[inline]
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        for t in &*self {
+            t.trace(trc);
+        }
+    }
+}
+
+unsafe impl<A: Traceable, B: Traceable> Traceable for (A, B) {
+    #[inline]
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        self.0.trace(trc);
+        self.1.trace(trc);
+    }
+}
+
+unsafe impl<A: Traceable, B: Traceable, C: Traceable> Traceable for (A, B, C) {
+    #[inline]
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        self.0.trace(trc);
+        self.1.trace(trc);
+        self.2.trace(trc);
+    }
+}
+
+unsafe impl<A: Traceable, B: Traceable, C: Traceable, D: Traceable> Traceable for (A, B, C, D) {
+    #[inline]
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        self.0.trace(trc);
+        self.1.trace(trc);
+        self.2.trace(trc);
+        self.3.trace(trc);
+    }
+}
+
+struct RootedTraceableSet {
+    set: Vec<*const dyn Traceable>,
+}
+
+thread_local!(
+    static ROOTED_TRACEABLES: RefCell<RootedTraceableSet>  = RefCell::new(RootedTraceableSet::new())
+);
+
+impl RootedTraceableSet {
+    fn new() -> RootedTraceableSet {
+        RootedTraceableSet { set: Vec::new() }
+    }
+
+    unsafe fn add(traceable: *const dyn Traceable) {
+        ROOTED_TRACEABLES.with(|traceables| {
+            traceables.borrow_mut().set.push(traceable);
+        });
+    }
+
+    unsafe fn remove(traceable: *const dyn Traceable) {
+        ROOTED_TRACEABLES.with(|traceables| {
+            let mut traceables = traceables.borrow_mut();
+            let idx = match traceables.set.iter().rposition(|x| *x as *const () == traceable as *const ()) {
+                Some(idx) => idx,
+                None => return,
+            };
+            traceables.set.remove(idx);
+        });
+    }
+
+    pub(crate) unsafe fn trace(&self, trc: *mut JSTracer) {
+        for traceable in &self.set {
+            (**traceable).trace(trc);
+        }
+    }
+}
+
+pub(crate) unsafe extern "C" fn trace_traceables(trc: *mut JSTracer, _: *mut c_void) {
+    ROOTED_TRACEABLES.with(|traceables| {
+        traceables.borrow().trace(trc);
+    });
 }
 
 /// Trait for things that can be converted to handles

--- a/mozjs/src/jsglue.cpp
+++ b/mozjs/src/jsglue.cpp
@@ -69,6 +69,50 @@ bool JS_ForOfIteratorNext(JS::ForOfIterator* iterator,
   return iterator->next(val, done);
 }
 
+// Expose templated functions for tracing
+
+void CallValueTracer(JSTracer* trc, JS::Heap<JS::Value>* valuep,
+                     const char* name) {
+  JS::TraceEdge(trc, valuep, name);
+}
+
+void CallIdTracer(JSTracer* trc, JS::Heap<jsid>* idp, const char* name) {
+  JS::TraceEdge(trc, idp, name);
+}
+
+void CallObjectTracer(JSTracer* trc, JS::Heap<JSObject*>* objp,
+                      const char* name) {
+  JS::TraceEdge(trc, objp, name);
+}
+
+void CallStringTracer(JSTracer* trc, JS::Heap<JSString*>* strp,
+                      const char* name) {
+  JS::TraceEdge(trc, strp, name);
+}
+
+void CallScriptTracer(JSTracer* trc, JS::Heap<JSScript*>* scriptp,
+                      const char* name) {
+  JS::TraceEdge(trc, scriptp, name);
+}
+
+void CallFunctionTracer(JSTracer* trc, JS::Heap<JSFunction*>* funp,
+                        const char* name) {
+  JS::TraceEdge(trc, funp, name);
+}
+
+void CallUnbarrieredObjectTracer(JSTracer* trc, JSObject** objp,
+                                 const char* name) {
+  js::UnsafeTraceManuallyBarrieredEdge(trc, objp, name);
+}
+
+void CallObjectRootTracer(JSTracer* trc, JSObject** objp, const char* name) {
+  JS::TraceRoot(trc, objp, name);
+}
+
+void CallValueRootTracer(JSTracer* trc, JS::Value* valp, const char* name) {
+  JS::TraceRoot(trc, valp, name);
+}
+
 // These functions are only intended for use in testing,
 // to make sure that the Rust implementation of JS::Value
 // agrees with the C++ implementation.
@@ -115,7 +159,7 @@ JSLinearString* AtomToLinearString(JSAtom* atom) {
   return JS::AtomToLinearString(atom);
 }
 
-/* These types are using maybe, so we manually unwrap it in these wrappers */
+// These types are using maybe so we manually unwrap them in these wrappers
 
 bool FromPropertyDescriptor(JSContext* cx,
                             JS::Handle<JS::PropertyDescriptor> desc_,

--- a/mozjs/src/jsglue.hpp
+++ b/mozjs/src/jsglue.hpp
@@ -47,9 +47,10 @@
 #include "jsapi.h"
 #include "jsfriendapi.h"
 
-// Reexport some functions that are marked inline.
 
 namespace glue {
+
+// Reexport some functions that are marked inline.
 
 bool JS_Init();
 
@@ -58,11 +59,17 @@ void DeleteRealmOptions(JS::RealmOptions* options);
 JS::OwningCompileOptions* JS_NewOwningCompileOptions(JSContext* cx);
 void DeleteOwningCompileOptions(JS::OwningCompileOptions* optiosn);
 
+JS::shadow::Zone* JS_AsShadowZone(JS::Zone* zone);
+
+JS::CallArgs JS_CallArgsFromVp(unsigned argc, JS::Value* vp);
+
 void JS_StackCapture_AllFrames(JS::StackCapture*);
 void JS_StackCapture_MaxFrames(uint32_t max, JS::StackCapture*);
 void JS_StackCapture_FirstSubsumedFrame(JSContext* cx,
                                         bool ignoreSelfHostedFrames,
                                         JS::StackCapture*);
+
+// Reexport some methods
 
 bool JS_ForOfIteratorInit(
     JS::ForOfIterator* iterator, JS::HandleValue iterable,
@@ -70,9 +77,27 @@ bool JS_ForOfIteratorInit(
 bool JS_ForOfIteratorNext(JS::ForOfIterator* iterator,
                           JS::MutableHandleValue val, bool* done);
 
-JS::shadow::Zone* JS_AsShadowZone(JS::Zone* zone);
+// Expose templated functions for tracing
 
-JS::CallArgs JS_CallArgsFromVp(unsigned argc, JS::Value* vp);
+void CallValueTracer(JSTracer* trc, JS::Heap<JS::Value>* valuep,
+                     const char* name);
+void CallIdTracer(JSTracer* trc, JS::Heap<jsid>* idp, const char* name);
+void CallObjectTracer(JSTracer* trc, JS::Heap<JSObject*>* objp,
+                      const char* name);
+void CallStringTracer(JSTracer* trc, JS::Heap<JSString*>* strp,
+                      const char* name);
+void CallScriptTracer(JSTracer* trc, JS::Heap<JSScript*>* scriptp,
+                      const char* name);
+void CallFunctionTracer(JSTracer* trc, JS::Heap<JSFunction*>* funp,
+                        const char* name);
+void CallUnbarrieredObjectTracer(JSTracer* trc, JSObject** objp,
+                                 const char* name);
+void CallObjectRootTracer(JSTracer* trc, JSObject** objp, const char* name);
+void CallValueRootTracer(JSTracer* trc, JS::Value* valp, const char* name);
+
+// These functions are only intended for use in testing,
+// to make sure that the Rust implementation of JS::Value
+// agrees with the C++ implementation.
 
 void JS_ValueSetBoolean(JS::Value* value, bool x);
 bool JS_ValueIsBoolean(const JS::Value* value);
@@ -98,36 +123,16 @@ size_t GetLinearStringLength(JSLinearString* s);
 uint16_t GetLinearStringCharAt(JSLinearString* s, size_t idx);
 JSLinearString* AtomToLinearString(JSAtom* atom);
 
-bool FromPropertyDescriptor(JSContext* cx,
-                            JS::Handle<JS::PropertyDescriptor> desc,
-                            JS::MutableHandle<JS::Value> vp);
-bool JS_GetOwnPropertyDescriptorById(
-    JSContext* cx, JS::HandleObject obj, JS::HandleId id,
-    JS::MutableHandle<JS::PropertyDescriptor> desc, bool* isNone);
-bool JS_GetOwnPropertyDescriptor(JSContext* cx, JS::HandleObject obj,
-                                 const char* name,
-                                 JS::MutableHandle<JS::PropertyDescriptor> desc,
-                                 bool* isNone);
-bool JS_GetOwnUCPropertyDescriptor(
-    JSContext* cx, JS::HandleObject obj, const char16_t* name, size_t namelen,
-    JS::MutableHandle<JS::PropertyDescriptor> desc, bool* isNone);
-bool JS_GetPropertyDescriptorById(
-    JSContext* cx, JS::HandleObject obj, JS::HandleId id,
-    JS::MutableHandle<JS::PropertyDescriptor> desc,
-    JS::MutableHandleObject holder, bool* isNone);
-bool JS_GetPropertyDescriptor(JSContext* cx, JS::HandleObject obj,
-                              const char* name,
-                              JS::MutableHandle<JS::PropertyDescriptor> desc,
-                              JS::MutableHandleObject holder, bool* isNone);
-bool JS_GetUCPropertyDescriptor(JSContext* cx, JS::HandleObject obj,
-                                const char16_t* name, size_t namelen,
-                                JS::MutableHandle<JS::PropertyDescriptor> desc,
-                                JS::MutableHandleObject holder, bool* isNone);
-bool SetPropertyIgnoringNamedGetter(JSContext* cx, JS::HandleObject obj,
-                                    JS::HandleId id, JS::HandleValue v,
-                                    JS::HandleValue receiver,
-                                    JS::Handle<JS::PropertyDescriptor> ownDesc,
-                                    JS::ObjectOpResult& result);
+// These types are using maybe so we manually unwrap them in these wrappers
+
+bool FromPropertyDescriptor(JSContext *cx, JS::Handle<JS::PropertyDescriptor> desc, JS::MutableHandle<JS::Value> vp);
+bool JS_GetOwnPropertyDescriptorById(JSContext* cx, JS::HandleObject obj, JS::HandleId id, JS::MutableHandle<JS::PropertyDescriptor> desc, bool* isNone);
+bool JS_GetOwnPropertyDescriptor(JSContext* cx, JS::HandleObject obj, const char* name, JS::MutableHandle<JS::PropertyDescriptor> desc, bool* isNone);
+bool JS_GetOwnUCPropertyDescriptor(JSContext* cx, JS::HandleObject obj, const char16_t* name, size_t namelen, JS::MutableHandle<JS::PropertyDescriptor> desc, bool* isNone);
+bool JS_GetPropertyDescriptorById(JSContext* cx, JS::HandleObject obj, JS::HandleId id, JS::MutableHandle<JS::PropertyDescriptor> desc, JS::MutableHandleObject holder, bool* isNone);
+bool JS_GetPropertyDescriptor(JSContext* cx, JS::HandleObject obj, const char* name, JS::MutableHandle<JS::PropertyDescriptor> desc, JS::MutableHandleObject holder, bool* isNone);
+bool JS_GetUCPropertyDescriptor(JSContext* cx, JS::HandleObject obj, const char16_t* name, size_t namelen, JS::MutableHandle<JS::PropertyDescriptor> desc, JS::MutableHandleObject holder, bool* isNone);
+bool SetPropertyIgnoringNamedGetter(JSContext* cx, JS::HandleObject obj, JS::HandleId id, JS::HandleValue v, JS::HandleValue receiver, JS::Handle<JS::PropertyDescriptor> ownDesc, JS::ObjectOpResult& result);
 
 bool CreateError(JSContext* cx, JSExnType type, JS::HandleObject stack,
                  JS::HandleString fileName, uint32_t lineNumber,

--- a/mozjs/src/jsimpls.rs
+++ b/mozjs/src/jsimpls.rs
@@ -90,7 +90,7 @@ impl<T> JS::Handle<T> {
 
 impl<T> JS::MutableHandle<T> {
     pub unsafe fn from_marked_location(ptr: *mut T) -> JS::MutableHandle<T> {
-        JS::MutableHandle { ptr: ptr, _phantom_0: ::std::marker::PhantomData }
+        JS::MutableHandle { ptr, _phantom_0: ::std::marker::PhantomData }
     }
 
     pub fn handle(&self) -> JS::Handle<T> {

--- a/rust-mozjs/src/conversions.rs
+++ b/rust-mozjs/src/conversions.rs
@@ -41,6 +41,7 @@ use jsval::{BooleanValue, Int32Value, NullValue, UInt32Value, UndefinedValue};
 use jsval::{JSVal, ObjectOrNullValue, ObjectValue, StringValue, SymbolValue};
 use libc;
 use num_traits::{Bounded, Zero};
+use rooted;
 use rust::maybe_wrap_value;
 use rust::{maybe_wrap_object_or_null_value, maybe_wrap_object_value, ToString};
 use rust::{HandleValue, MutableHandleValue};
@@ -631,7 +632,7 @@ impl<'a> ForOfIteratorGuard<'a> {
         unsafe {
             root.iterator.add_to_root_stack(cx);
         }
-        ForOfIteratorGuard { root: root }
+        ForOfIteratorGuard { root }
     }
 }
 

--- a/rust-mozjs/src/gc/custom.rs
+++ b/rust-mozjs/src/gc/custom.rs
@@ -1,0 +1,180 @@
+use std::ffi::c_void;
+use std::ops::{Deref, DerefMut};
+
+use jsapi;
+use mozjs_sys::jsapi::JS::{AutoGCRooter, AutoGCRooterKind, Value};
+use mozjs_sys::jsapi::{JSContext, JSObject, JSTracer};
+use mozjs_sys::jsgc::{CustomAutoRooterVFTable, RootKind};
+use rust::{Handle, MutableHandle};
+
+use mozjs_sys::c_str;
+use jsapi::glue::{CallObjectRootTracer, CallValueRootTracer};
+
+/// Similarly to `Trace` trait, it's used to specify tracing of various types
+/// that are used in conjunction with `CustomAutoRooter`.
+pub unsafe trait CustomTrace {
+    fn trace(&self, trc: *mut JSTracer);
+}
+
+unsafe impl CustomTrace for *mut JSObject {
+    fn trace(&self, trc: *mut JSTracer) {
+        let this = self as *const *mut _ as *mut *mut _;
+        unsafe {
+            CallObjectRootTracer(trc, this, c_str!("object"));
+        }
+    }
+}
+
+unsafe impl CustomTrace for Value {
+    fn trace(&self, trc: *mut JSTracer) {
+        let this = self as *const _ as *mut _;
+        unsafe {
+            CallValueRootTracer(trc, this, c_str!("any"));
+        }
+    }
+}
+
+unsafe impl<T: CustomTrace> CustomTrace for Option<T> {
+    fn trace(&self, trc: *mut JSTracer) {
+        if let Some(ref some) = *self {
+            some.trace(trc);
+        }
+    }
+}
+
+unsafe impl<T: CustomTrace> CustomTrace for Vec<T> {
+    fn trace(&self, trc: *mut JSTracer) {
+        for elem in self {
+            elem.trace(trc);
+        }
+    }
+}
+
+// This structure reimplements a C++ class that uses virtual dispatch, so
+// use C layout to guarantee that vftable in CustomAutoRooter is in right place.
+#[repr(C)]
+pub struct CustomAutoRooter<T> {
+    _base: jsapi::CustomAutoRooter,
+    data: T,
+}
+
+impl<T> CustomAutoRooter<T> {
+    unsafe fn add_to_root_stack(&mut self, cx: *mut JSContext) {
+        self._base._base.add_to_root_stack(cx);
+    }
+
+    unsafe fn remove_from_root_stack(&mut self) {
+        self._base._base.remove_from_root_stack();
+    }
+}
+
+/// `CustomAutoRooter` uses dynamic dispatch on the C++ side for custom tracing,
+/// so provide trace logic via vftable when creating an object on Rust side.
+unsafe trait CustomAutoTraceable: Sized {
+    const vftable: CustomAutoRooterVFTable = CustomAutoRooterVFTable {
+        padding: CustomAutoRooterVFTable::PADDING,
+        trace: Self::trace,
+    };
+
+    unsafe extern "C" fn trace(this: *mut c_void, trc: *mut JSTracer) {
+        let this = this as *const Self;
+        let this = this.as_ref().unwrap();
+        Self::do_trace(this, trc);
+    }
+
+    /// Used by `CustomAutoTraceable` implementer to trace its contents.
+    /// Corresponds to virtual `trace` call in a `CustomAutoRooter` subclass (C++).
+    fn do_trace(&self, trc: *mut JSTracer);
+}
+
+unsafe impl<T: CustomTrace> CustomAutoTraceable for CustomAutoRooter<T> {
+    fn do_trace(&self, trc: *mut JSTracer) {
+        self.data.trace(trc);
+    }
+}
+
+impl<T: CustomTrace> CustomAutoRooter<T> {
+    pub fn new(data: T) -> Self {
+        let vftable = &Self::vftable;
+        CustomAutoRooter {
+            _base: jsapi::CustomAutoRooter {
+                vtable_: vftable as *const _ as *const _,
+                _base: AutoGCRooter::new_unrooted(AutoGCRooterKind::Custom),
+            },
+            data,
+        }
+    }
+
+    pub fn root(&mut self, cx: *mut JSContext) -> CustomAutoRooterGuard<T> {
+        CustomAutoRooterGuard::new(cx, self)
+    }
+}
+
+/// An RAII guard used to root underlying data in `CustomAutoRooter` until the
+/// guard is dropped (falls out of scope).
+/// The underlying data can be accessed through this guard via its Deref and
+/// DerefMut implementations.
+/// This structure is created by `root` method on `CustomAutoRooter` or
+/// by the `auto_root!` macro.
+pub struct CustomAutoRooterGuard<'a, T: 'a + CustomTrace> {
+    rooter: &'a mut CustomAutoRooter<T>,
+}
+
+impl<'a, T: 'a + CustomTrace> CustomAutoRooterGuard<'a, T> {
+    pub fn new(cx: *mut JSContext, rooter: &'a mut CustomAutoRooter<T>) -> Self {
+        unsafe {
+            rooter.add_to_root_stack(cx);
+        }
+        CustomAutoRooterGuard { rooter }
+    }
+
+    pub fn handle(&'a self) -> Handle<'a, T>
+    where
+        T: RootKind,
+    {
+        Handle::new(&self.rooter.data)
+    }
+
+    pub fn handle_mut(&mut self) -> MutableHandle<T>
+    where
+        T: RootKind,
+    {
+        unsafe { MutableHandle::from_marked_location(&mut self.rooter.data) }
+    }
+}
+
+impl<'a, T: 'a + CustomTrace> Deref for CustomAutoRooterGuard<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.rooter.data
+    }
+}
+
+impl<'a, T: 'a + CustomTrace> DerefMut for CustomAutoRooterGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.rooter.data
+    }
+}
+
+impl<'a, T: 'a + CustomTrace> Drop for CustomAutoRooterGuard<'a, T> {
+    fn drop(&mut self) {
+        unsafe {
+            self.rooter.remove_from_root_stack();
+        }
+    }
+}
+
+pub type SequenceRooter<T> = CustomAutoRooter<Vec<T>>;
+pub type SequenceRooterGuard<'a, T> = CustomAutoRooterGuard<'a, Vec<T>>;
+
+#[macro_export]
+macro_rules! auto_root {
+    (in($cx:expr) let $name:ident = $init:expr) => {
+        let mut __root = $crate::rust::CustomAutoRooter::new($init);
+        let $name = __root.root($cx);
+    };
+    (in($cx:expr) let mut $name:ident = $init:expr) => {
+        let mut __root = $crate::rust::CustomAutoRooter::new($init);
+        let mut $name = __root.root($cx);
+    };
+}

--- a/rust-mozjs/src/gc/custom.rs
+++ b/rust-mozjs/src/gc/custom.rs
@@ -10,7 +10,7 @@ use rust::{Handle, MutableHandle};
 use mozjs_sys::c_str;
 use jsapi::glue::{CallObjectRootTracer, CallValueRootTracer};
 
-/// Similarly to `Trace` trait, it's used to specify tracing of various types
+/// Similarly to `Traceable` trait, it's used to specify tracing of various types
 /// that are used in conjunction with `CustomAutoRooter`.
 pub unsafe trait CustomTrace {
     fn trace(&self, trc: *mut JSTracer);

--- a/rust-mozjs/src/gc/mod.rs
+++ b/rust-mozjs/src/gc/mod.rs
@@ -1,0 +1,2 @@
+pub mod custom;
+pub mod root;

--- a/rust-mozjs/src/gc/mod.rs
+++ b/rust-mozjs/src/gc/mod.rs
@@ -1,2 +1,5 @@
+pub use gc::custom::*;
+pub use gc::root::*;
+
 pub mod custom;
 pub mod root;

--- a/rust-mozjs/src/gc/root.rs
+++ b/rust-mozjs/src/gc/root.rs
@@ -1,0 +1,245 @@
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
+use std::ptr;
+
+use jsapi::{jsid, JSContext, JSFunction, JSObject, JSScript, JSString, Symbol, Value};
+use mozjs_sys::jsgc::{GCMethods, RootKind, Rooted};
+
+use jsapi::Handle as RawHandle;
+use jsapi::HandleValue as RawHandleValue;
+use jsapi::MutableHandle as RawMutableHandle;
+use mozjs_sys::jsgc::IntoHandle as IntoRawHandle;
+use mozjs_sys::jsgc::IntoMutableHandle as IntoRawMutableHandle;
+
+/// Rust API for keeping a Rooted value in the context's root stack.
+/// Example usage: `rooted!(in(cx) let x = UndefinedValue());`.
+/// `RootedGuard::new` also works, but the macro is preferred.
+pub struct RootedGuard<'a, T: 'a + RootKind + GCMethods> {
+    root: &'a mut Rooted<T>,
+}
+
+impl<'a, T: 'a + RootKind + GCMethods> RootedGuard<'a, T> {
+    pub fn new(cx: *mut JSContext, root: &'a mut Rooted<T>, initial: T) -> Self {
+        root.ptr = initial;
+        unsafe {
+            root.add_to_root_stack(cx);
+        }
+        RootedGuard { root }
+    }
+
+    pub fn handle(&'a self) -> Handle<'a, T> {
+        Handle::new(&self.root.ptr)
+    }
+
+    pub fn handle_mut(&mut self) -> MutableHandle<T> {
+        unsafe { MutableHandle::from_marked_location(&mut self.root.ptr) }
+    }
+
+    pub fn get(&self) -> T
+    where
+        T: Copy,
+    {
+        self.root.ptr
+    }
+
+    pub fn set(&mut self, v: T) {
+        self.root.ptr = v;
+    }
+}
+
+impl<'a, T: 'a + RootKind + GCMethods> Deref for RootedGuard<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.root.ptr
+    }
+}
+
+impl<'a, T: 'a + RootKind + GCMethods> DerefMut for RootedGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.root.ptr
+    }
+}
+
+impl<'a, T: 'a + RootKind + GCMethods> Drop for RootedGuard<'a, T> {
+    fn drop(&mut self) {
+        unsafe {
+            self.root.ptr = T::initial();
+            self.root.remove_from_root_stack();
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! rooted {
+    (in($cx:expr) let $name:ident = $init:expr) => {
+        let mut __root = $crate::jsapi::Rooted::new_unrooted();
+        let $name = $crate::rust::RootedGuard::new($cx, &mut __root, $init);
+    };
+    (in($cx:expr) let mut $name:ident = $init:expr) => {
+        let mut __root = $crate::jsapi::Rooted::new_unrooted();
+        let mut $name = $crate::rust::RootedGuard::new($cx, &mut __root, $init);
+    };
+    (in($cx:expr) let $name:ident: $type:ty) => {
+        let mut __root = $crate::jsapi::Rooted::new_unrooted();
+        let $name = $crate::rust::RootedGuard::new(
+            $cx,
+            &mut __root,
+            <$type as $crate::rust::GCMethods>::initial(),
+        );
+    };
+    (in($cx:expr) let mut $name:ident: $type:ty) => {
+        let mut __root = $crate::jsapi::Rooted::new_unrooted();
+        let mut $name = $crate::rust::RootedGuard::new(
+            $cx,
+            &mut __root,
+            <$type as $crate::rust::GCMethods>::initial(),
+        );
+    };
+}
+
+#[derive(Clone, Copy)]
+pub struct Handle<'a, T: 'a> {
+    pub(crate) ptr: &'a T,
+}
+
+#[derive(Copy, Clone)]
+pub struct MutableHandle<'a, T: 'a> {
+    pub(crate) ptr: *mut T,
+    anchor: PhantomData<&'a mut T>,
+}
+
+pub type HandleFunction<'a> = Handle<'a, *mut JSFunction>;
+pub type HandleId<'a> = Handle<'a, jsid>;
+pub type HandleObject<'a> = Handle<'a, *mut JSObject>;
+pub type HandleScript<'a> = Handle<'a, *mut JSScript>;
+pub type HandleString<'a> = Handle<'a, *mut JSString>;
+pub type HandleSymbol<'a> = Handle<'a, *mut Symbol>;
+pub type HandleValue<'a> = Handle<'a, Value>;
+
+pub type MutableHandleFunction<'a> = MutableHandle<'a, *mut JSFunction>;
+pub type MutableHandleId<'a> = MutableHandle<'a, jsid>;
+pub type MutableHandleObject<'a> = MutableHandle<'a, *mut JSObject>;
+pub type MutableHandleScript<'a> = MutableHandle<'a, *mut JSScript>;
+pub type MutableHandleString<'a> = MutableHandle<'a, *mut JSString>;
+pub type MutableHandleSymbol<'a> = MutableHandle<'a, *mut Symbol>;
+pub type MutableHandleValue<'a> = MutableHandle<'a, Value>;
+
+impl<'a, T> Handle<'a, T> {
+    pub fn get(&self) -> T
+    where
+        T: Copy,
+    {
+        *self.ptr
+    }
+
+    pub(crate) fn new(ptr: &'a T) -> Self {
+        Handle { ptr }
+    }
+
+    pub unsafe fn from_marked_location(ptr: *const T) -> Self {
+        Handle::new(&*ptr)
+    }
+
+    pub unsafe fn from_raw(handle: RawHandle<T>) -> Self {
+        Handle::from_marked_location(handle.ptr)
+    }
+}
+
+impl<'a, T> IntoRawHandle for Handle<'a, T> {
+    type Target = T;
+    fn into_handle(self) -> RawHandle<T> {
+        unsafe { RawHandle::from_marked_location(self.ptr) }
+    }
+}
+
+impl<'a, T> IntoRawHandle for MutableHandle<'a, T> {
+    type Target = T;
+    fn into_handle(self) -> RawHandle<T> {
+        unsafe { RawHandle::from_marked_location(self.ptr) }
+    }
+}
+
+impl<'a, T> IntoRawMutableHandle for MutableHandle<'a, T> {
+    fn into_handle_mut(self) -> RawMutableHandle<T> {
+        unsafe { RawMutableHandle::from_marked_location(self.ptr) }
+    }
+}
+
+impl<'a, T> Deref for Handle<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        self.ptr
+    }
+}
+
+impl<'a, T> MutableHandle<'a, T> {
+    pub unsafe fn from_marked_location(ptr: *mut T) -> Self {
+        MutableHandle::new(&mut *ptr)
+    }
+
+    pub unsafe fn from_raw(handle: RawMutableHandle<T>) -> Self {
+        MutableHandle::from_marked_location(handle.ptr)
+    }
+
+    pub fn handle(&self) -> Handle<T> {
+        unsafe { Handle::new(&*self.ptr) }
+    }
+
+    pub fn new(ptr: &'a mut T) -> Self {
+        Self {
+            ptr,
+            anchor: PhantomData,
+        }
+    }
+
+    pub fn get(&self) -> T
+    where
+        T: Copy,
+    {
+        unsafe { *self.ptr }
+    }
+
+    pub fn set(&mut self, v: T)
+    where
+        T: Copy,
+    {
+        unsafe { *self.ptr = v }
+    }
+
+    pub(crate) fn raw(&mut self) -> RawMutableHandle<T> {
+        unsafe { RawMutableHandle::from_marked_location(self.ptr) }
+    }
+}
+
+impl<'a, T> Deref for MutableHandle<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        unsafe { &*self.ptr }
+    }
+}
+
+impl<'a, T> DerefMut for MutableHandle<'a, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        unsafe { &mut *self.ptr }
+    }
+}
+
+impl HandleValue<'static> {
+    pub fn null() -> Self {
+        unsafe { Self::from_raw(RawHandleValue::null()) }
+    }
+
+    pub fn undefined() -> Self {
+        unsafe { Self::from_raw(RawHandleValue::undefined()) }
+    }
+}
+
+const ConstNullValue: *mut JSObject = ptr::null_mut();
+
+impl<'a> HandleObject<'a> {
+    pub fn null() -> Self {
+        unsafe { HandleObject::from_marked_location(&ConstNullValue) }
+    }
+}

--- a/rust-mozjs/src/glue.rs
+++ b/rust-mozjs/src/glue.rs
@@ -460,35 +460,6 @@ extern "C" {
     pub fn InitializeMemoryReporter(
         want_to_measure: Option<unsafe extern "C" fn(obj: *mut JSObject) -> bool>,
     );
-    pub fn CallIdTracer(trc: *mut JSTracer, idp: *mut Heap<jsid>, name: *const c_char);
-    pub fn CallValueTracer(trc: *mut JSTracer, valuep: *mut Heap<Value>, name: *const c_char);
-    pub fn CallObjectTracer(
-        trc: *mut JSTracer,
-        objp: *mut Heap<*mut JSObject>,
-        name: *const c_char,
-    );
-    pub fn CallStringTracer(
-        trc: *mut JSTracer,
-        strp: *mut Heap<*mut JSString>,
-        name: *const c_char,
-    );
-    pub fn CallScriptTracer(
-        trc: *mut JSTracer,
-        scriptp: *mut Heap<*mut JSScript>,
-        name: *const c_char,
-    );
-    pub fn CallFunctionTracer(
-        trc: *mut JSTracer,
-        funp: *mut Heap<*mut JSFunction>,
-        name: *const c_char,
-    );
-    pub fn CallUnbarrieredObjectTracer(
-        trc: *mut JSTracer,
-        objp: *mut *mut JSObject,
-        name: *const c_char,
-    );
-    pub fn CallObjectRootTracer(trc: *mut JSTracer, objp: *mut *mut JSObject, name: *const c_char);
-    pub fn CallValueRootTracer(trc: *mut JSTracer, valp: *mut Value, name: *const c_char);
     pub fn GetProxyHandlerFamily() -> *const c_void;
 
     pub fn GetInt8ArrayLengthAndData(

--- a/rust-mozjs/src/jsglue.cpp
+++ b/rust-mozjs/src/jsglue.cpp
@@ -869,48 +869,6 @@ bool CollectServoSizes(JSContext* cx, JS::ServoSizes* sizes, GetSize gs) {
 
 void InitializeMemoryReporter(WantToMeasure wtm) { gWantToMeasure = wtm; }
 
-void CallValueTracer(JSTracer* trc, JS::Heap<JS::Value>* valuep,
-                     const char* name) {
-  JS::TraceEdge(trc, valuep, name);
-}
-
-void CallIdTracer(JSTracer* trc, JS::Heap<jsid>* idp, const char* name) {
-  JS::TraceEdge(trc, idp, name);
-}
-
-void CallObjectTracer(JSTracer* trc, JS::Heap<JSObject*>* objp,
-                      const char* name) {
-  JS::TraceEdge(trc, objp, name);
-}
-
-void CallStringTracer(JSTracer* trc, JS::Heap<JSString*>* strp,
-                      const char* name) {
-  JS::TraceEdge(trc, strp, name);
-}
-
-void CallScriptTracer(JSTracer* trc, JS::Heap<JSScript*>* scriptp,
-                      const char* name) {
-  JS::TraceEdge(trc, scriptp, name);
-}
-
-void CallFunctionTracer(JSTracer* trc, JS::Heap<JSFunction*>* funp,
-                        const char* name) {
-  JS::TraceEdge(trc, funp, name);
-}
-
-void CallUnbarrieredObjectTracer(JSTracer* trc, JSObject** objp,
-                                 const char* name) {
-  js::UnsafeTraceManuallyBarrieredEdge(trc, objp, name);
-}
-
-void CallObjectRootTracer(JSTracer* trc, JSObject** objp, const char* name) {
-  JS::TraceRoot(trc, objp, name);
-}
-
-void CallValueRootTracer(JSTracer* trc, JS::Value* valp, const char* name) {
-  JS::TraceRoot(trc, valp, name);
-}
-
 bool IsDebugBuild() {
 #ifdef JS_DEBUG
   return true;

--- a/rust-mozjs/src/lib.rs
+++ b/rust-mozjs/src/lib.rs
@@ -54,6 +54,7 @@ pub mod rust;
 mod consts;
 pub mod conversions;
 pub mod error;
+pub mod gc;
 pub mod glue;
 pub mod panic;
 pub mod typedarray;

--- a/rust-mozjs/src/rust.rs
+++ b/rust-mozjs/src/rust.rs
@@ -22,8 +22,7 @@ use consts::{JSCLASS_GLOBAL_SLOT_COUNT, JSCLASS_RESERVED_SLOTS_MASK};
 use consts::{JSCLASS_IS_DOMJSCLASS, JSCLASS_IS_GLOBAL};
 use conversions::jsstr_to_string;
 use default_heapsize;
-pub use gc::custom::*;
-pub use gc::root::*;
+pub use gc::*;
 use glue::{CreateRootedIdVector, CreateRootedObjectVector};
 use glue::{
 	DeleteCompileOptions, DeleteRootedObjectVector, DescribeScriptedCaller, DestroyRootedIdVector,


### PR DESCRIPTION
Fixes #346
Moved `mozjs::rust::Trace` to `mozjs_sys::jsgc::Traceable`, and added more implementations for smart pointers, wrappers, and collections.
Added `mozjs_sys::jsgc::RootedTraceableSet`.
Reorganised GC-related code in `mozjs`.


I'm not sure how to implement `RootedVec` properly or how this would actually be used, but here's a starting point.
I'm also not too sure about the file structure change, but I think it's fine.