### PR TITLE
Add default feature for JIT

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.128.3-4"
+version = "0.128.3-5"
 authors = ["Mozilla"]
 links = "mozjs"
 build = "build.rs"
@@ -23,8 +23,10 @@ name = "mozjs_sys"
 doctest = false
 
 [features]
+default = ["jit"]
 debugmozjs = []
 profilemozjs = []
+jit = []
 jitspew = []
 streams = []
 

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -137,6 +137,9 @@ fn should_build_from_source() -> bool {
     } else if !env::var_os("CARGO_FEATURE_STREAMS").is_some() {
         println!("streams feature isn't enabled. Building from source directly.");
         true
+    } else if !env::var_os("CARGO_FEATURE_JIT").is_some() {
+        println!("jit feature isn't enabled. Building from source directly.");
+        true
     } else {
         false
     }

--- a/mozjs-sys/makefile.cargo
+++ b/mozjs-sys/makefile.cargo
@@ -11,6 +11,10 @@ CONFIGURE_FLAGS := \
 	--disable-shared-js \
 	--build-backends=RecursiveMake
 
+ifeq (,$(CARGO_FEATURE_JIT))
+    CONFIGURE_FLAGS += --disable-jit
+endif
+
 ifneq (,$(CARGO_FEATURE_STREAMS))
     CONFIGURE_FLAGS += --enable-js-streams
 endif


### PR DESCRIPTION
This allows optionally disabling JIT by removing the feature. This is necessary on some variants of OpenHarmony, when JIT is forbidden by a system policy.

My idea is that on the servo side, I would disable `default-features` for mozjs when `target_env = "ohos"`, since the dependency on mozjs is in the script crate. One could then add a direct dependency in `servoshell` on mozjs (again only for OpenHarmony), so that we can expose a top-level feature `js-jit` to the user running `./mach`, since they are the only one that know if their distribution of openharmony allows jit or not. 