### PR TITLE
Remove casting hoops (fixes compilation on rust 1.73)

### DIFF
--- a/mozjs-sys/src/jsimpls.rs
+++ b/mozjs-sys/src/jsimpls.rs
@@ -189,13 +189,7 @@ impl JS::AutoGCRooter {
 
     pub unsafe fn remove_from_root_stack(&mut self) {
         assert!(*self.stackTop == self);
-        // This hoop-jumping is needed because bindgen gives stackTop
-        // the type *const *mut AutoGCRooter, so we need to make it
-        // mutable before setting it.
-        // https://github.com/rust-lang-nursery/rust-bindgen/issues/511
-        #[allow(non_snake_case)]
-        let autoGCRooters = &*self.stackTop as *const _ as *mut _;
-        *autoGCRooters = self.down;
+        *self.stackTop = self.down;
     }
 }
 


### PR DESCRIPTION
This hoops are not needed anymore because `AutoGCRooter` is now properly handled by bindgen:
```rust
pub struct AutoGCRooter {
    pub down: *mut AutoGCRooter,
    pub stackTop: *mut *mut AutoGCRooter,
    pub kind_: AutoGCRooterKind,
}
```

and code is now more similar to upstream: https://searchfox.org/mozilla-central/source/js/public/RootingAPI.h#1082 and to JS::Rooted method:
https://github.com/servo/mozjs/blob/ec63ca39efb346c414e0f55ef26e63c0b17ee69a/mozjs-sys/src/jsimpls.rs#L418-L421