### PR TITLE
set libz-sys to 1.1.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,3 @@ bindgen = { version = "0.69", default-features = false, features = [
     "runtime",
     "which-rustfmt",
 ] }
-
-# patch libz-sys for https://github.com/rust-lang/libz-sys/pull/199
-# until released as 1.1.19
-[patch.crates-io]
-libz-sys = { git = "https://github.com/rust-lang/libz-sys.git", rev = "f76b7a24ed0a71ef1b8bdac1895e8535cb2cb9c0" }

--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -31,7 +31,7 @@ streams = []
 [dependencies]
 libc.workspace = true
 # SM depends on them and we provide them using cargo
-libz-sys = "1.1.13"
+libz-sys = "1.1.19"
 encoding_c = "0.9.8"
 encoding_c_mem = "0.2.6"
 # unicode-bidi-ffi = { path = "./mozjs/intl/bidi/rust/unicode-bidi-ffi" }


### PR DESCRIPTION
No need for patching as 1.1.19 is released with needed fixes (mostly https://github.com/rust-lang/libz-sys/pull/199).