### PR TITLE
Mark mozjs-sys/mozjs as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 * text=auto eol=lf
 
-mozjs-sys/mozjs/** linguist-vendored
+mozjs-sys/mozjs/** linguist-generated=true


### PR DESCRIPTION
As they are not vendored but generated using update.py, so let's mark them as such. This should also hide files from github diff in PRs (but not local diffs), so it should be easier to review SM bumps. We have integrity check to prevent misuses.

https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github