### PR TITLE
Derive `PartialEq` in `mozjs-sys` 

### DIFF
--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -316,6 +316,7 @@ fn build_jsapi_bindings(build_dir: &Path) {
         // investigate switching to the "constified module" strategy, which has
         // similar ergonomics but avoids some potential Rust UB footguns.
         .rustified_enum(".*")
+        .derive_partialeq(true)
         .size_t_is_usize(true)
         .enable_cxx_namespaces()
         .with_codegen_config(config)


### PR DESCRIPTION
There are [a few places in Servo](https://github.com/search?q=repo%3Aservo%2Fservo%20asbits_&type=code) where we need to check if two structs from mozjs-sys are equal, but since Bindgen doesn't automatically derive `PartialEq` by default, the code has to compare the inner `asBits_` field.

This PR tells Bindgen to automatically derive `PartialEq` where possible, to allow making such code simpler.