### PR TITLE
Allow returning null context pointers from Runtime::get().

### DIFF
--- a/mozjs/src/rust.rs
+++ b/mozjs/src/rust.rs
@@ -12,7 +12,7 @@ use std::ffi::CStr;
 use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 use std::ops::{Deref, DerefMut};
-use std::ptr;
+use std::ptr::{self, NonNull};
 use std::slice;
 use std::str;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -303,10 +303,9 @@ pub struct Runtime {
 
 impl Runtime {
     /// Get the `JSContext` for this thread.
-    pub fn get() -> *mut JSContext {
+    pub fn get() -> Option<NonNull<JSContext>> {
         let cx = CONTEXT.with(|context| context.get());
-        assert!(!cx.is_null());
-        cx
+        NonNull::new(cx)
     }
 
     /// Create a [`ThreadSafeJSContext`] that can detect when this `Runtime` is destroyed.

--- a/mozjs/tests/runtime.rs
+++ b/mozjs/tests/runtime.rs
@@ -40,7 +40,7 @@ fn runtime() {
     let (sender, receiver) = channel();
     thread::spawn(move || {
         let runtime = unsafe { Runtime::create_with_parent(parent) };
-        assert!(!Runtime::get().is_null());
+        assert!(Runtime::get().is_some());
         drop(runtime);
         let _ = sender.send(());
     });
@@ -48,7 +48,7 @@ fn runtime() {
 }
 
 unsafe extern "C" fn finalize(_fop: *mut GCContext, _object: *mut JSObject) {
-    assert!(!Runtime::get().is_null());
+    assert!(Runtime::get().is_some());
 }
 
 static CLASS_OPS: JSClassOps = JSClassOps {


### PR DESCRIPTION
This assertion fails in various tests and real browser usage, because it's still possible to call this API while shutdown is in progress. Instead of asserting against a valid use, we can use the type system to ensure that callers make informed choices.