### PR TITLE
Add prebuilt artifacts for OpenHarmony and test github attestions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -153,7 +153,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [ 'aarch64-unknown-linux-ohos' ]
+        target: [ 'aarch64-unknown-linux-ohos', 'x86_64-unknown-linux-ohos' ]
     steps:
       - uses: actions/checkout@v4
       - name: Setup OpenHarmony SDK

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -171,6 +171,43 @@ jobs:
         run: |
           ./ohos-build cargo build --target="${{ matrix.target }}"
 
+  ohos-release:
+    name: "OpenHarmony release artifact"
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
+    strategy:
+      matrix:
+        target: [ 'aarch64-unknown-linux-ohos', 'x86_64-unknown-linux-ohos' ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup OpenHarmony SDK
+        id: setup_sdk
+        uses: openharmony-rs/setup-ohos-sdk@v0.1
+        with:
+          version: "4.1"
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - name: Build (arch ${{ matrix.target }} )
+        env:
+          OHOS_SDK_NATIVE: ${{ steps.setup_sdk.outputs.ohos_sdk_native }}
+        run: |
+          ./ohos-build cargo build --release --target="${{ matrix.target }}"
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: './target/libmozjs-${{ matrix.target }}.tar.gz'
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          path: ./target/libmozjs-${{ matrix.target }}.tar.gz
+          name: libmozjs-${{ matrix.target }}.tar.gz
+
   linux-cross-compile:
     name: linux (${{ matrix.target }})
     runs-on: ubuntu-latest
@@ -220,7 +257,7 @@ jobs:
   publish-release:
     name: Check version and publish release
     runs-on: ubuntu-latest
-    needs: ["linux", "mac", "windows"]
+    needs: ["linux", "mac", "windows", "ohos-release"]
     if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Adding prebuilt artifacts should fix the OpenHarmony build on windows hosts, since it avoids needing to build spidermonkey from source (the spidermonkey build system seems to assume that on windows hosts, one will only cross-compile to other windows targets).

Additionally we can use this as a test for the github attestations api. 
It requires splitting the build and upload artifact into 2 different jobs, since the job that creates the artifact needs elevated permissions.

Write permissions can't and shouldn't be granted to forks, so I made the `ohos-release` job conditional.