### PR TITLE
Also respect readelf and objcopy cc-rs variants

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,7 +41,7 @@ jobs:
           brew list -1 | grep python | while read formula; do brew unlink $formula; brew link --overwrite $formula; done
           brew install llvm yasm
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.4
       - name: Build
         run: |
           cargo build --verbose --features ${{ matrix.features }}
@@ -70,7 +70,7 @@ jobs:
         run: |
           sudo apt install llvm -y
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.4
       - name: Build
         run: |
           cargo build --verbose --features ${{ matrix.features }}
@@ -112,7 +112,7 @@ jobs:
           curl -SL "https://github.com/servo/servo-build-deps/releases/download/msvc-deps/moztools-4.0.zip" --create-dirs -o target/dependencies/moztools.zip
           cd target/dependencies && unzip -qo moztools.zip -d .
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.4
       - name: Build Windows
         shell: cmd
         run: |

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -45,6 +45,8 @@ const SM_TARGET_ENV_VARS: &'static [&'static str] = &[
     "CPPFLAGS",
     "CXX",
     "CXXFLAGS",
+    "READELF",
+    "OBJCOPY",
 ];
 
 const EXTRA_FILES: &'static [&'static str] = &[


### PR DESCRIPTION
While compiling servo for OpenHarmony on a MacOS host, I noticed that readelf and objcopy apparently aren't chosen from the same directory as the clang c compiler, but needed to be in PATH for the configure script to pick them up. To allow users to set READELF and OBJCOPY explicitly, we should also read the relevant cc-rs environment variables.

An alternative would have been to inspect the configure scripts and find out why they don't look next to clang, but I'm not familiar enough with the configure script.