### PR TITLE
Support Box<T>/Option<T> inside of non-JS value roots.

### DIFF
--- a/mozjs/src/gc/custom.rs
+++ b/mozjs/src/gc/custom.rs
@@ -40,6 +40,12 @@ unsafe impl<T: CustomTrace> CustomTrace for Option<T> {
     }
 }
 
+unsafe impl<T: CustomTrace> CustomTrace for Box<T> {
+    fn trace(&self, trc: *mut JSTracer) {
+        self.deref().trace(trc);
+    }
+}
+
 unsafe impl<T: CustomTrace> CustomTrace for Vec<T> {
     fn trace(&self, trc: *mut JSTracer) {
         for elem in self {

--- a/mozjs/src/gc/mod.rs
+++ b/mozjs/src/gc/mod.rs
@@ -2,7 +2,7 @@ pub use crate::gc::collections::*;
 pub use crate::gc::custom::*;
 pub use crate::gc::root::*;
 pub use crate::gc::trace::*;
-pub use mozjs_sys::jsgc::{GCMethods, RootKind};
+pub use mozjs_sys::jsgc::{GCMethods, RootKind, TraceableTrace};
 
 mod collections;
 mod custom;


### PR DESCRIPTION
The auto_root! macro creates a CustomAutoRoot value for the provided initializer. When this initializer contains a Box, the code fails to compile because we don't have custom tracing code for boxes.