### PR TITLE
fix: macOS CI build errors

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install deps
-        run: brew install llvm yasm
+        run: |
+          # Unlink and re-link to prevent errors when github mac runner images
+          # https://github.com/actions/setup-python/issues/577
+          brew list -1 | grep python | while read formula; do brew unlink $formula; brew link --overwrite $formula; done
+          brew install llvm yasm
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3
       - name: Build

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -18,7 +18,7 @@ const ENV_VARS: &'static [&'static str] = &[
     "CFLAGS",
     "CLANGFLAGS",
     "CPP",
-        "CPPFLAGS",
+    "CPPFLAGS",
     "CXX",
     "CXXFLAGS",
     "MAKE",

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -18,7 +18,7 @@ const ENV_VARS: &'static [&'static str] = &[
     "CFLAGS",
     "CLANGFLAGS",
     "CPP",
-    "CPPFLAGS",
+        "CPPFLAGS",
     "CXX",
     "CXXFLAGS",
     "MAKE",


### PR DESCRIPTION
The error in #409 seems to be an issue between github action runner and homebrew.
There are lots of issue around it:
https://github.com/orgs/Homebrew/discussions/3895
https://github.com/actions/setup-python/issues/577
https://github.com/actions/runner-images/issues/6459
https://github.com/actions/runner-images/issues/6507
https://github.com/actions/runner-images/issues/2322
One of the workarounds is trying to relink the python package.