### PR TITLE
Do not run the main workflow for non-master pushes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,6 +2,7 @@ name: Rust
 
 on: 
   push:
+    branches: [master]
   pull_request:
   merge_group:
     types: [checks_requested]
@@ -17,7 +18,6 @@ env:
 
 jobs:
   mac:
-    if: ${{ github.event_name != 'push' || github.ref_name == 'master' || github.repository != 'servo/mozjs' }}
     runs-on: macos-latest
     strategy:
       fail-fast: false
@@ -38,7 +38,6 @@ jobs:
         cargo build --verbose ${{ matrix.features }}
         cargo test --verbose ${{ matrix.features }}
   linux:
-    if: ${{ github.event_name != 'push' || github.ref_name == 'master' || github.repository != 'servo/mozjs' }}
     env:
       RUSTC_WRAPPER: "sccache"
     runs-on: ubuntu-latest
@@ -61,7 +60,6 @@ jobs:
         cargo build --verbose ${{ matrix.features }}
         cargo test --verbose ${{ matrix.features }}
   windows:
-    if: ${{ github.event_name != 'push' || github.ref_name == 'master' || github.repository != 'servo/mozjs' }}
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -131,7 +129,7 @@ jobs:
     name: Result
     runs-on: ubuntu-latest
     needs: ["mac", "linux", "windows"]
-    if: ${{ always() && github.event_name == 'pull_request' }}
+    if: ${{ always() }}
     steps:
       - name: Mark the job as successful
         if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}


### PR DESCRIPTION
This is essentially a revert of #369. It seems that skipping this
workflow for merge queue branches is causing PRs to merge without any
testing. See

https://github.com/servo/mozjs/actions/runs/5893101692

It's simply too finicky to maintain an upstream and downstream mode in
the same workflow when using the merge queue unfortunately.
