### PR TITLE
Use ANDROID_NDK_ROOT instead of ANDROID_NDK_HOME

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -120,7 +120,7 @@ jobs:
           targets: armv7-linux-androideabi
       - name: Build
         env:
-          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+          ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
         run: |
           ./android-build cargo build --target="armv7-linux-androideabi"
 

--- a/android-build
+++ b/android-build
@@ -69,16 +69,16 @@ def set_toolchain_binaries_in_env(toolchain_dir: str, env: Dict[str, str]):
 
 def create_environment_for_build() -> Dict[str, str]:
     env = os.environ.copy()
-    if "ANDROID_NDK_HOME" not in env:
-        raise Exception("Please set the ANDROID_NDK_HOME environment variable.")
+    if "ANDROID_NDK_ROOT" not in env:
+        raise Exception("Please set the ANDROID_NDK_ROOT environment variable.")
 
-    ndk_home_dir = env["ANDROID_NDK_HOME"]
+    ndk_home_dir = env["ANDROID_NDK_ROOT"]
 
     # Check if the NDK version is 21
     if not os.path.isfile(os.path.join(ndk_home_dir, 'source.properties')):
         raise Exception(
             "ANDROID_NDK should have file `source.properties`.\n" +
-            "The environment variable ANDROID_NDK_HOME may be set at a wrong path."
+            "The environment variable ANDROID_NDK_ROOT may be set at a wrong path."
         )
 
     with open(os.path.join(ndk_home_dir, 'source.properties'), encoding="utf8") as ndk_properties:

--- a/mozjs-sys/makefile.cargo
+++ b/mozjs-sys/makefile.cargo
@@ -78,7 +78,7 @@ ifneq ($(HOST),$(TARGET))
 		# non-developer builds, but NDK r25c ships with only lld.
 		CONFIGURE_FLAGS += \
 			--without-system-zlib \
-			--with-android-ndk=$(ANDROID_NDK_HOME) \
+			--with-android-ndk=$(ANDROID_NDK_ROOT) \
 			--with-android-version=$(ANDROID_API_LEVEL) \
 			--enable-linker=lld \
 			$(NULL)


### PR DESCRIPTION
ANDROID_NDK_ROOT seems to be the more common environment variable
nowadays.
