### PR TITLE
Add API to (maybe) wrap a DOM object.

### DIFF
--- a/rust-mozjs/src/rust.rs
+++ b/rust-mozjs/src/rust.rs
@@ -44,7 +44,7 @@ use jsapi::{AutoGCRooter, AutoGCRooterKind};
 use jsapi::{BuildStackString, CaptureCurrentStack, StackFormat};
 use jsapi::{Evaluate2, HandleValueArray, Heap, StencilRelease};
 use jsapi::{InitSelfHostedCode, InstantiationStorage, IsWindowSlow, OffThreadToken};
-use jsapi::{JSAutoRealm, JS_SetGCParameter, JS_SetNativeStackQuota, JS_WrapValue};
+use jsapi::{JSAutoRealm, JS_SetGCParameter, JS_SetNativeStackQuota, JS_WrapValue, JS_WrapObject};
 use jsapi::{JSClass, JSClassOps, JSContext, Realm, JSCLASS_RESERVED_SLOTS_SHIFT};
 use jsapi::{JSErrorReport, JSFunction, JSFunctionSpec, JSGCParamKey};
 use jsapi::{JSObject, JSPropertySpec, JSRuntime, JSScript};
@@ -1301,6 +1301,23 @@ pub unsafe fn try_to_outerize(mut rval: MutableHandleValue) {
         assert!(!obj.is_null());
         rval.set(ObjectValue(&mut *obj));
     }
+}
+
+#[inline]
+pub unsafe fn try_to_outerize_object(mut rval: MutableHandleObject) {
+    if is_window(*rval) {
+        let obj = ToWindowProxyIfWindowSlow(*rval);
+        assert!(!obj.is_null());
+        rval.set(obj);
+    }
+}
+
+#[inline]
+pub unsafe fn maybe_wrap_object(cx: *mut JSContext, obj: MutableHandleObject) {
+    if get_object_realm(*obj) != get_context_realm(cx) {
+        assert!(JS_WrapObject(cx, obj.into()));
+    }
+    try_to_outerize_object(obj);
 }
 
 #[inline]


### PR DESCRIPTION
This will be needed to port https://searchfox.org/mozilla-central/rev/2d678a843ceab81e43f7ffb83212197dc10e944a/dom/bindings/BindingUtils.cpp#3667 to Servo in https://github.com/servo/servo/issues/29770.