### PR TITLE
Add `-ohos` target support to autoconf

### DIFF
--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -138,8 +138,9 @@ fn cc_flags() -> Vec<&'static str> {
 
     let is_apple = target.contains("apple");
     let is_freebsd = target.contains("freebsd");
+    let is_ohos = target.contains("ohos");
 
-    if is_apple || is_freebsd {
+    if is_apple || is_freebsd || is_ohos {
         result.push("-stdlib=libc++");
     }
 
@@ -244,7 +245,7 @@ fn build_spidermonkey(build_dir: &Path) {
         cmd.env("MAKEFLAGS", makeflags);
     }
 
-    if target.contains("apple") || target.contains("freebsd") {
+    if target.contains("apple") || target.contains("freebsd") || target.contains("ohos") {
         cmd.env("CXXFLAGS", "-stdlib=libc++");
     }
 
@@ -276,7 +277,7 @@ fn build_spidermonkey(build_dir: &Path) {
         if target.contains("gnu") {
             println!("cargo:rustc-link-lib=stdc++");
         }
-    } else if target.contains("apple") || target.contains("freebsd") {
+    } else if target.contains("apple") || target.contains("freebsd") || target.contains("ohos") {
         println!("cargo:rustc-link-lib=c++");
     } else {
         println!("cargo:rustc-link-lib=stdc++");
@@ -821,7 +822,7 @@ fn download_static_lib_binaries(archive: &Path, build_dir: &Path) {
         if target.contains("gnu") {
             println!("cargo:rustc-link-lib=stdc++");
         }
-    } else if target.contains("apple") || target.contains("freebsd") {
+    } else if target.contains("apple") || target.contains("freebsd") || target.contains("ohos") {
         println!("cargo:rustc-link-lib=c++");
     } else {
         println!("cargo:rustc-link-lib=stdc++");

--- a/mozjs-sys/etc/patches/0030-autoconf-add-ohos.patch
+++ b/mozjs-sys/etc/patches/0030-autoconf-add-ohos.patch
@@ -1,0 +1,21 @@
+diff --git a/build/autoconf/config.sub b/build/autoconf/config.sub
+--- a/build/autoconf/config.sub	(revision 20f7934762a6a1d4751353c8d024a0185ba85547)
++++ b/build/autoconf/config.sub	(revision 1d3dc1d7b53439ce8f799526ddbbe0f833b8ef0f)
+@@ -1754,7 +1754,7 @@
+ 	     | onefs* | tirtos* | phoenix* | fuchsia* | redox* | bme* \
+ 	     | midnightbsd* | amdhsa* | unleashed* | emscripten* | wasi* \
+ 	     | nsk* | powerunix* | genode* | zvmoe* | qnx* | emx* | zephyr* \
+-	     | fiwix* )
++	     | fiwix* | ohos* )
+ 		;;
+ 	# This one is extra strict with allowed versions
+ 	sco3.2v2 | sco3.2v[4-9]* | sco5v6*)
+@@ -1772,7 +1772,7 @@
+ # (given a valid OS), if there is a kernel.
+ case $kernel-$os in
+ 	linux-gnu* | linux-dietlibc* | linux-android* | linux-newlib* \
+-		   | linux-musl* | linux-relibc* | linux-uclibc* )
++		   | linux-musl* | linux-relibc* | linux-uclibc* | linux-ohos* )
+ 		;;
+ 	uclinux-uclibc* )
+ 		;;

--- a/mozjs-sys/mozjs/build/autoconf/config.sub
+++ b/mozjs-sys/mozjs/build/autoconf/config.sub
@@ -1754,7 +1754,7 @@ case $os in
 	     | onefs* | tirtos* | phoenix* | fuchsia* | redox* | bme* \
 	     | midnightbsd* | amdhsa* | unleashed* | emscripten* | wasi* \
 	     | nsk* | powerunix* | genode* | zvmoe* | qnx* | emx* | zephyr* \
-	     | fiwix* )
+	     | fiwix* | ohos* )
 		;;
 	# This one is extra strict with allowed versions
 	sco3.2v2 | sco3.2v[4-9]* | sco5v6*)
@@ -1772,7 +1772,7 @@ esac
 # (given a valid OS), if there is a kernel.
 case $kernel-$os in
 	linux-gnu* | linux-dietlibc* | linux-android* | linux-newlib* \
-		   | linux-musl* | linux-relibc* | linux-uclibc* )
+		   | linux-musl* | linux-relibc* | linux-uclibc* | linux-ohos* )
 		;;
 	uclinux-uclibc* )
 		;;


### PR DESCRIPTION
Adds support for OpenHarmony OS.
A patch has been submitted upstream, pending review: https://lists.gnu.org/archive/html/config-patches/2024-02/msg00008.html
After the patch has been merged upstream, we can update `config.sub` in spidermonkey and drop this patch.