### PR TITLE
Bump mozjs-sys to v0.128.0-10

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.128.0-9"
+version = "0.128.0-10"
 authors = ["Mozilla"]
 links = "mozjs"
 build = "build.rs"


### PR DESCRIPTION
Creates a release for:
-  Add prebuilt artifacts for OpenHarmony and test github attestions #501