### PR TITLE
Check for MOZJS_ARCHIVE before Building from Source

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.128.0-8"
+version = "0.128.0-9"
 authors = ["Mozilla"]
 links = "mozjs"
 build = "build.rs"

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -123,6 +123,8 @@ fn should_build_from_source() -> bool {
             "Environment variable MOZJS_CREATE_ARCHIVE is set. Building from source directly."
         );
         true
+    } else if env::var_os("MOZJS_ARCHIVE").is_some() {
+        false
     } else if env::var_os("CARGO_FEATURE_DEBUGMOZJS").is_some() {
         println!("debug-mozjs feature is enabled. Building from source directly.");
         true


### PR DESCRIPTION
If the user specifies `MOZJS_ARCHIVE`, that should be used no matter what, instead of checking for activated features.
The current system does not allow me to create an archive for testing locally with `debugmozjs` and use it, since it checks for that and returns `true`.

I can add some output if you want, but I wasn't sure about what to add.