### PR TITLE
jsglue.cpp: Fix -Winconsistent-missing-override

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.128.3-5"
+version = "0.128.3-6"
 authors = ["Mozilla"]
 links = "mozjs"
 build = "build.rs"

--- a/mozjs-sys/src/jsglue.cpp
+++ b/mozjs-sys/src/jsglue.cpp
@@ -61,28 +61,28 @@ class RustJobQueue : public JS::JobQueue {
   RustJobQueue(const JobQueueTraps& aTraps, const void* aQueue)
       : mTraps(aTraps), mQueue(aQueue) {}
 
-  virtual JSObject* getIncumbentGlobal(JSContext* cx) {
+  virtual JSObject* getIncumbentGlobal(JSContext* cx) override {
     return mTraps.getIncumbentGlobal(mQueue, cx);
   }
 
   virtual bool enqueuePromiseJob(JSContext* cx, JS::HandleObject promise,
                                  JS::HandleObject job,
                                  JS::HandleObject allocationSite,
-                                 JS::HandleObject incumbentGlobal) {
+                                 JS::HandleObject incumbentGlobal) override {
     return mTraps.enqueuePromiseJob(mQueue, cx, promise, job, allocationSite,
                                     incumbentGlobal);
   }
 
-  virtual bool empty() const { return mTraps.empty(mQueue); }
+  virtual bool empty() const override { return mTraps.empty(mQueue); }
 
-  virtual void runJobs(JSContext* cx) {
+  virtual void runJobs(JSContext* cx) override {
     MOZ_ASSERT(false, "runJobs should not be invoked");
   }
 
   bool isDrainingStopped() const override { return false; }
 
  private:
-  virtual js::UniquePtr<SavedJobQueue> saveJobQueue(JSContext* cx) {
+  virtual js::UniquePtr<SavedJobQueue> saveJobQueue(JSContext* cx) override {
     MOZ_ASSERT(false, "saveJobQueue should not be invoked");
     return nullptr;
   }


### PR DESCRIPTION
`-Winconsistent-missing-override` is enabled by default when compiling with clang.