### PR TITLE
Added Clang Format Checks to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -171,8 +171,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - name: Check formatting
+      - name: Check Rust formatting
         run: cargo fmt --check
+      - name: Check C++ formatting
+        uses: jidicula/clang-format-action@v4.11.0
+        with:
+          clang-format-version: "18"
+          exclude-regex: mozjs-sys\/mozjs
       - name: Get mozjs
         run: |
           bash ./mozjs-sys/etc/get_mozjs.sh


### PR DESCRIPTION
Adds C++ Formatting to the CI under the Integrity Check.

I suspect we could switch to `check-path=mozjs-sys/src` instead of `exclude-regex` since `mozjs` doesn't have any c++ anymore.