### PR TITLE
Add `is_constructing` method to `JS::CallArgs`

### DIFF
--- a/mozjs-sys/src/jsimpls.rs
+++ b/mozjs-sys/src/jsimpls.rs
@@ -304,8 +304,8 @@ impl JS::CallArgs {
     }
 
     #[inline]
-    pub unsafe fn is_constructing(&self) -> bool {
-        (*self.argv_.offset(-1)).is_magic()
+    pub fn is_constructing(&self) -> bool {
+        unsafe { (*self.argv_.offset(-1)).is_magic() }
     }
 }
 

--- a/mozjs-sys/src/jsimpls.rs
+++ b/mozjs-sys/src/jsimpls.rs
@@ -302,6 +302,11 @@ impl JS::CallArgs {
             JS::MutableHandleValue::from_marked_location(self.argv_.offset(self.argc_ as isize))
         }
     }
+
+    #[inline]
+    pub unsafe fn is_constructing(&self) -> bool {
+        (*self.argv_.offset(-1)).is_magic()
+    }
 }
 
 impl JSJitSetterCallArgs {


### PR DESCRIPTION
This PR is for fixing the issue in servo repo https://github.com/servo/servo/issues/29821.

We implemented a util function named [`callargs_is_constructing`](https://github.com/servo/servo/blob/20273b062af969152635306c3df2a3a1364ac4d1/components/script/dom/bindings/utils.rs#L629) in servo repo, but having an equivalent method in `JS::CallArgs` and using it should be clearer.

In this PR, a new method `is_constructing` is added to `JS::CallArgs`. It will be used in servo repo to replace all the usage of `callargs_is_constructing` function.

