### PR TITLE
ci: Pin ubuntu to 22.04 in linux builder

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
       RUSTC_WRAPPER: "sccache"
       CCACHE: sccache
       SCCACHE_GHA_ENABLED: "true"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # Needed for artifacts to work on older systems (due to glibc)
     strategy:
       fail-fast: false
       matrix:

--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.128.3-7"
+version = "0.128.3-8"
 authors = ["Mozilla"]
 links = "mozjs"
 build = "build.rs"


### PR DESCRIPTION
This will allow artifacts to be used on older systems (due to glibc).

Issue: https://github.com/servo/servo/pull/34562#issuecomment-2543342461