### PR TITLE
Guard against null pointer when dropping Stencil

### DIFF
--- a/mozjs/src/rust.rs
+++ b/mozjs/src/rust.rs
@@ -498,6 +498,9 @@ unsafe impl Sync for Stencil {}*/
 
 impl Drop for Stencil {
     fn drop(&mut self) {
+        if (self.is_null()) {
+            return;
+        }
         unsafe {
             StencilRelease(self.inner.mRawPtr);
         }


### PR DESCRIPTION
### Summary

Crash originally encountered in https://github.com/servo/servo/issues/32654

Before going into the `unsafe` block, make sure that we have a valid pointer
to hand to `StencilRelease()`. A null pointer previously resulted in a
segfault.

### Test plan

Tested using Servo:

1. Open news.baidu.com, which currently exposes this bug through a faulty
   JS script being loaded (it's HTML and not JS).
2. Observe the segfault.
3. Apply the above fix.
4. Repeat, observe no crash.