### PR TITLE
Add cross testing for linux arm64 & armhf

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -110,8 +110,8 @@ jobs:
         run: |
           ./android-build cargo build --target="armv7-linux-androideabi"
 
-  cross:
-    name: Cross ${{ matrix.target }}
+  linux-cross-compile:
+    name: linux (${{ matrix.target }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -153,7 +153,7 @@ jobs:
   build_result:
     name: Result
     runs-on: ubuntu-latest
-    needs: ["mac", "linux", "windows", "android", "cross"]
+    needs: ["android", "linux", "linux-cross-compile", "mac", "windows"]
     if: ${{ always() }}
     steps:
       - name: Mark the job as successful

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -110,6 +110,27 @@ jobs:
         run: |
           ./android-build cargo build --target="armv7-linux-androideabi"
 
+  cross:
+    name: Cross ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - aarch64-unknown-linux-gnu
+          - armv7-unknown-linux-gnueabihf
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - name: Install cross
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: cross
+      - run: cross test --target ${{ matrix.target }}
+
   # The integrity check is currently broken. See issue #345.
   #
   # Integrity:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -156,7 +156,7 @@ jobs:
   build_result:
     name: Result
     runs-on: ubuntu-latest
-    needs: ["mac", "linux", "windows", "android"]
+    needs: ["mac", "linux", "windows", "android", "cross"]
     if: ${{ always() }}
     steps:
       - name: Mark the job as successful

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -119,17 +119,14 @@ jobs:
         target:
           - aarch64-unknown-linux-gnu
           - armv7-unknown-linux-gnueabihf
+    container: ghcr.io/sagudev/cross-${{ matrix.target }}:docker-images
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-      - name: Install cross
-        uses: baptiste0928/cargo-install@v2
-        with:
-          crate: cross
-      - run: cross test --target ${{ matrix.target }}
+      - run: cargo test --target ${{ matrix.target }}
 
   # The integrity check is currently broken. See issue #345.
   #

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -119,7 +119,7 @@ jobs:
         target:
           - aarch64-unknown-linux-gnu
           - armv7-unknown-linux-gnueabihf
-    container: ghcr.io/sagudev/cross-${{ matrix.target }}:docker-images
+    container: ghcr.io/servo/cross-${{ matrix.target }}:main
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,5 +1,5 @@
 [target.aarch64-unknown-linux-gnu]
-image = "ghcr.io/sagudev/cross-aarch64-unknown-linux-gnu:docker-images"
+image = "ghcr.io/servo/cross-aarch64-unknown-linux-gnu:main"
 
 [target.armv7-unknown-linux-gnueabihf]
-image = "ghcr.io/sagudev/cross-armv7-unknown-linux-gnueabihf:docker-images"
+image = "ghcr.io/servo/cross-armv7-unknown-linux-gnueabihf:main"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,27 +1,5 @@
 [target.aarch64-unknown-linux-gnu]
-image = "ghcr.io/sagudev/cross/aarch64-unknown-linux-gnu:23"
-# this is not part of cross dockerfile because we want minimal cross changes
-pre-build = [
-    "dpkg --add-architecture arm64",
-    "apt-get update && apt-get install --assume-yes --no-install-recommends python3 python3-distutils llvm llvm-dev lld libclang-dev clang dpkg-dev",
-]
-# use clang
-env.passthrough = [
-    "CC=clang -target aarch64-unknown-linux-gnu -isysroot=/usr/aarch64-linux-gnu --sysroot=/ -fuse-ld=lld",
-    "CXX=clang++ -target aarch64-unknown-linux-gnu -isysroot=/usr/aarch64-linux-gnu --sysroot=/ -fuse-ld=lld",
-    "BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_gnu=-isysroot=/usr/aarch64-linux-gnu --sysroot=/ -fuse-ld=lld",
-]
+image = "ghcr.io/sagudev/cross-aarch64-unknown-linux-gnu:docker-images"
 
 [target.armv7-unknown-linux-gnueabihf]
-image = "ghcr.io/sagudev/cross/armv7-unknown-linux-gnueabihf:23"
-# this is not part of cross dockerfile because we want minimal cross changes
-pre-build = [
-    "dpkg --add-architecture armhf",
-    "apt-get update && apt-get install --assume-yes --no-install-recommends python3 python3-distutils llvm llvm-dev lld libclang-dev clang dpkg-dev",
-]
-# use clang
-env.passthrough = [
-    "CC=clang -target armv7-unknown-linux-gnueabihf -isysroot=/usr/arm-linux-gnueabihf --sysroot=/ -fuse-ld=lld",
-    "CXX=clang++ -target armv7-unknown-linux-gnueabihf -isysroot=/usr/arm-linux-gnueabihf --sysroot=/ -fuse-ld=lld",
-    "BINDGEN_EXTRA_CLANG_ARGS_armv7_unknown_linux_gnueabihf=-isysroot=/usr/arm-linux-gnueabihf --sysroot=/ -fuse-ld=lld",
-]
+image = "ghcr.io/sagudev/cross-armv7-unknown-linux-gnueabihf:docker-images"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,27 @@
+[target.aarch64-unknown-linux-gnu]
+image = "ghcr.io/sagudev/cross/aarch64-unknown-linux-gnu:23"
+# this is not part of cross dockerfile because we want minimal cross changes
+pre-build = [
+    "dpkg --add-architecture arm64",
+    "apt-get update && apt-get install --assume-yes --no-install-recommends python3 python3-distutils llvm llvm-dev lld libclang-dev clang dpkg-dev",
+]
+# use clang
+env.passthrough = [
+    "CC=clang -target aarch64-unknown-linux-gnu -isysroot=/usr/aarch64-linux-gnu --sysroot=/ -fuse-ld=lld",
+    "CXX=clang++ -target aarch64-unknown-linux-gnu -isysroot=/usr/aarch64-linux-gnu --sysroot=/ -fuse-ld=lld",
+    "BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_gnu=-isysroot=/usr/aarch64-linux-gnu --sysroot=/ -fuse-ld=lld",
+]
+
+[target.armv7-unknown-linux-gnueabihf]
+image = "ghcr.io/sagudev/cross/armv7-unknown-linux-gnueabihf:23"
+# this is not part of cross dockerfile because we want minimal cross changes
+pre-build = [
+    "dpkg --add-architecture armhf",
+    "apt-get update && apt-get install --assume-yes --no-install-recommends python3 python3-distutils llvm llvm-dev lld libclang-dev clang dpkg-dev",
+]
+# use clang
+env.passthrough = [
+    "CC=clang -target armv7-unknown-linux-gnueabihf -isysroot=/usr/arm-linux-gnueabihf --sysroot=/ -fuse-ld=lld",
+    "CXX=clang++ -target armv7-unknown-linux-gnueabihf -isysroot=/usr/arm-linux-gnueabihf --sysroot=/ -fuse-ld=lld",
+    "BINDGEN_EXTRA_CLANG_ARGS_armv7_unknown_linux_gnueabihf=-isysroot=/usr/arm-linux-gnueabihf --sysroot=/ -fuse-ld=lld",
+]

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ are in the [rust-mozjs directory][r-m].
 
 ## Linux
 
-Install Clang and `build-essential`, for example on a Debian-based Linux:
+Install Python, Clang and `build-essential`, for example on a Debian-based Linux:
 
 ```sh
-sudo apt-get install clang build-essential
+sudo apt-get install build-essential python3 python3-distutils llvm libclang-dev clang
 ```
 
 If you have more than one version of Clang installed, you can set the `LIBCLANG_PATH`

--- a/mozjs/makefile.cargo
+++ b/mozjs/makefile.cargo
@@ -45,7 +45,7 @@ endif
 ifneq ($(HOST),$(TARGET))
 
 	ifeq (armv7-linux-androideabi,$(TARGET))
-		# Reset TARGET variable because armv7 target name used by Rust is not 
+		# Reset TARGET variable because armv7 target name used by Rust is not
 		# the same as the target name needed for the CXX toolchain.
 		TARGET = armv7a-linux-androideabi
 		CONFIGURE_FLAGS += \
@@ -54,13 +54,21 @@ ifneq ($(HOST),$(TARGET))
 			$(NULL)
 	endif
 
+	ifeq (armv7-unknown-linux-gnueabihf,$(TARGET))
+		# Reset TARGET variable because armv7 target name used by Rust is not
+		# the same as the target name needed for the CXX toolchain.
+		TARGET = arm-linux-gnueabihf
+		# fpu according to cross-rs
+		CONFIGURE_FLAGS += \
+			--with-arch=armv7-a \
+			--with-fpu=vfpv3-d16 \
+			$(NULL)
+	endif
+
 	ifeq (aarch64-unknown-linux-gnu,$(TARGET))
 	    # Reset TARGET variable because aarch64 target name used by Rust is not 
 		# the same as the target name needed for the CXX toolchain.
 		TARGET = aarch64-linux-gnu
-		CONFIGURE_FLAGS += \
-			--with-arch=armv8-a \
-			$(NULL)
 	endif
 
 	ifeq (android,$(findstring android,$(TARGET)))

--- a/mozjs/makefile.cargo
+++ b/mozjs/makefile.cargo
@@ -58,10 +58,8 @@ ifneq ($(HOST),$(TARGET))
 		# Reset TARGET variable because armv7 target name used by Rust is not
 		# the same as the target name needed for the CXX toolchain.
 		TARGET = arm-linux-gnueabihf
-		# fpu according to cross-rs
 		CONFIGURE_FLAGS += \
 			--with-arch=armv7-a \
-			--with-fpu=vfpv3-d16 \
 			$(NULL)
 	endif
 

--- a/mozjs/tests/evaluate.rs
+++ b/mozjs/tests/evaluate.rs
@@ -20,6 +20,7 @@ use mozjs_sys::jsapi::JSCLASS_GLOBAL_FLAGS;
 
 use std::mem;
 use std::ptr;
+use core::ffi::c_char;
 
 // The class operations for the global object.
 static GLOBAL_CLASS_OPS: JSClassOps = JSClassOps {
@@ -37,7 +38,7 @@ static GLOBAL_CLASS_OPS: JSClassOps = JSClassOps {
 
 // The class of the global object.
 static GLOBAL_CLASS: JSClass = JSClass {
-    name: "global\0" as *const str as *const i8,
+    name: "global\0" as *const str as *const c_char,
     flags: JSCLASS_GLOBAL_FLAGS,
     cOps: &GLOBAL_CLASS_OPS,
     spec: ptr::null(),


### PR DESCRIPTION
Partially resolves #401

This PR uses our [public docker images](https://github.com/orgs/servo/packages) for cross compiling. Minimal cross configuration is provided for easier usage of those docker images.