### PR TITLE
Fixed Windows `jsglue` Builds with Define for Built-in `offsetof`

### DIFF
--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -781,7 +781,12 @@ mod jsglue {
             .clang_args(["-include", &confdefs_path.to_str().expect("UTF-8")]);
 
         if msvc {
-            builder = builder.clang_args(["-fms-compatibility", "-DWIN32", "-std=c++17"])
+            builder = builder.clang_args([
+                "-fms-compatibility",
+                "-DWIN32",
+                "-D_CRT_USE_BUILTIN_OFFSETOF",
+                "-std=c++17",
+            ])
         } else {
             builder = builder.clang_args(["-fPIC", "-fno-rtti", "-std=c++17"])
         }


### PR DESCRIPTION
Adds `-D_CRT_USE_BUILTIN_OFFSETOF` for `jsglue` during the `bindgen` phase.
When building for `aarch64-pc-windows-msvc` with llvm 19, I had 12 errors as a result of `offsetof` not being `constexpr` compatible.

Examples of code which caused the errors:
<https://searchfox.org/mozilla-central/source/js/public/Proxy.h#459>
<https://searchfox.org/mozilla-central/source/mfbt/HashFunctions.h#367>

<details>

```shell
D:\a\spiderfire\spiderfire\target\aarch64-pc-windows-msvc\release\build\mozjs_sys-cbcf24600a385d3e\out\build\dist/include\mozilla/HashFunctions.h:367:27: error: constexpr function never produces a constant expression [-Winvalid-constexpr]
D:\a\spiderfire\spiderfire\target\aarch64-pc-windows-msvc\release\build\mozjs_sys-cbcf24600a385d3e\out\build\dist/include\mozilla/HashFunctions.h:371:27: error: constexpr function never produces a constant expression [-Winvalid-constexpr]
D:\a\spiderfire\spiderfire\target\aarch64-pc-windows-msvc\release\build\mozjs_sys-cbcf24600a385d3e\out\build\dist/include\js/Proxy.h:444:27: error: constexpr function never produces a constant expression [-Winvalid-constexpr]
D:\a\spiderfire\spiderfire\target\aarch64-pc-windows-msvc\release\build\mozjs_sys-cbcf24600a385d3e\out\build\dist/include\js/Proxy.h:449:19: error: static assertion expression is not an integral constant expression
D:\a\spiderfire\spiderfire\target\aarch64-pc-windows-msvc\release\build\mozjs_sys-cbcf24600a385d3e\out\build\dist/include\js/Proxy.h:461:41: error: constexpr function never produces a constant expression [-Winvalid-constexpr]
D:\a\spiderfire\spiderfire\target\aarch64-pc-windows-msvc\release\build\mozjs_sys-cbcf24600a385d3e\out\build\dist/include\js/Proxy.h:727:20: error: constexpr variable 'numSlots' must be initialized by a constant expression
D:\a\spiderfire\spiderfire\target\aarch64-pc-windows-msvc\release\build\mozjs_sys-cbcf24600a385d3e\out\build\dist/include\js/experimental/JitInfo.h:116:27: error: constexpr variable 'offsetOfArgv' must be initialized by a constant expression
D:\a\spiderfire\spiderfire\target\aarch64-pc-windows-msvc\release\build\mozjs_sys-cbcf24600a385d3e\out\build\dist/include\js/experimental/JitInfo.h:117:27: error: constexpr variable 'offsetOfArgc' must be initialized by a constant expression
C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0\ucrt\stddef.h:47:31: error: static assertion expression is not an integral constant expression
D:\a\spiderfire\spiderfire\target\aarch64-pc-windows-msvc\release\build\mozjs_sys-cbcf24600a385d3e\out\build\dist/include\js/Proxy.h:727:20: error: constexpr variable 'numSlots' must be initialized by a constant expression
D:\a\spiderfire\spiderfire\target\aarch64-pc-windows-msvc\release\build\mozjs_sys-cbcf24600a385d3e\out\build\dist/include\js/Proxy.h:732:17: error: static assertion expression is not an integral constant expression
```

</details>