### PR TITLE
Respect "STRIP" env variable for prebuilt artifact 

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.128.0-10"
+version = "0.128.0-11"
 authors = ["Mozilla"]
 links = "mozjs"
 build = "build.rs"

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -847,10 +847,11 @@ fn compress_static_lib(build_dir: &Path) -> Result<(), std::io::Error> {
             &mut File::open(build_dir.join("gluebindings.rs")).unwrap(),
         )?;
     } else {
+        let strip_bin = get_cc_rs_env_os("STRIP").unwrap_or_else(|| "strip".into());
         // Strip symbols from the static binary since it could bump up to 1.6GB on Linux.
         // TODO: Maybe we could separate symbols for thos who still want the debug ability.
         // https://github.com/GabrielMajeri/separate-symbols
-        let mut strip = Command::new("strip");
+        let mut strip = Command::new(strip_bin);
         if !target.contains("apple") {
             strip.arg("--strip-debug");
         };


### PR DESCRIPTION
Allow the user to select the strip command via setting the STRIP environment variable (or the cc-rs variants of it).
For the OpenHarmony build the `ohos-build` script already sets `STRIP`, so this change also reduces the artifact size of the OpenHarmony release artifact.

Closes #508