### PR TITLE
Update bindgen to 0.68

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [workspace.dependencies]
 cc = "1"
 libc = "0.2"
-bindgen = { version = "0.66", default-features = false, features = [
+bindgen = { version = "0.68", default-features = false, features = [
     "runtime",
     "which-rustfmt",
 ] }


### PR DESCRIPTION
In preparation to update servo/webxr to the same version and dedup bindgen in Servo