### PR TITLE
Fix enforcerange for 64bit numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /doc
 /target
 /Cargo.lock
+/.vscode
 
 # Keep this in sync with ignore() in build.rs
 

--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -20,7 +20,6 @@ streams = ['mozjs_sys/streams']
 lazy_static = "1"
 libc.workspace = true
 log = "0.4"
-num-traits = "0.2"
 mozjs_sys = { path = "../mozjs-sys" }
 
 [build-dependencies]

--- a/mozjs/src/conversions.rs
+++ b/mozjs/src/conversions.rs
@@ -45,7 +45,6 @@ use crate::rust::{HandleValue, MutableHandleValue};
 use crate::rust::{ToBoolean, ToInt32, ToInt64, ToNumber, ToUint16, ToUint32, ToUint64};
 use libc;
 use log::debug;
-use num_traits::{Bounded, Zero};
 use std::borrow::Cow;
 use std::mem;
 use std::rc::Rc;
@@ -91,6 +90,39 @@ impl_as!(i32, i32);
 impl_as!(u32, u32);
 impl_as!(i64, i64);
 impl_as!(u64, u64);
+
+/// Similar to num_traits, but we use need to be able to customize values
+pub trait Number {
+    /// Zero value of this type
+    const ZERO: Self;
+    /// Smallest finite number this type can represent
+    const MIN: Self;
+    /// Largest finite number this type can represent
+    const MAX: Self;
+}
+
+macro_rules! impl_num {
+    ($N:ty, $zero:expr, $min:expr, $max:expr) => {
+        impl Number for $N {
+            const ZERO: $N = $zero;
+            const MIN: $N = $min;
+            const MAX: $N = $max;
+        }
+    };
+}
+
+impl_num!(u8, 0, u8::MIN, u8::MAX);
+impl_num!(u16, 0, u16::MIN, u16::MAX);
+impl_num!(u32, 0, u32::MIN, u32::MAX);
+impl_num!(u64, 0, 0, (1 << 53) - 1);
+
+impl_num!(i8, 0, i8::MIN, i8::MAX);
+impl_num!(i16, 0, i16::MIN, i16::MAX);
+impl_num!(i32, 0, i32::MIN, i32::MAX);
+impl_num!(i64, 0, -(1 << 53) + 1, (1 << 53) - 1);
+
+impl_num!(f32, 0.0, f32::MIN, f32::MAX);
+impl_num!(f64, 0.0, f64::MIN, f64::MAX);
 
 /// A trait to convert Rust types to `JSVal`s.
 pub trait ToJSValConvertible {
@@ -148,7 +180,7 @@ pub enum ConversionBehavior {
 /// if it doesn't fit, it will return an error.
 unsafe fn enforce_range<D>(cx: *mut JSContext, d: f64) -> Result<ConversionResult<D>, ()>
 where
-    D: Bounded + As<f64>,
+    D: Number + As<f64>,
     f64: As<D>,
 {
     if d.is_infinite() {
@@ -157,7 +189,7 @@ where
     }
 
     let rounded = d.round();
-    if D::min_value().cast() <= rounded && rounded <= D::max_value().cast() {
+    if D::MIN.cast() <= rounded && rounded <= D::MAX.cast() {
         Ok(ConversionResult::Success(rounded.cast()))
     } else {
         throw_type_error(cx, "value out of range in an EnforceRange argument");
@@ -170,15 +202,15 @@ where
 /// the destination type.
 fn clamp_to<D>(d: f64) -> D
 where
-    D: Bounded + As<f64> + Zero,
+    D: Number + As<f64>,
     f64: As<D>,
 {
     if d.is_nan() {
-        D::zero()
-    } else if d > D::max_value().cast() {
-        D::max_value()
-    } else if d < D::min_value().cast() {
-        D::min_value()
+        D::ZERO
+    } else if d > D::MAX.cast() {
+        D::MAX
+    } else if d < D::MIN.cast() {
+        D::MIN
     } else {
         d.cast()
     }
@@ -235,8 +267,8 @@ unsafe fn convert_int_from_jsval<T, M>(
     convert_fn: unsafe fn(*mut JSContext, HandleValue) -> Result<M, ()>,
 ) -> Result<ConversionResult<T>, ()>
 where
-    T: Bounded + Zero + As<f64>,
-    M: Zero + As<T>,
+    T: Number + As<f64>,
+    M: Number + As<T>,
     f64: As<T>,
 {
     match option {

--- a/mozjs/src/conversions.rs
+++ b/mozjs/src/conversions.rs
@@ -178,6 +178,7 @@ pub enum ConversionBehavior {
 
 /// Try to cast the number to a smaller type, but
 /// if it doesn't fit, it will return an error.
+// https://searchfox.org/mozilla-esr128/rev/1aa97f9d67f7a7231e62af283eaa02a6b31380e1/dom/bindings/PrimitiveConversions.h#166
 unsafe fn enforce_range<D>(cx: *mut JSContext, d: f64) -> Result<ConversionResult<D>, ()>
 where
     D: Number + As<f64>,
@@ -188,7 +189,7 @@ where
         return Err(());
     }
 
-    let rounded = d.round();
+    let rounded = d.signum() * d.abs().floor();
     if D::MIN.cast() <= rounded && rounded <= D::MAX.cast() {
         Ok(ConversionResult::Success(rounded.cast()))
     } else {

--- a/mozjs/src/conversions.rs
+++ b/mozjs/src/conversions.rs
@@ -111,6 +111,7 @@ macro_rules! impl_num {
     };
 }
 
+// lower upper bound per: https://webidl.spec.whatwg.org/#abstract-opdef-converttoint
 impl_num!(u8, 0, u8::MIN, u8::MAX);
 impl_num!(u16, 0, u16::MIN, u16::MAX);
 impl_num!(u32, 0, u32::MIN, u32::MAX);

--- a/mozjs/tests/enforce_range.rs
+++ b/mozjs/tests/enforce_range.rs
@@ -1,0 +1,109 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::ptr;
+
+use mozjs::conversions::{ConversionBehavior, ConversionResult, FromJSValConvertible};
+use mozjs::jsapi::JSAutoRealm;
+use mozjs::jsapi::{Heap, JSObject, JS_NewGlobalObject, OnNewGlobalHookOption};
+use mozjs::jsapi::{JS_ClearPendingException, JS_IsExceptionPending};
+use mozjs::jsval::UndefinedValue;
+use mozjs::rooted;
+use mozjs::rust::{HandleObject, JSEngine, RealmOptions, Runtime, SIMPLE_GLOBAL_CLASS};
+
+struct SM {
+    _ac: JSAutoRealm,
+    global: Box<Heap<*mut JSObject>>,
+    rt: Runtime,
+    _engine: JSEngine,
+}
+
+impl SM {
+    fn new() -> Self {
+        let engine = JSEngine::init().unwrap();
+        let rt = Runtime::new(engine.handle());
+        let cx = rt.cx();
+        let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
+        let c_option = RealmOptions::default();
+        rooted!(in(cx) let global = unsafe {JS_NewGlobalObject(
+            cx,
+            &SIMPLE_GLOBAL_CLASS,
+            ptr::null_mut(),
+            h_option,
+            &*c_option,
+        )});
+        let _ac = JSAutoRealm::new(cx, global.get());
+        Self {
+            _engine: engine,
+            rt,
+            global: Heap::boxed(global.get()),
+            _ac,
+        }
+    }
+
+    /// Returns value or (Type)Error
+    fn obtain<T: FromJSValConvertible<Config = ConversionBehavior>>(
+        &self,
+        js: &str,
+    ) -> Result<T, ()> {
+        let cx = self.rt.cx();
+        rooted!(in(cx) let mut rval = UndefinedValue());
+        unsafe {
+            self.rt
+                .evaluate_script(
+                    HandleObject::from_raw(self.global.handle()),
+                    js,
+                    "test",
+                    1,
+                    rval.handle_mut(),
+                )
+                .unwrap();
+            assert!(!JS_IsExceptionPending(cx));
+            match <T as FromJSValConvertible>::from_jsval(
+                cx,
+                rval.handle(),
+                ConversionBehavior::EnforceRange,
+            ) {
+                Ok(ConversionResult::Success(t)) => Ok(t),
+                Ok(ConversionResult::Failure(e)) => panic!("{e}"),
+                Err(()) => {
+                    assert!(JS_IsExceptionPending(cx));
+                    JS_ClearPendingException(cx);
+                    Err(())
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn conversion() {
+    let sm = SM::new();
+
+    // u64 = unsigned long long
+    // use `AbortSignal.timeout(u64)` to test for TypeError in browser
+    assert!(sm.obtain::<u64>("Number.MIN_VALUE").is_ok());
+    assert!(sm.obtain::<u64>("Number.MIN_SAFE_INTEGER").is_err());
+    assert!(sm.obtain::<u64>("-1").is_err());
+    assert_eq!(sm.obtain::<u64>("-0.9999"), Ok(0));
+    assert_eq!(sm.obtain::<u64>("-0.9"), Ok(0));
+    assert_eq!(sm.obtain::<u64>("-0.6"), Ok(0));
+    assert_eq!(sm.obtain::<u64>("-0.5"), Ok(0));
+    assert_eq!(sm.obtain::<u64>("-0.4"), Ok(0));
+    assert_eq!(sm.obtain::<u64>("-0.1"), Ok(0));
+    assert_eq!(sm.obtain::<u64>("0"), Ok(0));
+
+    assert_eq!(
+        sm.obtain::<u64>("Number.MAX_SAFE_INTEGER-1"),
+        Ok((1 << 53) - 2)
+    );
+    assert_eq!(
+        sm.obtain::<u64>("Number.MAX_SAFE_INTEGER"),
+        Ok((1 << 53) - 1)
+    );
+    assert!(sm.obtain::<u64>("Number.MAX_SAFE_INTEGER+0.4").is_ok());
+    assert!(sm.obtain::<u64>("Number.MAX_SAFE_INTEGER+0.5").is_err());
+    assert!(sm.obtain::<u64>("Number.MAX_SAFE_INTEGER+1").is_err());
+    assert!(sm.obtain::<u64>("Number.MAX_VALUE").is_err());
+}


### PR DESCRIPTION
While working on WebGPU I noticed that `EnforceRange` is not working right, per [specs](https://webidl.spec.whatwg.org/#abstract-opdef-converttoint), limits for 64bit values are 2**+-53 -+1.

See also relevant limits overrides in mozilla: https://searchfox.org/mozilla-esr128/rev/1aa97f9d67f7a7231e62af283eaa02a6b31380e1/dom/bindings/PrimitiveConversions.h#166