### PR TITLE
Rebuild when `MOZJS_` options are changed

### DIFF
--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -28,7 +28,10 @@ const ENV_VARS: &'static [&'static str] = &[
     "CXXFLAGS",
     "MAKE",
     "MOZTOOLS_PATH",
+    "MOZJS_ARCHIVE",
+    "MOZJS_CREATE_ARCHIVE",
     "MOZJS_FORCE_RERUN",
+    "MOZJS_FROM_SOURCE",
     "PYTHON",
     "STLPORT_LIBS",
 ];


### PR DESCRIPTION
Emit the `rerun-if-changed` lines for publicly documented MOZJS options.

Closes #516