### PR TITLE
Hide js-streams behind feature

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -26,6 +26,7 @@ doctest = false
 debugmozjs = []
 profilemozjs = []
 jitspew = []
+streams = []
 
 [dependencies]
 encoding_c = "0.9.8"

--- a/mozjs-sys/makefile.cargo
+++ b/mozjs-sys/makefile.cargo
@@ -9,8 +9,11 @@ CONFIGURE_FLAGS := \
 	--disable-tests \
 	--disable-export-js \
 	--disable-shared-js \
-	--build-backends=RecursiveMake \
-	--enable-js-streams
+	--build-backends=RecursiveMake
+
+ifneq (,$(CARGO_FEATURE_STREAMS))
+    CONFIGURE_FLAGS += --enable-js-streams
+endif
 
 ifneq (,$(CARGO_FEATURE_JITSPEW))
     CONFIGURE_FLAGS += --enable-jitspew

--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -15,6 +15,7 @@ doctest = false
 debugmozjs = ['mozjs_sys/debugmozjs']
 jitspew = ['mozjs_sys/jitspew']
 profilemozjs = ['mozjs_sys/profilemozjs']
+streams = ['mozjs_sys/streams']
 
 [dependencies]
 lazy_static = "1"


### PR DESCRIPTION
This will make prototyping streams in servo easier.