### PR TITLE
Fix unsound use of Rooted<T> with RootKind::Traceable

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.128.3-0"
+version = "0.128.3-1"
 authors = ["Mozilla"]
 links = "mozjs"
 build = "build.rs"

--- a/mozjs-sys/src/jsgc.rs
+++ b/mozjs-sys/src/jsgc.rs
@@ -68,7 +68,7 @@ impl RootKind for JS::Value {
     const KIND: JS::RootKind = JS::RootKind::Value;
 }
 
-impl RootKind for JS::PropertyDescriptor {
+impl<T: TraceableTrace> RootKind for T {
     type Vtable = *const RootedVFTable;
     const VTABLE: Self::Vtable = &<Self as TraceableTrace>::VTABLE;
     const KIND: JS::RootKind = JS::RootKind::Traceable;
@@ -96,7 +96,7 @@ impl RootedVFTable {
 /// `Rooted<T>` with a T that uses the Traceable RootKind uses dynamic dispatch on the C++ side
 /// for custom tracing. This trait provides trace logic via a vtable when creating a Rust instance
 /// of the object.
-pub unsafe trait TraceableTrace: Sized + RootKind {
+pub unsafe trait TraceableTrace: Sized {
     const VTABLE: RootedVFTable = RootedVFTable {
         padding: RootedVFTable::PADDING,
         trace: Self::trace,
@@ -265,12 +265,6 @@ impl<const N: usize> ValueArray<N> {
     pub unsafe fn get_mut_ptr(&self) -> *mut JS::Value {
         self.elements.as_ptr() as *mut _
     }
-}
-
-impl<const N: usize> RootKind for ValueArray<N> {
-    type Vtable = *const RootedVFTable;
-    const VTABLE: Self::Vtable = &<Self as TraceableTrace>::VTABLE;
-    const KIND: JS::RootKind = JS::RootKind::Traceable;
 }
 
 unsafe impl<const N: usize> TraceableTrace for ValueArray<N> {

--- a/mozjs-sys/src/jsgc.rs
+++ b/mozjs-sys/src/jsgc.rs
@@ -2,91 +2,145 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use crate::glue::CallPropertyDescriptorTracer;
+use crate::jsapi::js::TraceValueArray;
 use crate::jsapi::JS;
 use crate::jsapi::{jsid, JSFunction, JSObject, JSScript, JSString, JSTracer};
 
 use crate::jsid::VoidId;
 use std::cell::UnsafeCell;
-use std::ffi::c_void;
+use std::ffi::{c_char, c_void};
 use std::mem;
 use std::ptr;
 
 /// A trait for JS types that can be registered as roots.
 pub trait RootKind {
-    #[allow(non_snake_case)]
-    /// Returns the rooting kind for `Self`.
-    fn rootKind() -> JS::RootKind;
+    type Vtable;
+    const VTABLE: Self::Vtable;
+    const KIND: JS::RootKind;
 }
 
 impl RootKind for *mut JSObject {
-    #[inline(always)]
-    fn rootKind() -> JS::RootKind {
-        JS::RootKind::Object
-    }
+    type Vtable = ();
+    const VTABLE: Self::Vtable = ();
+    const KIND: JS::RootKind = JS::RootKind::Object;
 }
 
 impl RootKind for *mut JSFunction {
-    #[inline(always)]
-    fn rootKind() -> JS::RootKind {
-        JS::RootKind::Object
-    }
+    type Vtable = ();
+    const VTABLE: Self::Vtable = ();
+    const KIND: JS::RootKind = JS::RootKind::Object;
 }
 
 impl RootKind for *mut JSString {
-    #[inline(always)]
-    fn rootKind() -> JS::RootKind {
-        JS::RootKind::String
-    }
+    type Vtable = ();
+    const VTABLE: Self::Vtable = ();
+    const KIND: JS::RootKind = JS::RootKind::String;
 }
 
 impl RootKind for *mut JS::Symbol {
-    #[inline(always)]
-    fn rootKind() -> JS::RootKind {
-        JS::RootKind::Symbol
-    }
+    type Vtable = ();
+    const VTABLE: Self::Vtable = ();
+    const KIND: JS::RootKind = JS::RootKind::Symbol;
 }
 
 impl RootKind for *mut JS::BigInt {
-    #[inline(always)]
-    fn rootKind() -> JS::RootKind {
-        JS::RootKind::BigInt
-    }
+    type Vtable = ();
+    const VTABLE: Self::Vtable = ();
+    const KIND: JS::RootKind = JS::RootKind::BigInt;
 }
 
 impl RootKind for *mut JSScript {
-    #[inline(always)]
-    fn rootKind() -> JS::RootKind {
-        JS::RootKind::Script
-    }
+    type Vtable = ();
+    const VTABLE: Self::Vtable = ();
+    const KIND: JS::RootKind = JS::RootKind::Script;
 }
 
 impl RootKind for jsid {
-    #[inline(always)]
-    fn rootKind() -> JS::RootKind {
-        JS::RootKind::Id
-    }
+    type Vtable = ();
+    const VTABLE: Self::Vtable = ();
+    const KIND: JS::RootKind = JS::RootKind::Id;
 }
 
 impl RootKind for JS::Value {
-    #[inline(always)]
-    fn rootKind() -> JS::RootKind {
-        JS::RootKind::Value
-    }
+    type Vtable = ();
+    const VTABLE: Self::Vtable = ();
+    const KIND: JS::RootKind = JS::RootKind::Value;
 }
 
 impl RootKind for JS::PropertyDescriptor {
-    #[inline(always)]
-    fn rootKind() -> JS::RootKind {
-        JS::RootKind::Traceable
+    type Vtable = *const RootedVFTable;
+    const VTABLE: Self::Vtable = &<Self as TraceableTrace>::VTABLE;
+    const KIND: JS::RootKind = JS::RootKind::Traceable;
+}
+
+/// A vtable for use in RootedTraceable<T>, which must be present for stack roots using
+/// RootKind::Traceable. The C++ tracing implementation uses a virtual trace function
+/// which is only present for C++ Rooted<T> values that use the Traceable root kind.
+#[repr(C)]
+pub struct RootedVFTable {
+    #[cfg(windows)]
+    pub padding: [usize; 1],
+    #[cfg(not(windows))]
+    pub padding: [usize; 2],
+    pub trace: unsafe extern "C" fn(this: *mut c_void, trc: *mut JSTracer, name: *const c_char),
+}
+
+impl RootedVFTable {
+    #[cfg(windows)]
+    pub const PADDING: [usize; 1] = [0];
+    #[cfg(not(windows))]
+    pub const PADDING: [usize; 2] = [0, 0];
+}
+
+/// `Rooted<T>` with a T that uses the Traceable RootKind uses dynamic dispatch on the C++ side
+/// for custom tracing. This trait provides trace logic via a vtable when creating a Rust instance
+/// of the object.
+pub unsafe trait TraceableTrace: Sized + RootKind {
+    const VTABLE: RootedVFTable = RootedVFTable {
+        padding: RootedVFTable::PADDING,
+        trace: Self::trace,
+    };
+
+    unsafe extern "C" fn trace(this: *mut c_void, trc: *mut JSTracer, _name: *const c_char) {
+        let rooted = this as *mut Rooted<Self>;
+        let rooted = rooted.as_mut().unwrap();
+        Self::do_trace(&mut rooted.ptr, trc);
     }
+
+    /// Used by `TraceableTrace` implementer to trace its contents.
+    /// Corresponds to virtual `trace` call in a `Rooted` that inherits from
+    /// StackRootedTraceableBase (C++).
+    fn do_trace(&mut self, trc: *mut JSTracer);
+}
+
+unsafe impl TraceableTrace for JS::PropertyDescriptor {
+    fn do_trace(&mut self, trc: *mut JSTracer) {
+        unsafe {
+            CallPropertyDescriptorTracer(trc, self);
+        }
+    }
+}
+
+// The C++ representation of Rooted<T> inherits from StackRootedBase, which
+// contains the actual pointers that get manipulated. The Rust representation
+// also uses the pattern, which is critical to ensuring that the right pointers
+// to Rooted<T> values are used, since some Rooted<T> values are prefixed with
+// a vtable pointer, and we don't want to store pointers to that vtable where
+// C++ expects a StackRootedBase.
+#[repr(C)]
+#[derive(Debug)]
+pub struct RootedBase {
+    pub stack: *mut *mut RootedBase,
+    pub prev: *mut RootedBase,
 }
 
 // Annoyingly, bindgen can't cope with SM's use of templates, so we have to roll our own.
 #[repr(C)]
 #[derive(Debug)]
-pub struct Rooted<T> {
-    pub stack: *mut *mut Rooted<*mut c_void>,
-    pub prev: *mut Rooted<*mut c_void>,
+pub struct Rooted<T: RootKind> {
+    pub vtable: T::Vtable,
+    pub base: RootedBase,
     pub ptr: T,
 }
 
@@ -214,8 +268,16 @@ impl<const N: usize> ValueArray<N> {
 }
 
 impl<const N: usize> RootKind for ValueArray<N> {
-    fn rootKind() -> JS::RootKind {
-        JS::RootKind::Traceable
+    type Vtable = *const RootedVFTable;
+    const VTABLE: Self::Vtable = &<Self as TraceableTrace>::VTABLE;
+    const KIND: JS::RootKind = JS::RootKind::Traceable;
+}
+
+unsafe impl<const N: usize> TraceableTrace for ValueArray<N> {
+    fn do_trace(&mut self, trc: *mut JSTracer) {
+        unsafe {
+            TraceValueArray(trc, N, self.get_mut_ptr());
+        }
     }
 }
 

--- a/mozjs-sys/src/jsgc.rs
+++ b/mozjs-sys/src/jsgc.rs
@@ -111,14 +111,12 @@ pub unsafe trait TraceableTrace: Sized {
     /// Used by `TraceableTrace` implementer to trace its contents.
     /// Corresponds to virtual `trace` call in a `Rooted` that inherits from
     /// StackRootedTraceableBase (C++).
-    fn do_trace(&mut self, trc: *mut JSTracer);
+    unsafe fn do_trace(&mut self, trc: *mut JSTracer);
 }
 
 unsafe impl TraceableTrace for JS::PropertyDescriptor {
-    fn do_trace(&mut self, trc: *mut JSTracer) {
-        unsafe {
-            CallPropertyDescriptorTracer(trc, self);
-        }
+    unsafe fn do_trace(&mut self, trc: *mut JSTracer) {
+        CallPropertyDescriptorTracer(trc, self);
     }
 }
 
@@ -268,10 +266,8 @@ impl<const N: usize> ValueArray<N> {
 }
 
 unsafe impl<const N: usize> TraceableTrace for ValueArray<N> {
-    fn do_trace(&mut self, trc: *mut JSTracer) {
-        unsafe {
-            TraceValueArray(trc, N, self.get_mut_ptr());
-        }
+    unsafe fn do_trace(&mut self, trc: *mut JSTracer) {
+        TraceValueArray(trc, N, self.get_mut_ptr());
     }
 }
 

--- a/mozjs-sys/src/jsglue.cpp
+++ b/mozjs-sys/src/jsglue.cpp
@@ -943,6 +943,10 @@ void CallValueRootTracer(JSTracer* trc, JS::Value* valp, const char* name) {
   JS::TraceRoot(trc, valp, name);
 }
 
+void CallPropertyDescriptorTracer(JSTracer* trc, JS::PropertyDescriptor* desc) {
+  desc->trace(trc);
+}
+
 bool IsDebugBuild() {
 #ifdef JS_DEBUG
   return true;


### PR DESCRIPTION
The existing implementation for `Rooted<T>` is correct for most JS types that are rooted, but there's one significant case that is broken. `Rooted<T>` uses C++ template magic to change its base class depending on the type that it's templated over, and certain types that map to `RootKind::Traceable` [end up with a vtable](https://searchfox.org/mozilla-central/source/js/public/RootingAPI.h#923) that contains a custom tracing implementation, while other types do not have any such vtable.

These template shenanigans are very likely the reason why we have a handwritten `Rooted<T>` definition, since bindgen is not able to handle this situation. This PR makes the following changes:
* we introduce a vtable field into `Rooted<T>` which is zero-sized for types that do not have Traceable RootKind value
* we introduce a `TraceableTrace` trait that `Rooted<T>`'s vtable delegates to, allowing implementers to write straightforward tracing implementations for their types

These changes were verified by running the property_descriptor unit test with zealous GC enabled (ie. perform a GC every time there's an allocation) and the test no longer crashes after these changes are applied.