### PR TITLE
Add DeleteWrapperProxyHandler

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.115.13-0"
+version = "0.115.13-1"
 authors = ["Mozilla"]
 links = "mozjs"
 build = "build.rs"

--- a/mozjs-sys/src/jsglue.cpp
+++ b/mozjs-sys/src/jsglue.cpp
@@ -624,6 +624,10 @@ const void* CreateWrapperProxyHandler(const ProxyTraps* aTraps) {
   return new WrapperProxyHandler(*aTraps);
 }
 
+void DeleteWrapperProxyHandler(const void* handler) {
+  delete static_cast<const WrapperProxyHandler*>(handler);
+}
+
 const void* GetCrossCompartmentWrapper() {
   return &js::CrossCompartmentWrapper::singleton;
 }


### PR DESCRIPTION
This function is needed to be able to release the memory allocated by CreateWrapperProxyHandler from Rust after use.

This came up while investigating memory leaks in servo (servo/servo#32223). With this function added, we managed to create a proof of concept to fix the leak.

CC @rhetenor