### PR TITLE
Bump mozjs_sys version to 0.115.7-0

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.68.2"
+version = "0.115.7-0"
 authors = ["Mozilla"]
 links = "mozjs"
 build = "build.rs"


### PR DESCRIPTION
In #454 we got the need to have versioned mozjs-sys (even if unpublished) for artifact purposes so I proposed the following versioning for mozjs-sys (modeled after what we used before we give up on versioning):
`0.{SM-major}.{SM-minor}-#` where # is sequential number that is incremented for every C/C++ change in same SM version.

So we would start with `0.115.7-0` (we currently use SM 115.7) then for every C* change increment last number (`0.115.7-1`) until we move on to new SM `0.115.9-0` that would again start with new number.

CC @jdm @mrobinson @wusyong 