### PR TITLE
Use GCZeal in tests when run with debugmozjs

### DIFF
--- a/mozjs/tests/callback.rs
+++ b/mozjs/tests/callback.rs
@@ -18,6 +18,10 @@ fn callback() {
     let engine = JSEngine::init().unwrap();
     let runtime = Runtime::new(engine.handle());
     let context = runtime.cx();
+    #[cfg(feature = "debugmozjs")]
+    unsafe {
+        mozjs::jsapi::SetGCZeal(context, 2, 1);
+    }
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = RealmOptions::default();
 

--- a/mozjs/tests/capture_stack.rs
+++ b/mozjs/tests/capture_stack.rs
@@ -16,6 +16,10 @@ fn capture_stack() {
     let engine = JSEngine::init().unwrap();
     let runtime = Runtime::new(engine.handle());
     let context = runtime.cx();
+    #[cfg(feature = "debugmozjs")]
+    unsafe {
+        mozjs::jsapi::SetGCZeal(context, 2, 1);
+    }
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = RealmOptions::default();
 

--- a/mozjs/tests/enforce_range.rs
+++ b/mozjs/tests/enforce_range.rs
@@ -24,6 +24,10 @@ impl SM {
         let engine = JSEngine::init().unwrap();
         let rt = Runtime::new(engine.handle());
         let cx = rt.cx();
+        #[cfg(feature = "debugmozjs")]
+        unsafe {
+            mozjs::jsapi::SetGCZeal(cx, 2, 1);
+        }
         let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
         let c_option = RealmOptions::default();
         rooted!(in(cx) let global = unsafe {JS_NewGlobalObject(

--- a/mozjs/tests/enumerate.rs
+++ b/mozjs/tests/enumerate.rs
@@ -17,6 +17,10 @@ fn enumerate() {
     let engine = JSEngine::init().unwrap();
     let runtime = Runtime::new(engine.handle());
     let context = runtime.cx();
+    #[cfg(feature = "debugmozjs")]
+    unsafe {
+        mozjs::jsapi::SetGCZeal(context, 2, 1);
+    }
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = RealmOptions::default();
 

--- a/mozjs/tests/evaluate.rs
+++ b/mozjs/tests/evaluate.rs
@@ -14,6 +14,10 @@ fn evaluate() {
     let engine = JSEngine::init().unwrap();
     let runtime = Runtime::new(engine.handle());
     let context = runtime.cx();
+    #[cfg(feature = "debugmozjs")]
+    unsafe {
+        mozjs::jsapi::SetGCZeal(context, 2, 1);
+    }
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = RealmOptions::default();
 

--- a/mozjs/tests/external_string.rs
+++ b/mozjs/tests/external_string.rs
@@ -19,6 +19,10 @@ fn external_string() {
     let engine = JSEngine::init().unwrap();
     let runtime = Runtime::new(engine.handle());
     let context = runtime.cx();
+    #[cfg(feature = "debugmozjs")]
+    unsafe {
+        mozjs::jsapi::SetGCZeal(context, 2, 1);
+    }
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = RealmOptions::default();
 

--- a/mozjs/tests/jsvalue.rs
+++ b/mozjs/tests/jsvalue.rs
@@ -40,6 +40,10 @@ fn jsvalues() {
     let engine = JSEngine::init().unwrap();
     let runtime = Runtime::new(engine.handle());
     let context = runtime.cx();
+    #[cfg(feature = "debugmozjs")]
+    unsafe {
+        mozjs::jsapi::SetGCZeal(context, 2, 1);
+    }
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = RealmOptions::default();
 

--- a/mozjs/tests/panic.rs
+++ b/mozjs/tests/panic.rs
@@ -17,6 +17,10 @@ fn test_panic() {
     let engine = JSEngine::init().unwrap();
     let runtime = Runtime::new(engine.handle());
     let context = runtime.cx();
+    #[cfg(feature = "debugmozjs")]
+    unsafe {
+        mozjs::jsapi::SetGCZeal(context, 2, 1);
+    }
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = RealmOptions::default();
 

--- a/mozjs/tests/property_descriptor.rs
+++ b/mozjs/tests/property_descriptor.rs
@@ -21,6 +21,12 @@ fn property_descriptor() {
     let engine = JSEngine::init().unwrap();
     let runtime = Runtime::new(engine.handle());
     let context = runtime.cx();
+
+    #[cfg(feature = "debugmozjs")]
+    unsafe {
+        mozjs::jsapi::SetGCZeal(context, 2, 1);
+    }
+
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = RealmOptions::default();
 

--- a/mozjs/tests/runtime.rs
+++ b/mozjs/tests/runtime.rs
@@ -17,6 +17,10 @@ fn runtime() {
     let engine = JSEngine::init().unwrap();
     let runtime = Runtime::new(engine.handle());
     let context = runtime.cx();
+    #[cfg(feature = "debugmozjs")]
+    unsafe {
+        mozjs::jsapi::SetGCZeal(context, 2, 1);
+    }
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = RealmOptions::default();
 

--- a/mozjs/tests/stack_limit.rs
+++ b/mozjs/tests/stack_limit.rs
@@ -14,6 +14,10 @@ fn stack_limit() {
     let engine = JSEngine::init().unwrap();
     let runtime = Runtime::new(engine.handle());
     let context = runtime.cx();
+    #[cfg(feature = "debugmozjs")]
+    unsafe {
+        mozjs::jsapi::SetGCZeal(context, 2, 1);
+    }
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = RealmOptions::default();
 

--- a/mozjs/tests/typedarray.rs
+++ b/mozjs/tests/typedarray.rs
@@ -16,6 +16,10 @@ fn typedarray() {
     let engine = JSEngine::init().unwrap();
     let runtime = Runtime::new(engine.handle());
     let context = runtime.cx();
+    #[cfg(feature = "debugmozjs")]
+    unsafe {
+        mozjs::jsapi::SetGCZeal(context, 2, 1);
+    }
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = RealmOptions::default();
 

--- a/mozjs/tests/vec_conversion.rs
+++ b/mozjs/tests/vec_conversion.rs
@@ -19,7 +19,7 @@ fn vec_conversion() {
     let engine = JSEngine::init().unwrap();
     let runtime = Runtime::new(engine.handle());
     let context = runtime.cx();
-    
+
     #[cfg(feature = "debugmozjs")]
     unsafe {
         mozjs::jsapi::SetGCZeal(context, 2, 1);

--- a/mozjs/tests/vec_conversion.rs
+++ b/mozjs/tests/vec_conversion.rs
@@ -19,6 +19,11 @@ fn vec_conversion() {
     let engine = JSEngine::init().unwrap();
     let runtime = Runtime::new(engine.handle());
     let context = runtime.cx();
+    
+    #[cfg(feature = "debugmozjs")]
+    unsafe {
+        mozjs::jsapi::SetGCZeal(context, 2, 1);
+    }
 
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = RealmOptions::default();


### PR DESCRIPTION
Discovered on work from https://github.com/servo/mozjs/pull/514 (failed before it landed: https://github.com/servo/mozjs/actions/runs/11548177590)