### PR TITLE
[WIP]: Shared object

### DIFF
--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -271,11 +271,12 @@ fn build_jsapi(build_dir: &Path) {
 
 fn build_jsglue(build_dir: &Path) {
     let mut build = cc::Build::new();
+    // "-undefined" and "dynamic_lookup" to avoid compiler's complain about linking
     build.cpp(true)
          .shared_flag(true)
          .flag("-undefined")
          .flag("dynamic_lookup")
-         .flag_if_supported("-std=g++17");
+         .flag_if_supported("-std=g++17"); // this seems mac specific, we already have gnu++ in cc_flags(), yet it only seems to be working with g++
 
     for flag in cc_flags() {
         build.flag_if_supported(flag);
@@ -299,7 +300,7 @@ fn build_jsglue(build_dir: &Path) {
     //We had static libs in /glue, make sure we have shared object at the same path
     let glue_dir = build_dir.join("glue");
     std::fs::create_dir_all(&glue_dir).expect("Failed to create glue directory");
-    let file = glue_dir.join("jsglue.dylib");
+    let file = glue_dir.join(format!("{}.dylib", "jsglue"));
     let mut cmd = build.get_compiler().to_command();
     cmd.arg("src/jsglue.cpp")
        .arg("-o")

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -96,7 +96,7 @@ fn find_make() -> OsString {
 }
 
 fn cc_flags() -> Vec<&'static str> {
-    let mut result = vec!["-DRUST_BINDGEN", "-DSTATIC_JS_API"];
+    let mut result = vec!["-DRUST_BINDGEN", "-DJS_SHARED_LIBRARY"];
 
     if env::var_os("CARGO_FEATURE_DEBUGMOZJS").is_some() {
         result.extend(&["-DJS_GC_ZEAL", "-DDEBUG", "-DJS_DEBUG"]);
@@ -249,7 +249,7 @@ fn build_jsapi(build_dir: &Path) {
         "cargo:rustc-link-search=native={}/js/src/build",
         build_dir.display()
     );
-    println!("cargo:rustc-link-lib=static=js_static"); // Must come before c++
+    println!("cargo:rustc-link-lib=dylib=mozjs-115"); // Must come before c++
     if target.contains("windows") {
         println!(
             "cargo:rustc-link-search=native={}/dist/bin",
@@ -271,7 +271,11 @@ fn build_jsapi(build_dir: &Path) {
 
 fn build_jsglue(build_dir: &Path) {
     let mut build = cc::Build::new();
-    build.cpp(true);
+    build.cpp(true)
+         .shared_flag(true)
+         .flag("-undefined")
+         .flag("dynamic_lookup")
+         .flag_if_supported("-std=g++17");
 
     for flag in cc_flags() {
         build.flag_if_supported(flag);
@@ -279,19 +283,33 @@ fn build_jsglue(build_dir: &Path) {
 
     let config = format!("{}/js/src/js-confdefs.h", build_dir.display());
     if build.get_compiler().is_like_msvc() {
-        build.flag_if_supported("-std:c++17");
-        build.flag("-FI");
+        build
+            .flag_if_supported("-std:c++17")
+            .flag("-FI");
     } else {
-        build.flag("-std=c++17");
-        build.flag("-include");
+        build
+            .flag("-std=c++17")
+            .flag("-include");
     }
-    build
-        .flag(&config)
-        .file("src/jsglue.cpp")
-        .include(build_dir.join("dist/include"))
-        .include(build_dir.join("js/src"))
-        .out_dir(build_dir.join("glue"))
-        .compile("jsglue");
+
+    build.flag(&config)
+         .include(build_dir.join("dist/include"))
+         .include(build_dir.join("js/src"));
+
+    //We had static libs in /glue, make sure we have shared object at the same path
+    let glue_dir = build_dir.join("glue");
+    std::fs::create_dir_all(&glue_dir).expect("Failed to create glue directory");
+    let file = glue_dir.join("jsglue.dylib");
+    let mut cmd = build.get_compiler().to_command();
+    cmd.arg("src/jsglue.cpp")
+       .arg("-o")
+       .arg(&file);
+
+    println!("cargo:rustc-link-lib=dylib=jsglue");
+    println!("cargo:rustc-link-search=native={}", glue_dir.display());
+
+    let status = cmd.status().expect("Failed to link the dynamic library");
+    assert!(status.success(), "Linking failed");
 }
 
 /// Invoke bindgen on the JSAPI headers to produce raw FFI bindings for use from

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -300,7 +300,7 @@ fn build_jsglue(build_dir: &Path) {
     //We had static libs in /glue, make sure we have shared object at the same path
     let glue_dir = build_dir.join("glue");
     std::fs::create_dir_all(&glue_dir).expect("Failed to create glue directory");
-    let file = glue_dir.join(format!("{}.dylib", "jsglue"));
+    let file = glue_dir.join(format!("{}.dylib", "libjsglue"));
     let mut cmd = build.get_compiler().to_command();
     cmd.arg("src/jsglue.cpp")
        .arg("-o")

--- a/mozjs-sys/makefile.cargo
+++ b/mozjs-sys/makefile.cargo
@@ -7,8 +7,6 @@ CONFIGURE_FLAGS := \
 	--disable-jemalloc \
 	--disable-js-shell \
 	--disable-tests \
-	--disable-export-js \
-	--disable-shared-js \
 	--build-backends=RecursiveMake
 
 ifneq (,$(CARGO_FEATURE_STREAMS))

--- a/mozjs-sys/mozjs/config/rules.mk
+++ b/mozjs-sys/mozjs/config/rules.mk
@@ -279,7 +279,7 @@ endif
 ifeq ($(OS_ARCH),Darwin)
 ifneq (,$(SHARED_LIBRARY))
 _LOADER_PATH := @rpath
-EXTRA_DSO_LDOPTS	+= -undefined dynamic_lookup -dynamiclib -install_name $(_LOADER_PATH)/$@ -compatibility_version 1 -current_version 1
+EXTRA_DSO_LDOPTS += -undefined dynamic_lookup -dynamiclib -install_name $(_LOADER_PATH)/$@ -compatibility_version 1 -current_version 1
 endif
 endif
 

--- a/mozjs-sys/mozjs/config/rules.mk
+++ b/mozjs-sys/mozjs/config/rules.mk
@@ -279,7 +279,7 @@ endif
 ifeq ($(OS_ARCH),Darwin)
 ifneq (,$(SHARED_LIBRARY))
 _LOADER_PATH := @rpath
-EXTRA_DSO_LDOPTS	+= -dynamiclib -install_name $(_LOADER_PATH)/$@ -compatibility_version 1 -current_version 1
+EXTRA_DSO_LDOPTS	+= -undefined dynamic_lookup -dynamiclib -install_name $(_LOADER_PATH)/$@ -compatibility_version 1 -current_version 1
 endif
 endif
 

--- a/mozjs-sys/mozjs/js/src/build/moz.build
+++ b/mozjs-sys/mozjs/js/src/build/moz.build
@@ -41,6 +41,9 @@ else:
     Library("js")
     USE_LIBS += ["mozglue"]
 
+# We should remove this, we don't want both static and dynamic lib
+FORCE_STATIC_LIB = True
+STATIC_LIBRARY_NAME = "js_static"
 
 if CONFIG["JS_HAS_INTL_API"]:
     USE_LIBS += [
@@ -89,7 +92,18 @@ if CONFIG["MOZ_NEEDS_LIBATOMIC"]:
 
 OS_LIBS += CONFIG["REALTIME_LIBS"]
 
+NO_EXPAND_LIBS = True
+
 DIST_INSTALL = True
 
 # Run SpiderMonkey style checker after linking the static library. This avoids
 # running the script for no-op builds.
+GeneratedFile(
+    "spidermonkey_checks",
+    script="/config/run_spidermonkey_checks.py",
+    inputs=[
+        "!%sjs_static.%s" % (CONFIG["LIB_PREFIX"], CONFIG["LIB_SUFFIX"]),
+        "/config/check_macroassembler_style.py",
+        "/config/check_js_opcode.py",
+    ],
+)

--- a/mozjs-sys/mozjs/js/src/build/moz.build
+++ b/mozjs-sys/mozjs/js/src/build/moz.build
@@ -41,8 +41,6 @@ else:
     Library("js")
     USE_LIBS += ["mozglue"]
 
-FORCE_STATIC_LIB = True
-STATIC_LIBRARY_NAME = "js_static"
 
 if CONFIG["JS_HAS_INTL_API"]:
     USE_LIBS += [
@@ -91,18 +89,7 @@ if CONFIG["MOZ_NEEDS_LIBATOMIC"]:
 
 OS_LIBS += CONFIG["REALTIME_LIBS"]
 
-NO_EXPAND_LIBS = True
-
 DIST_INSTALL = True
 
 # Run SpiderMonkey style checker after linking the static library. This avoids
 # running the script for no-op builds.
-GeneratedFile(
-    "spidermonkey_checks",
-    script="/config/run_spidermonkey_checks.py",
-    inputs=[
-        "!%sjs_static.%s" % (CONFIG["LIB_PREFIX"], CONFIG["LIB_SUFFIX"]),
-        "/config/check_macroassembler_style.py",
-        "/config/check_js_opcode.py",
-    ],
-)

--- a/mozjs/build.rs
+++ b/mozjs/build.rs
@@ -70,7 +70,7 @@ fn main() {
     };
 
     let out_dir_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-    let file = out_dir_path.join(format!("{}.dylib", "jsglue"));
+    let file = out_dir_path.join(format!("{}.dylib", "libjsglue"));
     let mut cmd = build.get_compiler().to_command();
     cmd.arg("src/jsglue.cpp")
        .arg("-o")


### PR DESCRIPTION
Right now we have 3 static library in mozjs: `libmozjs.a`, `libjsglue.a` for mozjs/mozjs-sys glue code and `libjsglue.a` for mozjs/mozjs glue code. we are trying to have shared object instead. See [servo/30593](https://github.com/servo/servo/issues/30593)

TODO:
* [ ] shared object Spidermonkey `libmozjs-115.dylib` (`.so/.dll` for `linux/windows`)
* [ ] shared object glue code in mozjs-sys `libjsglue.dylib`
* [ ] shared object glue code in mozjs `libjsglue.dylib`