### PR TITLE
Fix mmap for JIT code on HarmonyOS NEXT Beta 2

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.128.0-4"
+version = "0.128.0-5"
 authors = ["Mozilla"]
 links = "mozjs"
 build = "build.rs"

--- a/mozjs-sys/etc/patches/0034-build__Add_compile_definition_for_ohos.patch
+++ b/mozjs-sys/etc/patches/0034-build__Add_compile_definition_for_ohos.patch
@@ -1,0 +1,18 @@
+diff --git a/build/moz.configure/init.configure b/build/moz.configure/init.configure
+--- a/build/moz.configure/init.configure	(revision dbffebd0937c14d3c73ce9be4798da15cb2f369d)
++++ b/build/moz.configure/init.configure	(revision 8a1dbb7da45148151dbb0d05d969118103cfa8d0)
+@@ -950,6 +950,14 @@
+ set_define("ANDROID", target_is_android)
+
+
++@depends(target)
++def target_is_ohos(target):
++    return target.raw_os.endswith("-ohos")
++
++
++set_define("XP_OHOS", target_is_ohos)
++
++
+ @depends(target)
+ def target_is_openbsd(target):
+     if target.kernel == "OpenBSD":

--- a/mozjs-sys/etc/patches/0035-Fix_mmap_for_JIT_on_HOS_Beta2.patch
+++ b/mozjs-sys/etc/patches/0035-Fix_mmap_for_JIT_on_HOS_Beta2.patch
@@ -1,0 +1,22 @@
+diff --git a/js/src/jit/ProcessExecutableMemory.cpp b/js/src/jit/ProcessExecutableMemory.cpp
+--- a/js/src/jit/ProcessExecutableMemory.cpp	(revision 5ef22dcf66d5aa396ad6fe8dd53dac88a29f8774)
++++ b/js/src/jit/ProcessExecutableMemory.cpp	(revision c9a9b9b6b8f6aba9858ca14171f8c0051baa272a)
+@@ -584,9 +584,15 @@
+ #    endif
+   return true;
+ #  else
+-  unsigned flags = ProtectionSettingToFlags(protection);
+-  void* p = MozTaggedAnonymousMmap(addr, bytes, flags,
+-                                   MAP_FIXED | MAP_PRIVATE | MAP_ANON, -1, 0,
++  unsigned prot_flags = ProtectionSettingToFlags(protection);
++  int flags = MAP_FIXED | MAP_PRIVATE | MAP_ANON;
++#    ifdef XP_OHOS
++  // Required for JIT code on HarmonyOS.
++  // Since MAP_EXECUTABLE is documented to be ignored on Linux, we
++  // unconditionally enable it for all OpenHarmony distributions.
++  flags |= MAP_EXECUTABLE;
++#    endif
++  void* p = MozTaggedAnonymousMmap(addr, bytes, prot_flags, flags, -1, 0,
+                                    "js-executable-memory");
+   if (p == MAP_FAILED) {
+     return false;

--- a/mozjs-sys/mozjs/build/moz.configure/init.configure
+++ b/mozjs-sys/mozjs/build/moz.configure/init.configure
@@ -951,6 +951,14 @@ set_define("ANDROID", target_is_android)
 
 
 @depends(target)
+def target_is_ohos(target):
+    return target.raw_os.endswith("-ohos")
+
+
+set_define("XP_OHOS", target_is_ohos)
+
+
+@depends(target)
 def target_is_openbsd(target):
     if target.kernel == "OpenBSD":
         return True

--- a/mozjs-sys/mozjs/js/src/jit/ProcessExecutableMemory.cpp
+++ b/mozjs-sys/mozjs/js/src/jit/ProcessExecutableMemory.cpp
@@ -584,9 +584,15 @@ static unsigned ProtectionSettingToFlags(ProtectionSetting protection) {
 #    endif
   return true;
 #  else
-  unsigned flags = ProtectionSettingToFlags(protection);
-  void* p = MozTaggedAnonymousMmap(addr, bytes, flags,
-                                   MAP_FIXED | MAP_PRIVATE | MAP_ANON, -1, 0,
+  unsigned prot_flags = ProtectionSettingToFlags(protection);
+  int flags = MAP_FIXED | MAP_PRIVATE | MAP_ANON;
+#    ifdef XP_OHOS
+  // Required for JIT code on HarmonyOS.
+  // Since MAP_EXECUTABLE is documented to be ignored on Linux, we
+  // unconditionally enable it for all OpenHarmony distributions.
+  flags |= MAP_EXECUTABLE;
+#    endif
+  void* p = MozTaggedAnonymousMmap(addr, bytes, prot_flags, flags, -1, 0,
                                    "js-executable-memory");
   if (p == MAP_FAILED) {
     return false;


### PR DESCRIPTION
The Security policy for JIT code is tightening on HarmonyOS . Beta 2 and newer require us to pass `MAP_EXECUTABLE` (internally same as `MAP_JIT`) to the committing mmap, otherwise it will fail.
