### PR TITLE
Fix esr128 windows artifact & MOZJS_ARCHIVE

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ this feature:
       path, extract it, and then link against the static libraries included in the archive.
    - `MOZJS_ARCHIVE=https://url/to/release/page`: This option will download the archive from
       the provided base URL, extract it, and then link against the static libraries included in the
-      archive. The base URL should  be similar to `https://github.com/servo/mozjs/releases/`.
+      archive. The base URL should  be similar to `https://github.com/servo/mozjs/releases`.
       The build script will append the version and target accordingly. See the files at the example
       URL for more details.
 

--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.128.0-0"
+version = "0.128.0-1"
 authors = ["Mozilla"]
 links = "mozjs"
 build = "build.rs"

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -823,13 +823,6 @@ fn compress_static_lib(build_dir: &Path) -> Result<(), std::io::Error> {
     let mut tar = tar::Builder::new(enc);
 
     if target.contains("windows") {
-        let status = Command::new("llvm-strip.exe")
-            .arg("--strip-debug")
-            .arg(build_dir.join("js/src/build/js_static.lib"))
-            .status()
-            .unwrap();
-        assert!(status.success());
-
         // This is the static library of spidermonkey.
         tar.append_file(
             "js/src/build/js_static.lib",

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -903,7 +903,7 @@ fn decompress_static_lib(archive: &Path, build_dir: &Path) -> Result<(), std::io
 /// Download the SpiderMonkey archive with cURL using the provided base URL. If it's None,
 /// it will use `servo/mozjs`'s release page as the base URL.
 fn download_archive(base: Option<&str>) -> Result<PathBuf, std::io::Error> {
-    let base = base.unwrap_or("https://github.com/servo/mozjs/releases/download");
+    let base = base.unwrap_or("https://github.com/servo/mozjs/releases");
     let version = env::var("CARGO_PKG_VERSION").unwrap();
     let target = env::var("TARGET").unwrap();
     let archive_path = PathBuf::from(env::var_os("OUT_DIR").unwrap()).join("libmozjs.tar.gz");
@@ -915,7 +915,7 @@ fn download_archive(base: Option<&str>) -> Result<PathBuf, std::io::Error> {
             .arg("-o")
             .arg(&archive_path)
             .arg(format!(
-                "{base}/mozjs-sys-v{version}/libmozjs-{target}.tar.gz"
+                "{base}/download/mozjs-sys-v{version}/libmozjs-{target}.tar.gz"
             ))
             .status()?
             .success()


### PR DESCRIPTION
Stripping caused link error in script in servo's CI: https://github.com/servo/servo/pull/32769#issuecomment-2254893822