### PR TITLE
The options to the linker need to be separate elements in the list, n…

### DIFF
--- a/mozjs-sys/mozjs/build/moz.configure/toolchain.configure
+++ b/mozjs-sys/mozjs/build/moz.configure/toolchain.configure
@@ -1752,7 +1752,7 @@ def select_linker_tmpl(host_or_target):
             die("Unsupported linker " + linker)
 
         # Check the kind of linker
-        version_check = ["-Wl,--version"]
+        version_check = ["-Wl", "--version"]
         cmd_base = c_compiler.wrapper + [c_compiler.compiler] + c_compiler.flags
 
         def try_linker(linker):


### PR DESCRIPTION
The options to the linker were a single element in a list instead of two elements. This was breaking build on MacOS