### PR TITLE
Added Wrapper for NewArrayBufferWithContents

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.128.0-1"
+version = "0.128.0-2"
 authors = ["Mozilla"]
 links = "mozjs"
 build = "build.rs"

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -557,6 +557,8 @@ const BLACKLIST_FUNCTIONS: &'static [&'static str] = &[
     "JS::GetScriptTranscodingBuildId",
     "JS::GetScriptedCallerPrivate",
     "JS::MaybeGetScriptPrivate",
+    "JS::NewArrayBufferWithContents",
+    "JS::NewExternalArrayBuffer",
     "JS::dbg::FireOnGarbageCollectionHook",
     "JS_EncodeStringToUTF8BufferPartial",
     "JS_GetEmptyStringValue",

--- a/mozjs-sys/src/jsapi.cpp
+++ b/mozjs-sys/src/jsapi.cpp
@@ -107,6 +107,12 @@ JSObject* NewExternalArrayBuffer(
   return NewExternalArrayBuffer(cx, nbytes, std::move(dataPtr));
 }
 
+JSObject* NewArrayBufferWithContents(
+    JSContext* cx, size_t nbytes, void* contents) {
+    js::UniquePtr<void, JS::FreePolicy> dataPtr{contents};
+    return NewArrayBufferWithContents(cx, nbytes, contents);
+}
+
 // Reexport some methods
 
 bool JS_ForOfIteratorInit(


### PR DESCRIPTION
Removing the two wrapped array buffer functions from the bindings also shortens imports (`mozjs::jsapi::<function>` as compared to `mozjs::jsapi::glue::<function>`).