### PR TITLE
Use github artifact attestations for the prebuilt artifacts

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -49,3 +49,38 @@ jobs:
         run: |
           cargo build --verbose --features streams
           cargo test --tests --examples --verbose --features streams
+
+  verify-archive-ohos:
+    name: "Verify archive OpenHarmony"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: ["aarch64-unknown-linux-ohos", "x86_64-unknown-linux-ohos"]
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'release' && github.ref_name ||  inputs.release-tag }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup OpenHarmony SDK
+        id: setup_sdk
+        uses: openharmony-rs/setup-ohos-sdk@v0.1
+        with:
+          version: "4.1"
+      - name: Download prebuilt mozjs from artifact
+        if: ${{ env.RELEASE_TAG == '' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: libmozjs-${{ matrix.platform.target }}.tar.gz
+      - name: Build from archive
+        if: ${{ env.RELEASE_TAG == '' }}
+        env:
+          OHOS_SDK_NATIVE: ${{ steps.setup_sdk.outputs.ohos_sdk_native }}
+          MOZJS_ARCHIVE: libmozjs-${{ matrix.platform.target }}.tar.gz
+        run: |
+          ./ohos-build cargo build --target="${{ matrix.target }}" --verbose --features streams
+      - name: Build from auto-download (arch ${{ matrix.target }})
+        if: ${{ env.RELEASE_TAG != '' }}
+        env:
+          OHOS_SDK_NATIVE: ${{ steps.setup_sdk.outputs.ohos_sdk_native }}
+          MOZJS_ATTESTATION: strict
+        run: |
+          ./ohos-build cargo build --target="${{ matrix.target }}" --verbose --features "streams"

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -44,6 +44,8 @@ jobs:
           cargo test --tests --examples --verbose --features streams
       - name: Build from auto-download
         if: ${{ env.RELEASE_TAG != '' }}
+        env:
+          MOZJS_ATTESTATION: strict
         run: |
           cargo build --verbose --features streams
           cargo test --tests --examples --verbose --features streams

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -65,16 +65,20 @@ jobs:
         uses: openharmony-rs/setup-ohos-sdk@v0.1
         with:
           version: "4.1"
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
       - name: Download prebuilt mozjs from artifact
         if: ${{ env.RELEASE_TAG == '' }}
         uses: actions/download-artifact@v4
         with:
-          name: libmozjs-${{ matrix.platform.target }}.tar.gz
+          name: libmozjs-${{ matrix.target }}.tar.gz
       - name: Build from archive
         if: ${{ env.RELEASE_TAG == '' }}
         env:
           OHOS_SDK_NATIVE: ${{ steps.setup_sdk.outputs.ohos_sdk_native }}
-          MOZJS_ARCHIVE: libmozjs-${{ matrix.platform.target }}.tar.gz
+          MOZJS_ARCHIVE: libmozjs-${{ matrix.target }}.tar.gz
         run: |
           ./ohos-build cargo build --target="${{ matrix.target }}" --verbose --features streams
       - name: Build from auto-download (arch ${{ matrix.target }})

--- a/README.md
+++ b/README.md
@@ -27,6 +27,20 @@ this feature:
       archive. The base URL should  be similar to `https://github.com/servo/mozjs/releases`.
       The build script will append the version and target accordingly. See the files at the example
       URL for more details.
+- `MOZJS_ATTESTATION` allows uses [Github Attestations] to verify the integrity of the prebuilt archive
+  and that the archive was built by in CI, for a valid commit on the main branch of the servo/mozjs repo.
+  Attestation verification requires having a recent version of the github cli tool [gh] installed.
+  If artifact verification is enabled and reports an error, the prebuilt archive will be discarded and 
+  mozjs will be built from source instead.
+  Available values are:
+  - unset (default): Enable artifact verification when possible ([gh] is installed and recent enough).
+  - `MOZJS_ATTESTATION=<0|false|off>`: Disable artifact verification.
+  - `MOZJS_ATTESTATION=<1|true|on|lenient>`: Enable artifact verification and fallback to compiling from source if 
+      verification fails or is not possible.
+  - `MOZJS_ATTESTATION=<2|strict|force>`: Fail the build if artifact verification fails.
+
+[Github Attestations]: https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds
+[gh]: https://cli.github.com/
 
 ## Building from Source
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ this feature:
   If artifact verification is enabled and reports an error, the prebuilt archive will be discarded and 
   mozjs will be built from source instead.
   Available values are:
-  - unset (default): Enable artifact verification when possible ([gh] is installed and recent enough).
+  - unset (default): Equivalent to `off`.
   - `MOZJS_ATTESTATION=<0|false|off>`: Disable artifact verification.
   - `MOZJS_ATTESTATION=<1|true|on|lenient>`: Enable artifact verification and fallback to compiling from source if 
       verification fails or is not possible.

--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.128.3-2"
+version = "0.128.3-3"
 authors = ["Mozilla"]
 links = "mozjs"
 build = "build.rs"

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -964,13 +964,7 @@ impl ArtifactAttestation {
                 );
             }
         }
-        // When the environment variable is not set or invalid,
-        // we enable attestation if possible.
-        if *ATTESTATION_AVAILABLE {
-            ArtifactAttestation::Enabled(AttestationType::Lenient)
-        } else {
-            ArtifactAttestation::Disabled
-        }
+        ArtifactAttestation::Disabled
     }
 }
 


### PR DESCRIPTION
I tested this on my local fork (changed line 908 to point to `jschwe/mozjs`.
On my work machine the attestation takes around 500ms, but network is generally slow (downloading the 16MB artifact via curl takes somewhere between 20 and 60s for some reason)