### PR TITLE
Allow iterating over the frames of a CapturedJSStack

### DIFF
--- a/mozjs/src/rust.rs
+++ b/mozjs/src/rust.rs
@@ -65,6 +65,7 @@ use crate::jsval::ObjectValue;
 use crate::panic::maybe_resume_unwind;
 use lazy_static::lazy_static;
 use log::{debug, warn};
+use mozjs_sys::jsapi::JS::SavedFrameResult;
 pub use mozjs_sys::jsgc::{GCMethods, IntoHandle, IntoMutableHandle};
 
 use crate::rooted;
@@ -1025,6 +1026,34 @@ impl<'a> CapturedJSStack<'a> {
             }
 
             Some(jsstr_to_string(self.cx, string_handle.get()))
+        }
+    }
+
+    /// Executes the provided closure for each frame on the js stack
+    pub fn for_each_stack_frame<F>(&self, mut f: F)
+    where
+        F: FnMut(Handle<*mut JSObject>),
+    {
+        rooted!(in(self.cx) let mut current_element = self.stack.clone());
+        rooted!(in(self.cx) let mut next_element = ptr::null_mut::<JSObject>());
+
+        loop {
+            f(current_element.handle());
+
+            unsafe {
+                let result = jsapi::GetSavedFrameParent(
+                    self.cx,
+                    ptr::null_mut(),
+                    current_element.handle().into_handle(),
+                    next_element.handle_mut().into_handle_mut(),
+                    jsapi::SavedFrameSelfHosted::Include,
+                );
+
+                if result != SavedFrameResult::Ok || next_element.is_null() {
+                    return;
+                }
+            }
+            current_element.set(next_element.get());
         }
     }
 }

--- a/mozjs/tests/capture_stack.rs
+++ b/mozjs/tests/capture_stack.rs
@@ -5,7 +5,6 @@
 use std::ptr;
 
 use mozjs::capture_stack;
-use mozjs::jsapi;
 use mozjs::jsapi::{CallArgs, JSAutoRealm, JSContext, OnNewGlobalHookOption, StackFormat, Value};
 use mozjs::jsapi::{JS_DefineFunction, JS_NewGlobalObject};
 use mozjs::jsval::UndefinedValue;
@@ -71,96 +70,6 @@ fn capture_stack() {
             }
 
             foo(\"arg1-value\");
-        ";
-        rooted!(in(context) let mut rval = UndefinedValue());
-        assert!(runtime
-            .evaluate_script(global.handle(), javascript, "test.js", 0, rval.handle_mut())
-            .is_ok());
-    }
-}
-
-#[test]
-fn iterate_stack_frames() {
-    unsafe extern "C" fn assert_stack_state(
-        context: *mut JSContext,
-        argc: u32,
-        vp: *mut Value,
-    ) -> bool {
-        let mut function_names = vec![];
-        capture_stack!(in(context) let stack);
-        stack.unwrap().for_each_stack_frame(|frame| {
-            rooted!(in(context) let mut result: *mut jsapi::JSString = ptr::null_mut());
-
-            // Get function name
-            unsafe {
-                jsapi::GetSavedFrameFunctionDisplayName(
-                    context,
-                    ptr::null_mut(),
-                    frame.into(),
-                    result.handle_mut().into(),
-                    jsapi::SavedFrameSelfHosted::Include,
-                );
-            }
-            let buffer = if !result.is_null() {
-                let mut buffer = vec![0; 3];
-                jsapi::JS_EncodeStringToBuffer(context, *result, buffer.as_mut_ptr(), 3);
-                Some(buffer.into_iter().map(|c| c as u8).collect())
-            } else {
-                None
-            };
-            function_names.push(buffer);
-        });
-
-        assert_eq!(function_names.len(), 4);
-        assert_eq!(function_names[0], Some(b"baz".to_vec()));
-        assert_eq!(function_names[1], Some(b"bar".to_vec()));
-        assert_eq!(function_names[2], Some(b"foo".to_vec()));
-        assert_eq!(function_names[3], None);
-
-        true
-    }
-
-    let engine = JSEngine::init().unwrap();
-    let runtime = Runtime::new(engine.handle());
-    let context = runtime.cx();
-    #[cfg(feature = "debugmozjs")]
-    unsafe {
-        mozjs::jsapi::SetGCZeal(context, 2, 1);
-    }
-    let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
-    let c_option = RealmOptions::default();
-
-    unsafe {
-        rooted!(in(context) let global = JS_NewGlobalObject(
-            context,
-            &SIMPLE_GLOBAL_CLASS,
-            ptr::null_mut(),
-            h_option,
-            &*c_option,
-        ));
-        let _ac = JSAutoRealm::new(context, global.get());
-
-        let function = JS_DefineFunction(
-            context,
-            global.handle().into(),
-            c"assert_stack_state".as_ptr(),
-            Some(assert_stack_state),
-            0,
-            0,
-        );
-        assert!(!function.is_null());
-
-        let javascript = "
-            function foo() {
-                function bar() {
-                    function baz() {
-                        assert_stack_state();
-                    }
-                    baz();
-                }
-                bar();
-            }
-            foo();
         ";
         rooted!(in(context) let mut rval = UndefinedValue());
         assert!(runtime

--- a/mozjs/tests/capture_stack.rs
+++ b/mozjs/tests/capture_stack.rs
@@ -5,6 +5,7 @@
 use std::ptr;
 
 use mozjs::capture_stack;
+use mozjs::jsapi;
 use mozjs::jsapi::{CallArgs, JSAutoRealm, JSContext, OnNewGlobalHookOption, StackFormat, Value};
 use mozjs::jsapi::{JS_DefineFunction, JS_NewGlobalObject};
 use mozjs::jsval::UndefinedValue;
@@ -13,6 +14,24 @@ use mozjs::rust::{JSEngine, RealmOptions, Runtime, SIMPLE_GLOBAL_CLASS};
 
 #[test]
 fn capture_stack() {
+    unsafe extern "C" fn print_stack(context: *mut JSContext, argc: u32, vp: *mut Value) -> bool {
+        let args = CallArgs::from_vp(vp, argc);
+
+        capture_stack!(in(context) let stack);
+        let str_stack = stack
+            .unwrap()
+            .as_string(None, StackFormat::SpiderMonkey)
+            .unwrap();
+        println!("{}", str_stack);
+        assert_eq!(
+            "bar@test.js:3:21\nfoo@test.js:5:17\n@test.js:8:16\n".to_string(),
+            str_stack
+        );
+
+        args.rval().set(UndefinedValue());
+        true
+    }
+
     let engine = JSEngine::init().unwrap();
     let runtime = Runtime::new(engine.handle());
     let context = runtime.cx();
@@ -60,20 +79,92 @@ fn capture_stack() {
     }
 }
 
-unsafe extern "C" fn print_stack(context: *mut JSContext, argc: u32, vp: *mut Value) -> bool {
-    let args = CallArgs::from_vp(vp, argc);
+#[test]
+fn iterate_stack_frames() {
+    unsafe extern "C" fn assert_stack_state(
+        context: *mut JSContext,
+        argc: u32,
+        vp: *mut Value,
+    ) -> bool {
+        let mut function_names = vec![];
+        capture_stack!(in(context) let stack);
+        stack.unwrap().for_each_stack_frame(|frame| {
+            rooted!(in(context) let mut result: *mut jsapi::JSString = ptr::null_mut());
 
-    capture_stack!(in(context) let stack);
-    let str_stack = stack
-        .unwrap()
-        .as_string(None, StackFormat::SpiderMonkey)
-        .unwrap();
-    println!("{}", str_stack);
-    assert_eq!(
-        "bar@test.js:3:21\nfoo@test.js:5:17\n@test.js:8:16\n".to_string(),
-        str_stack
-    );
+            // Get function name
+            unsafe {
+                jsapi::GetSavedFrameFunctionDisplayName(
+                    context,
+                    ptr::null_mut(),
+                    frame.into(),
+                    result.handle_mut().into(),
+                    jsapi::SavedFrameSelfHosted::Include,
+                );
+            }
+            let buffer = if !result.is_null() {
+                let mut buffer = vec![0; 3];
+                jsapi::JS_EncodeStringToBuffer(context, *result, buffer.as_mut_ptr(), 3);
+                Some(buffer.into_iter().map(|c| c as u8).collect())
+            } else {
+                None
+            };
+            function_names.push(buffer);
+        });
 
-    args.rval().set(UndefinedValue());
-    true
+        assert_eq!(function_names.len(), 4);
+        assert_eq!(function_names[0], Some(b"baz".to_vec()));
+        assert_eq!(function_names[1], Some(b"bar".to_vec()));
+        assert_eq!(function_names[2], Some(b"foo".to_vec()));
+        assert_eq!(function_names[3], None);
+
+        true
+    }
+
+    let engine = JSEngine::init().unwrap();
+    let runtime = Runtime::new(engine.handle());
+    let context = runtime.cx();
+    #[cfg(feature = "debugmozjs")]
+    unsafe {
+        mozjs::jsapi::SetGCZeal(context, 2, 1);
+    }
+    let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
+    let c_option = RealmOptions::default();
+
+    unsafe {
+        rooted!(in(context) let global = JS_NewGlobalObject(
+            context,
+            &SIMPLE_GLOBAL_CLASS,
+            ptr::null_mut(),
+            h_option,
+            &*c_option,
+        ));
+        let _ac = JSAutoRealm::new(context, global.get());
+
+        let function = JS_DefineFunction(
+            context,
+            global.handle().into(),
+            c"assert_stack_state".as_ptr(),
+            Some(assert_stack_state),
+            0,
+            0,
+        );
+        assert!(!function.is_null());
+
+        let javascript = "
+            function foo() {
+                function bar() {
+                    function baz() {
+                        assert_stack_state();
+                    }
+                    baz();
+                }
+                bar();
+            }
+            foo();
+        ";
+        rooted!(in(context) let mut rval = UndefinedValue());
+        assert!(runtime
+            .evaluate_script(global.handle(), javascript, "test.js", 0, rval.handle_mut())
+            .is_ok());
+    }
 }

--- a/mozjs/tests/iterate_stack.rs
+++ b/mozjs/tests/iterate_stack.rs
@@ -1,0 +1,99 @@
+use std::ptr;
+
+use mozjs::{
+    capture_stack,
+    jsapi::{self, JSAutoRealm, JSContext, OnNewGlobalHookOption, Value},
+    jsval::UndefinedValue,
+    rooted,
+    rust::{JSEngine, RealmOptions, Runtime, SIMPLE_GLOBAL_CLASS},
+};
+
+#[test]
+fn iterate_stack_frames() {
+    unsafe extern "C" fn assert_stack_state(
+        context: *mut JSContext,
+        _argc: u32,
+        _vp: *mut Value,
+    ) -> bool {
+        let mut function_names = vec![];
+        capture_stack!(in(context) let stack);
+        stack.unwrap().for_each_stack_frame(|frame| {
+            rooted!(in(context) let mut result: *mut jsapi::JSString = ptr::null_mut());
+
+            // Get function name
+            unsafe {
+                jsapi::GetSavedFrameFunctionDisplayName(
+                    context,
+                    ptr::null_mut(),
+                    frame.into(),
+                    result.handle_mut().into(),
+                    jsapi::SavedFrameSelfHosted::Include,
+                );
+            }
+            let buffer = if !result.is_null() {
+                let mut buffer = vec![0; 3];
+                jsapi::JS_EncodeStringToBuffer(context, *result, buffer.as_mut_ptr(), 3);
+                Some(buffer.into_iter().map(|c| c as u8).collect())
+            } else {
+                None
+            };
+            function_names.push(buffer);
+        });
+
+        assert_eq!(function_names.len(), 4);
+        assert_eq!(function_names[0], Some(b"baz".to_vec()));
+        assert_eq!(function_names[1], Some(b"bar".to_vec()));
+        assert_eq!(function_names[2], Some(b"foo".to_vec()));
+        assert_eq!(function_names[3], None);
+
+        true
+    }
+
+    let engine = JSEngine::init().unwrap();
+    let runtime = Runtime::new(engine.handle());
+    let context = runtime.cx();
+    #[cfg(feature = "debugmozjs")]
+    unsafe {
+        mozjs::jsapi::SetGCZeal(context, 2, 1);
+    }
+    let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
+    let c_option = RealmOptions::default();
+
+    unsafe {
+        rooted!(in(context) let global = jsapi::JS_NewGlobalObject(
+            context,
+            &SIMPLE_GLOBAL_CLASS,
+            ptr::null_mut(),
+            h_option,
+            &*c_option,
+        ));
+        let _ac = JSAutoRealm::new(context, global.get());
+
+        let function = jsapi::JS_DefineFunction(
+            context,
+            global.handle().into(),
+            c"assert_stack_state".as_ptr(),
+            Some(assert_stack_state),
+            0,
+            0,
+        );
+        assert!(!function.is_null());
+
+        let javascript = "
+            function foo() {
+                function bar() {
+                    function baz() {
+                        assert_stack_state();
+                    }
+                    baz();
+                }
+                bar();
+            }
+            foo();
+        ";
+        rooted!(in(context) let mut rval = UndefinedValue());
+        assert!(runtime
+            .evaluate_script(global.handle(), javascript, "test.js", 0, rval.handle_mut())
+            .is_ok());
+    }
+}

--- a/mozjs/tests/jsvalue.rs
+++ b/mozjs/tests/jsvalue.rs
@@ -4,11 +4,8 @@
 
 use std::ptr;
 
-use mozjs::jsapi::{JSAutoRealm, JSObject, JS_NewGlobalObject, OnNewGlobalHookOption, Type};
-use mozjs::jsval::{
-    BigIntValue, BooleanValue, DoubleValue, Int32Value, NullValue, ObjectValue, StringValue,
-    UndefinedValue,
-};
+use mozjs::jsapi::{JS_NewGlobalObject, OnNewGlobalHookOption};
+use mozjs::jsval::{BooleanValue, DoubleValue, Int32Value, NullValue, UndefinedValue};
 use mozjs::rooted;
 use mozjs::rust::{
     HandleObject, JSEngine, RealmOptions, RootedGuard, Runtime, SIMPLE_GLOBAL_CLASS,


### PR DESCRIPTION
This adds `CapturedJSStack::for_each_stack_frame` which calls the provided closure for each element in the linked list of `SavedFrame`s. Unfortunately, I don't think there's an easy way to make this an iterator over `SavedFrame`s, because of the lifetime associated with a `RootedGuard`.

`for_each_stack_frame` is useful for providing js backtraces in functions like `console.trace`.