### PR TITLE
Reconfigure if configure inputs changed

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.128.0-11"
+version = "0.128.0-12"
 authors = ["Mozilla"]
 links = "mozjs"
 build = "build.rs"

--- a/mozjs-sys/makefile.cargo
+++ b/mozjs-sys/makefile.cargo
@@ -148,12 +148,18 @@ all: maybe-configure
 # The second two time checks handle the case of configure.in and configure having
 # the same timestamp (e.g. after a git checkout)
 JSSRC := '$(SRC_DIR)'/js/src
+# Keep track of all input variables to configure, so we don't skip reconfigure
+# when we do need to reconfigure
+CONFIGURE_INPUTS := "$(CC)$(CFLAGS)$(CPP)$(CPPFLAGS)$(CXX)$(CXXFLAGS)$(AS)$(AR)$(CONFIGURE_FLAGS)"
+LAST_CONFIGURE_INPUTS := "$(shell cat reconfigure.inputs)"
 maybe-configure:
 	[[ $(JSSRC)/configure -ot $(JSSRC)/configure.in ]] && touch $(JSSRC)/configure || true
 	[[ $(JSSRC)/old-configure -ot $(JSSRC)/old-configure.in ]] && touch $(JSSRC)/old-configure || true
+	[[ $(LAST_CONFIGURE_INPUTS) != $(CONFIGURE_INPUTS) ]] && touch $(JSSRC)/configure || true
 	! [[ $(JSSRC)/configure.in -ot $(JSSRC)/configure ]] && touch $(JSSRC)/configure || true
 	! [[ $(JSSRC)/old-configure.in -ot $(JSSRC)/old-configure ]] && touch $(JSSRC)/old-configure || true
 	if [[ $(JSSRC)/configure -nt config.status ]] ; then \
+	  ( echo "$(CONFIGURE_INPUTS)" > reconfigure.inputs ); \
 	  CC="$(CC)" CFLAGS="$(CFLAGS)" \
 	  CPP="$(CPP)" CPPFLAGS="$(CPPFLAGS)" \
 	  CXX="$(CXX)" CXXFLAGS="$(CXXFLAGS)" \


### PR DESCRIPTION
Save all input variables to the configure script, so that we can re-run it when necessary.

Closes #505