### PR TITLE
Fix aarch64-linux-gnu cross compilation

### DIFF
--- a/mozjs/makefile.cargo
+++ b/mozjs/makefile.cargo
@@ -55,12 +55,9 @@ ifneq ($(HOST),$(TARGET))
 	endif
 
 	ifeq (aarch64-unknown-linux-gnu,$(TARGET))
-	    # Reset TARGET variable because aarch64 target name used by Rust is not 
+	        # Reset TARGET variable because aarch64 target name used by Rust is not 
 		# the same as the target name needed for the CXX toolchain.
 		TARGET = aarch64-linux-gnu
-		CONFIGURE_FLAGS += \
-			--with-arch=armv8-a \
-			$(NULL)
 	endif
 
 	ifeq (android,$(findstring android,$(TARGET)))

--- a/rust-mozjs/build.rs
+++ b/rust-mozjs/build.rs
@@ -80,6 +80,10 @@ fn main() {
         .allowlist_file("./src/jsglue.cpp")
         .allowlist_recursively(false);
 
+    if let Ok(bindgen_flags) = env::var("CLANGFLAGS") {
+        builder = builder.clang_args(bindgen_flags.split(' '));
+    }
+
     if msvc {
         builder = builder.clang_args([
             &format!("-FI{}", confdefs_path.to_string_lossy()),


### PR DESCRIPTION
While trying to cross-compile Servo to run on a Pinephone, I faced this error building `mozjs` :

```
  --- stderr
  gmake: *** No targets specified and no makefile found.  Stop.
  Traceback (most recent call last):
    File "/home/fabrice/dev/mozjs/mozjs/mozjs/js/src/../../configure.py", line 350, in <module>
      sys.exit(main(sys.argv))
               ^^^^^^^^^^^^^^
    File "/home/fabrice/dev/mozjs/mozjs/mozjs/js/src/../../configure.py", line 132, in main
      sandbox.run(os.path.join(os.path.dirname(__file__), "moz.configure"))
    File "/home/fabrice/dev/mozjs/mozjs/mozjs/python/mozbuild/mozbuild/configure/__init__.py", line 516, in run
      self._value_for(option)
    File "/home/fabrice/dev/mozjs/mozjs/mozjs/python/mozbuild/mozbuild/configure/__init__.py", line 621, in _value_for
      return self._value_for_option(obj)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/home/fabrice/dev/mozjs/mozjs/mozjs/python/mozbuild/mozbuild/util.py", line 1061, in method_call
      cache[args] = self.func(instance, *args)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/home/fabrice/dev/mozjs/mozjs/mozjs/python/mozbuild/mozbuild/configure/__init__.py", line 688, in _value_for_option
      raise InvalidOptionError(
  mozbuild.configure.options.InvalidOptionError: --with-arch is not available in this configuration
  make: *** [/home/fabrice/dev/mozjs/mozjs/makefile.cargo:159: maybe-configure] Error 1
```

While I'm not exactly sure what this configuration issue is, I fixed the overall cross-compiling by telling spidermonkey to use `lld` as linker. I test with this shell script in a simple cargo library project that has `mozjs` as a dependency:

```shell
#!/bin/bash

SYSROOT=$HOME/.mozbuild/sysroot-aarch64-linux-gnu
TOOLCHAIN=$HOME/.mozbuild/clang/bin

export PKG_CONFIG_SYSROOT_DIR=$SYSROOT

export CC=$TOOLCHAIN/clang
export CXX=$TOOLCHAIN/clang++
export AR=$TOOLCHAIN/llvm-ar

INCLUDES="-I$SYSROOT/usr/include/aarch64-linux-gnu"

export CFLAGS="--sysroot=$SYSROOT $INCLUDES"
export CXXFLAGS="--sysroot=$SYSROOT $INCLUDES"

cargo build --target aarch64-unknown-linux-gnu
```
