### PR TITLE
Revert to windows 2022 image for CI runner

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,7 +57,7 @@ jobs:
           cargo build --verbose ${{ matrix.features }}
           cargo test --verbose ${{ matrix.features }}
   windows:
-    runs-on: windows-2019
+    runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Github has [deployed](https://github.com/actions/runner-images/issues/8125) the updated window-2022 image which includes LLVM 16.

Tested on my [fork](https://github.com/mukilan/mozjs/actions/runs/6146325253/job/16675474360)