### PR TITLE
Fixed Additional CPPFLAGS

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.128.0-6"
+version = "0.128.0-7"
 authors = ["Mozilla"]
 links = "mozjs"
 build = "build.rs"

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -303,6 +303,7 @@ fn build_spidermonkey(build_dir: &Path) {
     }
     if let Ok(include) = std::env::var("DEP_Z_INCLUDE") {
         cppflags.push(format!("-I{include}").replace("\\", "/"));
+        cppflags.push(" ");
     }
     cppflags.push(get_cc_rs_env_os("CPPFLAGS").unwrap_or_default());
     cmd.env("CPPFLAGS", cppflags);


### PR DESCRIPTION
Currently, it's missing a space after the `-I{include_dir}`, so the user must manually specify ` {flags}` instead of `{flags}`.