### PR TITLE
use windows-2019 until build with windows-2022 is fixed

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,7 +62,7 @@ jobs:
         cargo build --verbose ${{ matrix.features }}
         cargo test --verbose ${{ matrix.features }}
   windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       fail-fast: false
       matrix:
@@ -88,7 +88,6 @@ jobs:
       run: |
         Start-BitsTransfer -Source https://ftp.mozilla.org/pub/mozilla/libraries/win32/MozillaBuildSetup-3.4.exe -Destination ./MozillaBuildSetup.exe
         .\MozillaBuildSetup.exe /S | Out-Null
-        echo 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Tools\LLVM\bin' | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.3
       with:


### PR DESCRIPTION
Windows builds are failing recently, potentially caused by the windows-2022 images being [updated to use LLVM 16](https://github.com/servo/mozjs/pull/368#issuecomment-1700838483). 

I haven't analyzed the failures in detail yet. To unblock open PRs, this change makes CI use windows-2019 which is still on LLVM 15. I have validated that the builds pass on my [fork](https://github.com/mukilan/mozjs/actions/runs/6072763112).