### PR TITLE
Fix rustbindgen tags in documentation

### DIFF
--- a/mozjs/src/jsglue.hpp
+++ b/mozjs/src/jsglue.hpp
@@ -176,7 +176,7 @@ class JSJitMethodCallArgsReplacement {
 #endif
 };
 
-/// <div rustbindgen replaces="JS::MutableHandleIdVector" />
+/// <div rustbindgen replaces="JS::MutableHandleIdVector"></div>
 struct MutableHandleIdVector_Simple {
   void* ptr;
 };
@@ -184,12 +184,12 @@ static_assert(sizeof(JS::MutableHandleIdVector) ==
                   sizeof(MutableHandleIdVector_Simple),
               "wrong handle size");
 
-/// <div rustbindgen replaces="JS::HandleObjectVector" />
+/// <div rustbindgen replaces="JS::HandleObjectVector"></div>
 struct HandleObjectVector_Simple {
   void* ptr;
 };
 
-/// <div rustbindgen replaces="JS::MutableHandleObjectVector" />
+/// <div rustbindgen replaces="JS::MutableHandleObjectVector"></div>
 struct MutableHandleObjectVector_Simple {
   void* ptr;
 };


### PR DESCRIPTION
Trailing solidus in non-void tags is [not valid HTML5](https://html.spec.whatwg.org/multipage/parsing.html#parse-error-non-void-html-element-start-tag-with-trailing-solidus) and is specified to be treated as a start tag. This breaks the layout of the [generated Rust docs](https://doc.servo.org/mozjs/jsapi/index.html) and makes them very hard to read and use.

Replacing these with standard `div` tags fixes layout:
![image](https://github.com/servo/mozjs/assets/20660/6bd69a9d-e8d1-448b-a1a3-f9de52c6d649)
