### PR TITLE
fix weird build error?

### DIFF
--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -675,7 +675,7 @@ mod jsglue {
             build.flag("-fno-rtti");
             build.flag("-std=c++17");
             build.flag("-include");
-            build.flag(&confdefs_path.to_string_lossy());
+            build.flag(&*confdefs_path.to_string_lossy());
             false
         };
 


### PR DESCRIPTION
Hey everyone!
Just tried to build mozjs locally and got a build error on the most recent main commit (369f2902e6481b8f237cca1652f56e61f508a0ad). Your CI seems to be building just fine though.

```
error[E0277]: the trait bound `Cow<'_, str>: AsRef<OsStr>` is not satisfied
--> mozjs-sys/build.rs:678:25
|
678 |             build.flag(&confdefs_path.to_string_lossy());
|                   ----  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsRef<OsStr>` is not implemented for `Cow<'_, str>`, which is required by `&Cow<'_, str>: AsRef<OsStr>`
|                   |
|                   required by a bound introduced by this call
|
= note: required for `&Cow<'_, str>` to implement `AsRef<OsStr>`
note: required by a bound in `Build::flag`
--> /home/erik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cc-1.0.104/src/lib.rs:513:39
|
513 |     pub fn flag(&mut self, flag: impl AsRef<OsStr>) -> &mut Build {
|                                       ^^^^^^^^^^^^ required by this bound in `Build::flag`
help: consider dereferencing here
|
678 |             build.flag(&*confdefs_path.to_string_lossy());
|                         +
```

Not sure what's going wrong, I compiled with `cargo +1.79.0 build --features streams`, just as you do in [CI](https://github.com/servo/mozjs/actions/runs/9533588366/job/26277013977):
![image](https://github.com/servo/mozjs/assets/26464515/30a08072-f5e4-4f17-9ad7-2294dc1e6c83)


Applying Rust's suggestion fixed the build for me.