### PR TITLE
Indicate to the compiler that Rooted<T> may be uninitialized

### DIFF
--- a/mozjs-sys/src/jsgc.rs
+++ b/mozjs-sys/src/jsgc.rs
@@ -104,7 +104,7 @@ pub trait Rootable: crate::trace::Traceable + Sized {
     unsafe extern "C" fn trace(this: *mut c_void, trc: *mut JSTracer, _name: *const c_char) {
         let rooted = this as *mut Rooted<Self>;
         let rooted = rooted.as_mut().unwrap();
-        <Self as crate::trace::Traceable>::trace(&mut rooted.ptr, trc);
+        <Self as crate::trace::Traceable>::trace(rooted.ptr.assume_init_mut(), trc);
     }
 }
 
@@ -132,7 +132,11 @@ pub struct RootedBase {
 pub struct Rooted<T: RootKind> {
     pub vtable: T::Vtable,
     pub base: RootedBase,
-    pub ptr: T,
+
+    /// The rooted value
+    ///
+    /// This will be initialied iff there is a `RootedGuard` for this `Rooted`
+    pub ptr: mem::MaybeUninit<T>,
 }
 
 /// Trait that provides a GC-safe default value for the given type, if one exists.

--- a/mozjs-sys/src/jsimpls.rs
+++ b/mozjs-sys/src/jsimpls.rs
@@ -25,6 +25,7 @@ use crate::jsid::VoidId;
 use crate::jsval::{JSVal, UndefinedValue};
 
 use std::marker::PhantomData;
+use std::mem;
 use std::ops::Deref;
 use std::ops::DerefMut;
 use std::ptr;
@@ -143,7 +144,7 @@ impl<const N: usize> From<&Rooted<ValueArray<N>>> for JS::HandleValueArray {
     fn from(array: &Rooted<ValueArray<N>>) -> JS::HandleValueArray {
         JS::HandleValueArray {
             length_: N,
-            elements_: unsafe { array.ptr.get_ptr() },
+            elements_: unsafe { array.ptr.assume_init_ref().get_ptr() },
         }
     }
 }
@@ -435,7 +436,7 @@ impl<T: RootKind> JS::Rooted<T> {
                 stack: ptr::null_mut(),
                 prev: ptr::null_mut(),
             },
-            ptr: unsafe { std::mem::zeroed() },
+            ptr: mem::MaybeUninit::zeroed(),
         }
     }
 

--- a/mozjs/src/conversions.rs
+++ b/mozjs/src/conversions.rs
@@ -713,7 +713,7 @@ impl<C: Clone, T: FromJSValConvertible<Config = C>> FromJSValConvertible for Vec
             return Err(());
         }
 
-        if iterator.iterator.ptr.is_null() {
+        if iterator.iterator.ptr.assume_init_ref().is_null() {
             return Ok(ConversionResult::Failure("Value is not iterable".into()));
         }
 


### PR DESCRIPTION
Wraps `Rooted::ptr` in `MaybeUninit` so it can safely be zero-initialized.

Fixes #548