### PR TITLE
Add JSContext wrapper for bindings with fewer raw pointers.

### DIFF
--- a/mozjs/examples/eval.rs
+++ b/mozjs/examples/eval.rs
@@ -23,8 +23,9 @@ use mozjs::rust::{JSEngine, RealmOptions, Runtime};
 
 fn run(rt: Runtime) {
     let options = RealmOptions::default();
-    rooted!(in(rt.cx()) let global = unsafe {
-        JS_NewGlobalObject(rt.cx(), &SIMPLE_GLOBAL_CLASS, ptr::null_mut(),
+    let cx = rt.cx();
+    rooted!(in(*cx) let global = unsafe {
+        JS_NewGlobalObject(*cx, &SIMPLE_GLOBAL_CLASS, ptr::null_mut(),
                            OnNewGlobalHookOption::FireOnNewGlobalHook,
                            &*options)
     });
@@ -37,7 +38,7 @@ fn run(rt: Runtime) {
      * The return value comes back here. If it could be a GC thing, you must add it to the
      * GC's "root set" with the rooted! macro.
      */
-    rooted!(in(rt.cx()) let mut rval = UndefinedValue());
+    rooted!(in(*cx) let mut rval = UndefinedValue());
 
     /*
      * Some example source in a string. This is equivalent to JS_EvaluateScript in C++.

--- a/mozjs/examples/minimal.rs
+++ b/mozjs/examples/minimal.rs
@@ -40,8 +40,8 @@ fn run(rt: Runtime) {
     // This demonstrates the way Rust uses the C++ garbage collector: using the rooted! macro to
     // indicate when the GC can collect them.
     let options = RealmOptions::default();
-    rooted!(in(cx) let _global = unsafe {
-        JS_NewGlobalObject(cx, &SIMPLE_GLOBAL_CLASS, ptr::null_mut(),
+    rooted!(in(*cx) let _global = unsafe {
+        JS_NewGlobalObject(*cx, &SIMPLE_GLOBAL_CLASS, ptr::null_mut(),
                            OnNewGlobalHookOption::FireOnNewGlobalHook,
                            &*options)
     });

--- a/mozjs/examples/wasm.rs
+++ b/mozjs/examples/wasm.rs
@@ -47,34 +47,35 @@ unsafe extern "C" fn bar(_cx: *mut JSContext, argc: u32, vp: *mut Value) -> bool
 
 fn run(rt: Runtime) {
     let options = RealmOptions::default();
-    rooted!(in(rt.cx()) let global = unsafe {
-        JS_NewGlobalObject(rt.cx(), &SIMPLE_GLOBAL_CLASS, ptr::null_mut(),
+    let cx = rt.cx();
+    rooted!(in(*cx) let global = unsafe {
+        JS_NewGlobalObject(*cx, &SIMPLE_GLOBAL_CLASS, ptr::null_mut(),
                            OnNewGlobalHookOption::FireOnNewGlobalHook,
                            &*options)
     });
-    let _ac = JSAutoRealm::new(rt.cx(), global.get());
+    let _ac = JSAutoRealm::new(*cx, global.get());
 
     // Get WebAssembly.Module and WebAssembly.Instance constructors.
-    rooted!(in(rt.cx()) let mut wasm = UndefinedValue());
-    rooted!(in(rt.cx()) let mut wasm_module = UndefinedValue());
-    rooted!(in(rt.cx()) let mut wasm_instance = UndefinedValue());
+    rooted!(in(*cx) let mut wasm = UndefinedValue());
+    rooted!(in(*cx) let mut wasm_module = UndefinedValue());
+    rooted!(in(*cx) let mut wasm_instance = UndefinedValue());
 
     unsafe {
         assert!(JS_GetProperty(
-            rt.cx(),
+            *cx,
             global.handle(),
             c"WebAssembly".as_ptr(),
             &mut wasm.handle_mut()
         ));
-        rooted!(in(rt.cx()) let mut wasm_obj = wasm.to_object());
+        rooted!(in(*cx) let mut wasm_obj = wasm.to_object());
         assert!(JS_GetProperty(
-            rt.cx(),
+            *cx,
             wasm_obj.handle(),
             c"Module".as_ptr(),
             &mut wasm_module.handle_mut()
         ));
         assert!(JS_GetProperty(
-            rt.cx(),
+            *cx,
             wasm_obj.handle(),
             c"Instance".as_ptr(),
             &mut wasm_instance.handle_mut()
@@ -84,20 +85,20 @@ fn run(rt: Runtime) {
         assert!(HI_WASM.0.as_ptr() as usize % 8 == 0);
 
         // Construct Wasm module from bytes.
-        rooted!(in(rt.cx()) let mut module = null_mut::<JSObject>());
+        rooted!(in(*cx) let mut module = null_mut::<JSObject>());
         {
             let array_buffer = JS::NewArrayBufferWithUserOwnedContents(
-                rt.cx(),
+                *cx,
                 HI_WASM.0.len(),
                 HI_WASM.0.as_ptr() as _,
             );
             assert!(!array_buffer.is_null());
 
-            rooted!(in(rt.cx()) let val = ObjectValue(array_buffer));
+            rooted!(in(*cx) let val = ObjectValue(array_buffer));
             let args = HandleValueArray::from(val.handle().into_handle());
 
             assert!(Construct1(
-                rt.cx(),
+                *cx,
                 wasm_module.handle(),
                 &args,
                 &mut module.handle_mut()
@@ -105,13 +106,13 @@ fn run(rt: Runtime) {
         }
 
         // Construct Wasm module instance with required imports.
-        rooted!(in(rt.cx()) let mut instance = null_mut::<JSObject>());
+        rooted!(in(*cx) let mut instance = null_mut::<JSObject>());
         {
             // Build "env" imports object.
-            rooted!(in(rt.cx()) let mut env_import_obj = JS_NewPlainObject(rt.cx()));
+            rooted!(in(*cx) let mut env_import_obj = JS_NewPlainObject(*cx));
             assert!(!env_import_obj.is_null());
             let function = JS_DefineFunction(
-                rt.cx(),
+                *cx,
                 env_import_obj.handle().into(),
                 c"bar".as_ptr(),
                 Some(bar),
@@ -119,21 +120,21 @@ fn run(rt: Runtime) {
                 0,
             );
             assert!(!function.is_null());
-            rooted!(in(rt.cx()) let mut env_import = ObjectValue(env_import_obj.get()));
+            rooted!(in(*cx) let mut env_import = ObjectValue(env_import_obj.get()));
             // Build imports bag.
-            rooted!(in(rt.cx()) let mut imports = JS_NewPlainObject(rt.cx()));
+            rooted!(in(*cx) let mut imports = JS_NewPlainObject(*cx));
             assert!(!imports.is_null());
             assert!(JS_SetProperty(
-                rt.cx(),
+                *cx,
                 imports.handle(),
                 c"env".as_ptr(),
                 env_import.handle()
             ));
 
-            rooted!(in(rt.cx()) let mut args = ValueArray::new([ObjectValue(module.get()), ObjectValue(imports.get())]));
+            rooted!(in(*cx) let mut args = ValueArray::new([ObjectValue(module.get()), ObjectValue(imports.get())]));
 
             assert!(Construct1(
-                rt.cx(),
+                *cx,
                 wasm_instance.handle(),
                 &HandleValueArray::from(&args),
                 &mut instance.handle_mut()
@@ -141,28 +142,28 @@ fn run(rt: Runtime) {
         }
 
         // Find `foo` method in exports.
-        rooted!(in(rt.cx()) let mut exports = UndefinedValue());
+        rooted!(in(*cx) let mut exports = UndefinedValue());
 
         assert!(JS_GetProperty(
-            rt.cx(),
+            *cx,
             instance.handle(),
             c"exports".as_ptr(),
             &mut exports.handle_mut()
         ));
 
-        rooted!(in(rt.cx()) let mut exports_obj = exports.to_object());
-        rooted!(in(rt.cx()) let mut foo = UndefinedValue());
+        rooted!(in(*cx) let mut exports_obj = exports.to_object());
+        rooted!(in(*cx) let mut foo = UndefinedValue());
         assert!(JS_GetProperty(
-            rt.cx(),
+            *cx,
             exports_obj.handle(),
             c"foo".as_ptr(),
             &mut foo.handle_mut()
         ));
 
         // call foo and get its result
-        rooted!(in(rt.cx()) let mut rval = UndefinedValue());
+        rooted!(in(*cx) let mut rval = UndefinedValue());
         assert!(Call(
-            rt.cx(),
+            *cx,
             JS::UndefinedHandleValue,
             foo.handle().into(),
             &HandleValueArray::empty(),

--- a/mozjs/src/lib.rs
+++ b/mozjs/src/lib.rs
@@ -46,6 +46,7 @@ pub mod jsapi {
 pub mod rust;
 
 mod consts;
+pub mod context;
 pub mod conversions;
 pub mod error;
 pub mod gc;

--- a/mozjs/tests/callback.rs
+++ b/mozjs/tests/callback.rs
@@ -20,23 +20,23 @@ fn callback() {
     let context = runtime.cx();
     #[cfg(feature = "debugmozjs")]
     unsafe {
-        mozjs::jsapi::SetGCZeal(context, 2, 1);
+        mozjs::jsapi::SetGCZeal(*context, 2, 1);
     }
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = RealmOptions::default();
 
     unsafe {
-        rooted!(in(context) let global = JS_NewGlobalObject(
-            context,
+        rooted!(in(*context) let global = JS_NewGlobalObject(
+            *context,
             &SIMPLE_GLOBAL_CLASS,
             ptr::null_mut(),
             h_option,
             &*c_option,
         ));
-        let _ac = JSAutoRealm::new(context, global.get());
+        let _ac = JSAutoRealm::new(*context, global.get());
 
         let function = JS_DefineFunction(
-            context,
+            *context,
             global.handle().into(),
             c"puts".as_ptr(),
             Some(puts),
@@ -46,7 +46,7 @@ fn callback() {
         assert!(!function.is_null());
 
         let javascript = "puts('Test Iñtërnâtiônàlizætiøn ┬─┬ノ( º _ ºノ) ');";
-        rooted!(in(context) let mut rval = UndefinedValue());
+        rooted!(in(*context) let mut rval = UndefinedValue());
         assert!(runtime
             .evaluate_script(global.handle(), javascript, "test.js", 0, rval.handle_mut())
             .is_ok());

--- a/mozjs/tests/capture_stack.rs
+++ b/mozjs/tests/capture_stack.rs
@@ -36,23 +36,23 @@ fn capture_stack() {
     let context = runtime.cx();
     #[cfg(feature = "debugmozjs")]
     unsafe {
-        mozjs::jsapi::SetGCZeal(context, 2, 1);
+        mozjs::jsapi::SetGCZeal(*context, 2, 1);
     }
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = RealmOptions::default();
 
     unsafe {
-        rooted!(in(context) let global = JS_NewGlobalObject(
-            context,
+        rooted!(in(*context) let global = JS_NewGlobalObject(
+            *context,
             &SIMPLE_GLOBAL_CLASS,
             ptr::null_mut(),
             h_option,
             &*c_option,
         ));
-        let _ac = JSAutoRealm::new(context, global.get());
+        let _ac = JSAutoRealm::new(*context, global.get());
 
         let function = JS_DefineFunction(
-            context,
+            *context,
             global.handle().into(),
             c"print_stack".as_ptr(),
             Some(print_stack),
@@ -71,7 +71,7 @@ fn capture_stack() {
 
             foo(\"arg1-value\");
         ";
-        rooted!(in(context) let mut rval = UndefinedValue());
+        rooted!(in(*context) let mut rval = UndefinedValue());
         assert!(runtime
             .evaluate_script(global.handle(), javascript, "test.js", 0, rval.handle_mut())
             .is_ok());

--- a/mozjs/tests/custom_auto_rooter.rs
+++ b/mozjs/tests/custom_auto_rooter.rs
@@ -35,10 +35,10 @@ fn virtual_trace_called() {
     let context = runtime.cx();
 
     let mut rooter = CustomAutoRooter::new(TraceCheck::new());
-    let guard = rooter.root(context);
+    let guard = rooter.root(*context);
 
     unsafe {
-        JS_GC(context, GCReason::API);
+        JS_GC(*context, GCReason::API);
     }
 
     assert!(guard.trace_was_called.get());

--- a/mozjs/tests/custom_auto_rooter_macro.rs
+++ b/mozjs/tests/custom_auto_rooter_macro.rs
@@ -32,10 +32,10 @@ fn custom_auto_rooter_macro() {
     let runtime = Runtime::new(engine.handle());
     let context = runtime.cx();
 
-    auto_root!(in(context) let vec = vec![TraceCheck::new(), TraceCheck::new()]);
+    auto_root!(in(*context) let vec = vec![TraceCheck::new(), TraceCheck::new()]);
 
     unsafe {
-        JS_GC(context, GCReason::API);
+        JS_GC(*context, GCReason::API);
     }
 
     vec.iter()

--- a/mozjs/tests/enumerate.rs
+++ b/mozjs/tests/enumerate.rs
@@ -19,21 +19,21 @@ fn enumerate() {
     let context = runtime.cx();
     #[cfg(feature = "debugmozjs")]
     unsafe {
-        mozjs::jsapi::SetGCZeal(context, 2, 1);
+        mozjs::jsapi::SetGCZeal(*context, 2, 1);
     }
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = RealmOptions::default();
 
     unsafe {
-        rooted!(in(context) let global = JS_NewGlobalObject(
-            context,
+        rooted!(in(*context) let global = JS_NewGlobalObject(
+            *context,
             &SIMPLE_GLOBAL_CLASS,
             ptr::null_mut(),
             h_option,
             &*c_option,
         ));
 
-        rooted!(in(context) let mut rval = UndefinedValue());
+        rooted!(in(*context) let mut rval = UndefinedValue());
         assert!(runtime
             .evaluate_script(
                 global.handle(),
@@ -45,24 +45,24 @@ fn enumerate() {
             .is_ok());
         assert!(rval.is_object());
 
-        rooted!(in(context) let object = rval.to_object());
-        let mut ids = IdVector::new(context);
+        rooted!(in(*context) let object = rval.to_object());
+        let mut ids = IdVector::new(*context);
         assert!(GetPropertyKeys(
-            context,
+            *context,
             object.handle().into(),
             JSITER_OWNONLY,
             ids.handle_mut(),
         ));
 
         assert_eq!(ids.len(), 1);
-        rooted!(in(context) let id = ids[0]);
+        rooted!(in(*context) let id = ids[0]);
 
         assert!(id.is_string());
-        rooted!(in(context) let id = id.to_string());
+        rooted!(in(*context) let id = id.to_string());
 
         let mut matches = false;
         assert!(JS_StringEqualsAscii(
-            context,
+            *context,
             id.get(),
             c"a".as_ptr(),
             &mut matches

--- a/mozjs/tests/evaluate.rs
+++ b/mozjs/tests/evaluate.rs
@@ -16,21 +16,21 @@ fn evaluate() {
     let context = runtime.cx();
     #[cfg(feature = "debugmozjs")]
     unsafe {
-        mozjs::jsapi::SetGCZeal(context, 2, 1);
+        mozjs::jsapi::SetGCZeal(*context, 2, 1);
     }
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = RealmOptions::default();
 
     unsafe {
-        rooted!(in(context) let global = JS_NewGlobalObject(
-            context,
+        rooted!(in(*context) let global = JS_NewGlobalObject(
+            *context,
             &SIMPLE_GLOBAL_CLASS,
             ptr::null_mut(),
             h_option,
             &*c_option,
         ));
 
-        rooted!(in(context) let mut rval = UndefinedValue());
+        rooted!(in(*context) let mut rval = UndefinedValue());
         assert!(runtime
             .evaluate_script(global.handle(), "1 + 1", "test", 1, rval.handle_mut())
             .is_ok());

--- a/mozjs/tests/external_string.rs
+++ b/mozjs/tests/external_string.rs
@@ -21,20 +21,20 @@ fn external_string() {
     let context = runtime.cx();
     #[cfg(feature = "debugmozjs")]
     unsafe {
-        mozjs::jsapi::SetGCZeal(context, 2, 1);
+        mozjs::jsapi::SetGCZeal(*context, 2, 1);
     }
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = RealmOptions::default();
 
     unsafe {
-        rooted!(in(context) let global = JS_NewGlobalObject(
-            context,
+        rooted!(in(*context) let global = JS_NewGlobalObject(
+            *context,
             &SIMPLE_GLOBAL_CLASS,
             ptr::null_mut(),
             h_option,
             &*c_option,
         ));
-        let _ac = JSAutoRealm::new(context, global.get());
+        let _ac = JSAutoRealm::new(*context, global.get());
 
         let latin1_base = "test latin-1";
         let latin1_boxed = latin1_base.as_bytes().to_vec().into_boxed_slice();
@@ -44,13 +44,13 @@ fn external_string() {
             &EXTERNAL_STRING_CALLBACKS_TRAPS,
             latin1_base.len() as *mut c_void,
         );
-        rooted!(in(context) let latin1_jsstr = JS_NewExternalStringLatin1(
-            context,
+        rooted!(in(*context) let latin1_jsstr = JS_NewExternalStringLatin1(
+            *context,
             latin1_chars,
             latin1_base.len(),
             callbacks
         ));
-        assert_eq!(jsstr_to_string(context, latin1_jsstr.get()), latin1_base);
+        assert_eq!(jsstr_to_string(*context, latin1_jsstr.get()), latin1_base);
 
         let utf16_base = "test utf-16 $€ \u{10437}\u{24B62}";
         let utf16_boxed = utf16_base
@@ -64,13 +64,13 @@ fn external_string() {
             &EXTERNAL_STRING_CALLBACKS_TRAPS,
             utf16_len as *mut c_void,
         );
-        rooted!(in(context) let utf16_jsstr = JS_NewExternalUCString(
-            context,
+        rooted!(in(*context) let utf16_jsstr = JS_NewExternalUCString(
+            *context,
             utf16_chars,
             utf16_len,
             callbacks
         ));
-        assert_eq!(jsstr_to_string(context, utf16_jsstr.get()), utf16_base);
+        assert_eq!(jsstr_to_string(*context, utf16_jsstr.get()), utf16_base);
     }
 }
 

--- a/mozjs/tests/iterate_stack.rs
+++ b/mozjs/tests/iterate_stack.rs
@@ -54,23 +54,23 @@ fn iterate_stack_frames() {
     let context = runtime.cx();
     #[cfg(feature = "debugmozjs")]
     unsafe {
-        mozjs::jsapi::SetGCZeal(context, 2, 1);
+        mozjs::jsapi::SetGCZeal(*context, 2, 1);
     }
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = RealmOptions::default();
 
     unsafe {
-        rooted!(in(context) let global = jsapi::JS_NewGlobalObject(
-            context,
+        rooted!(in(*context) let global = jsapi::JS_NewGlobalObject(
+            *context,
             &SIMPLE_GLOBAL_CLASS,
             ptr::null_mut(),
             h_option,
             &*c_option,
         ));
-        let _ac = JSAutoRealm::new(context, global.get());
+        let _ac = JSAutoRealm::new(*context, global.get());
 
         let function = jsapi::JS_DefineFunction(
-            context,
+            *context,
             global.handle().into(),
             c"assert_stack_state".as_ptr(),
             Some(assert_stack_state),
@@ -91,7 +91,7 @@ fn iterate_stack_frames() {
             }
             foo();
         ";
-        rooted!(in(context) let mut rval = UndefinedValue());
+        rooted!(in(*context) let mut rval = UndefinedValue());
         assert!(runtime
             .evaluate_script(global.handle(), javascript, "test.js", 0, rval.handle_mut())
             .is_ok());

--- a/mozjs/tests/jsvalue.rs
+++ b/mozjs/tests/jsvalue.rs
@@ -22,13 +22,13 @@ unsafe fn tester<F: Fn(RootedGuard<JSVal>)>(
     test: F,
 ) {
     let cx = rt.cx();
-    rooted!(in(cx) let mut rval = UndefinedValue());
+    rooted!(in(*cx) let mut rval = UndefinedValue());
     assert!(rt
         .evaluate_script(global, js, "test", 1, rval.handle_mut())
         .is_ok());
     test(rval);
 
-    rooted!(in(cx) let mut val = rust);
+    rooted!(in(*cx) let mut val = rust);
     test(val);
 }
 
@@ -39,14 +39,14 @@ fn jsvalues() {
     let context = runtime.cx();
     #[cfg(feature = "debugmozjs")]
     unsafe {
-        mozjs::jsapi::SetGCZeal(context, 2, 1);
+        mozjs::jsapi::SetGCZeal(*context, 2, 1);
     }
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = RealmOptions::default();
 
     unsafe {
-        rooted!(in(context) let global = JS_NewGlobalObject(
-            context,
+        rooted!(in(*context) let global = JS_NewGlobalObject(
+            *context,
             &SIMPLE_GLOBAL_CLASS,
             ptr::null_mut(),
             h_option,

--- a/mozjs/tests/panic.rs
+++ b/mozjs/tests/panic.rs
@@ -19,23 +19,23 @@ fn test_panic() {
     let context = runtime.cx();
     #[cfg(feature = "debugmozjs")]
     unsafe {
-        mozjs::jsapi::SetGCZeal(context, 2, 1);
+        mozjs::jsapi::SetGCZeal(*context, 2, 1);
     }
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = RealmOptions::default();
 
     unsafe {
-        rooted!(in(context) let global = JS_NewGlobalObject(
-            context,
+        rooted!(in(*context) let global = JS_NewGlobalObject(
+            *context,
             &SIMPLE_GLOBAL_CLASS,
             ptr::null_mut(),
             h_option,
             &*c_option,
         ));
-        let _ac = JSAutoRealm::new(context, global.get());
+        let _ac = JSAutoRealm::new(*context, global.get());
 
         let function = JS_DefineFunction(
-            context,
+            *context,
             global.handle().into(),
             c"test".as_ptr(),
             Some(test),
@@ -44,7 +44,7 @@ fn test_panic() {
         );
         assert!(!function.is_null());
 
-        rooted!(in(context) let mut rval = UndefinedValue());
+        rooted!(in(*context) let mut rval = UndefinedValue());
         let _ =
             runtime.evaluate_script(global.handle(), "test();", "test.js", 0, rval.handle_mut());
     }

--- a/mozjs/tests/property_descriptor.rs
+++ b/mozjs/tests/property_descriptor.rs
@@ -24,40 +24,40 @@ fn property_descriptor() {
 
     #[cfg(feature = "debugmozjs")]
     unsafe {
-        mozjs::jsapi::SetGCZeal(context, 2, 1);
+        mozjs::jsapi::SetGCZeal(*context, 2, 1);
     }
 
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = RealmOptions::default();
 
     unsafe {
-        rooted!(in(context) let global = JS_NewGlobalObject(
-            context,
+        rooted!(in(*context) let global = JS_NewGlobalObject(
+            *context,
             &SIMPLE_GLOBAL_CLASS,
             ptr::null_mut(),
             h_option,
             &*c_option,
         ));
-        let _ac = JSAutoRealm::new(context, global.get());
+        let _ac = JSAutoRealm::new(*context, global.get());
 
-        rooted!(in(context) let object = JS_NewPlainObject(context));
-        rooted!(in(context) let property = Int32Value(32));
+        rooted!(in(*context) let object = JS_NewPlainObject(*context));
+        rooted!(in(*context) let property = Int32Value(32));
 
         let attrs = (JSPROP_ENUMERATE | JSPROP_PERMANENT | JSPROP_READONLY) as u32;
         assert!(JS_DefineProperty(
-            context,
+            *context,
             object.handle().into(),
             c"property".as_ptr(),
             property.handle().into(),
             attrs
         ));
 
-        rooted!(in(context) let mut descriptor: PropertyDescriptor);
+        rooted!(in(*context) let mut descriptor: PropertyDescriptor);
 
-        rooted!(in(context) let mut holder: *mut JSObject = ptr::null_mut());
+        rooted!(in(*context) let mut holder: *mut JSObject = ptr::null_mut());
         let mut is_none = true;
         assert!(JS_GetPropertyDescriptor(
-            context,
+            *context,
             object.handle().into(),
             c"property".as_ptr(),
             descriptor.handle_mut().into(),
@@ -69,38 +69,38 @@ fn property_descriptor() {
         assert!(!descriptor.get().writable_());
         assert_eq!(descriptor.get().value_.to_int32(), 32);
 
-        rooted!(in(context) let mut desc = NullValue());
+        rooted!(in(*context) let mut desc = NullValue());
         assert!(FromPropertyDescriptor(
-            context,
+            *context,
             descriptor.handle().into(),
             desc.handle_mut().into()
         ));
-        rooted!(in(context) let desc_object = desc.to_object());
+        rooted!(in(*context) let desc_object = desc.to_object());
 
-        rooted!(in(context) let mut rval = NullValue());
+        rooted!(in(*context) let mut rval = NullValue());
         assert!(JS_GetProperty(
-            context,
+            *context,
             desc_object.handle().into(),
             c"value".as_ptr(),
             rval.handle_mut().into()
         ));
         assert_eq!(rval.get().to_int32(), 32);
         assert!(JS_GetProperty(
-            context,
+            *context,
             desc_object.handle().into(),
             c"configurable".as_ptr(),
             rval.handle_mut().into()
         ));
         assert!(!rval.get().to_boolean());
         assert!(JS_GetProperty(
-            context,
+            *context,
             desc_object.handle().into(),
             c"enumerable".as_ptr(),
             rval.handle_mut().into()
         ));
         assert!(rval.get().to_boolean());
         assert!(JS_GetProperty(
-            context,
+            *context,
             desc_object.handle().into(),
             c"writable".as_ptr(),
             rval.handle_mut().into()

--- a/mozjs/tests/rootable.rs
+++ b/mozjs/tests/rootable.rs
@@ -38,21 +38,21 @@ fn rooting() {
     let c_option = RealmOptions::default();
 
     unsafe {
-        SetGCZeal(context, 2, 1);
-        rooted!(in(context) let global = JS_NewGlobalObject(
-            context,
+        SetGCZeal(*context, 2, 1);
+        rooted!(in(*context) let global = JS_NewGlobalObject(
+            *context,
             &SIMPLE_GLOBAL_CLASS,
             ptr::null_mut(),
             h_option,
             &*c_option,
         ));
-        let _ac = JSAutoRealm::new(context, global.get());
+        let _ac = JSAutoRealm::new(*context, global.get());
 
-        rooted!(in(context) let prototype_proto = GetRealmObjectPrototype(context));
-        rooted!(in(context) let some_container = ContainsGCValue {
+        rooted!(in(*context) let prototype_proto = GetRealmObjectPrototype(context));
+        rooted!(in(*context) let some_container = ContainsGCValue {
             val: ObjectValue(prototype_proto.get())
         });
-        rooted!(in(context) let some_optional_container = Some(ContainsGCValue {
+        rooted!(in(*context) let some_optional_container = Some(ContainsGCValue {
             val: ObjectValue(prototype_proto.get())
         }));
         assert_eq!(some_container.val.to_object(), prototype_proto.get());

--- a/mozjs/tests/rooting.rs
+++ b/mozjs/tests/rooting.rs
@@ -27,30 +27,30 @@ fn rooting() {
     let c_option = RealmOptions::default();
 
     unsafe {
-        SetGCZeal(context, 2, 1);
-        rooted!(in(context) let global = JS_NewGlobalObject(
-            context,
+        SetGCZeal(*context, 2, 1);
+        rooted!(in(*context) let global = JS_NewGlobalObject(
+            *context,
             &SIMPLE_GLOBAL_CLASS,
             ptr::null_mut(),
             h_option,
             &*c_option,
         ));
-        let _ac = JSAutoRealm::new(context, global.get());
+        let _ac = JSAutoRealm::new(*context, global.get());
 
-        rooted!(in(context) let prototype_proto = GetRealmObjectPrototype(context));
-        rooted!(in(context) let proto = JS_NewObjectWithGivenProto(context, &CLASS as *const _, prototype_proto.handle().into()));
-        define_methods(context, proto.handle(), METHODS).unwrap();
+        rooted!(in(*context) let prototype_proto = GetRealmObjectPrototype(context));
+        rooted!(in(*context) let proto = JS_NewObjectWithGivenProto(*context, &CLASS as *const _, prototype_proto.handle().into()));
+        define_methods(*context, proto.handle(), METHODS).unwrap();
 
-        rooted!(in(context) let root: JSVal);
+        rooted!(in(*context) let root: JSVal);
         assert_eq!(root.get().is_undefined(), true);
 
-        rooted!(in(context) let root: *mut JSObject);
+        rooted!(in(*context) let root: *mut JSObject);
         assert_eq!(root.get().is_null(), true);
 
-        rooted!(in(context) let root: *mut JSString);
+        rooted!(in(*context) let root: *mut JSString);
         assert_eq!(root.get().is_null(), true);
 
-        rooted!(in(context) let root: *mut JSFunction);
+        rooted!(in(*context) let root: *mut JSFunction);
         assert_eq!(root.get().is_null(), true);
     }
 }

--- a/mozjs/tests/runtime.rs
+++ b/mozjs/tests/runtime.rs
@@ -19,21 +19,21 @@ fn runtime() {
     let context = runtime.cx();
     #[cfg(feature = "debugmozjs")]
     unsafe {
-        mozjs::jsapi::SetGCZeal(context, 2, 1);
+        mozjs::jsapi::SetGCZeal(*context, 2, 1);
     }
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = RealmOptions::default();
 
     unsafe {
-        rooted!(in(context) let global = JS_NewGlobalObject(
-            context,
+        rooted!(in(*context) let global = JS_NewGlobalObject(
+            *context,
             &SIMPLE_GLOBAL_CLASS,
             ptr::null_mut(),
             h_option,
             &*c_option,
         ));
-        let _ac = JSAutoRealm::new(context, global.get());
-        rooted!(in(context) let _object = JS_NewObject(context, &CLASS as *const _));
+        let _ac = JSAutoRealm::new(*context, global.get());
+        rooted!(in(*context) let _object = JS_NewObject(*context, &CLASS as *const _));
     }
 
     let parent = runtime.prepare_for_new_child();

--- a/mozjs/tests/stack_limit.rs
+++ b/mozjs/tests/stack_limit.rs
@@ -16,20 +16,20 @@ fn stack_limit() {
     let context = runtime.cx();
     #[cfg(feature = "debugmozjs")]
     unsafe {
-        mozjs::jsapi::SetGCZeal(context, 2, 1);
+        mozjs::jsapi::SetGCZeal(*context, 2, 1);
     }
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = RealmOptions::default();
 
     unsafe {
-        rooted!(in(context) let global = JS_NewGlobalObject(
-            context,
+        rooted!(in(*context) let global = JS_NewGlobalObject(
+            *context,
             &SIMPLE_GLOBAL_CLASS,
             ptr::null_mut(),
             h_option,
             &*c_option,
         ));
-        rooted!(in(context) let mut rval = UndefinedValue());
+        rooted!(in(*context) let mut rval = UndefinedValue());
         assert!(runtime
             .evaluate_script(
                 global.handle(),

--- a/mozjs/tests/typedarray.rs
+++ b/mozjs/tests/typedarray.rs
@@ -18,22 +18,22 @@ fn typedarray() {
     let context = runtime.cx();
     #[cfg(feature = "debugmozjs")]
     unsafe {
-        mozjs::jsapi::SetGCZeal(context, 2, 1);
+        mozjs::jsapi::SetGCZeal(*context, 2, 1);
     }
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = RealmOptions::default();
 
     unsafe {
-        rooted!(in(context) let global = JS_NewGlobalObject(
-            context,
+        rooted!(in(*context) let global = JS_NewGlobalObject(
+            *context,
             &SIMPLE_GLOBAL_CLASS,
             ptr::null_mut(),
             h_option,
             &*c_option,
         ));
-        let _ac = JSAutoRealm::new(context, global.get());
+        let _ac = JSAutoRealm::new(*context, global.get());
 
-        rooted!(in(context) let mut rval = UndefinedValue());
+        rooted!(in(*context) let mut rval = UndefinedValue());
         assert!(runtime
             .evaluate_script(
                 global.handle(),
@@ -45,51 +45,51 @@ fn typedarray() {
             .is_ok());
         assert!(rval.is_object());
 
-        typedarray!(in(context) let array: Uint8Array = rval.to_object());
+        typedarray!(in(*context) let array: Uint8Array = rval.to_object());
         assert_eq!(array.unwrap().as_slice(), &[0, 2, 4][..]);
 
-        typedarray!(in(context) let array: Uint8Array = rval.to_object());
+        typedarray!(in(*context) let array: Uint8Array = rval.to_object());
         assert_eq!(array.unwrap().len(), 3);
 
-        typedarray!(in(context) let array: Uint8Array = rval.to_object());
+        typedarray!(in(*context) let array: Uint8Array = rval.to_object());
         assert_eq!(array.unwrap().to_vec(), vec![0, 2, 4]);
 
-        typedarray!(in(context) let array: Uint16Array = rval.to_object());
+        typedarray!(in(*context) let array: Uint16Array = rval.to_object());
         assert!(array.is_err());
 
-        typedarray!(in(context) let view: ArrayBufferView = rval.to_object());
+        typedarray!(in(*context) let view: ArrayBufferView = rval.to_object());
         assert_eq!(view.unwrap().get_array_type(), Type::Uint8);
 
-        rooted!(in(context) let mut rval = ptr::null_mut::<JSObject>());
+        rooted!(in(*context) let mut rval = ptr::null_mut::<JSObject>());
         assert!(
-            Uint32Array::create(context, CreateWith::Slice(&[1, 3, 5]), rval.handle_mut()).is_ok()
+            Uint32Array::create(*context, CreateWith::Slice(&[1, 3, 5]), rval.handle_mut()).is_ok()
         );
 
-        typedarray!(in(context) let array: Uint32Array = rval.get());
+        typedarray!(in(*context) let array: Uint32Array = rval.get());
         assert_eq!(array.unwrap().as_slice(), &[1, 3, 5][..]);
 
-        typedarray!(in(context) let mut array: Uint32Array = rval.get());
+        typedarray!(in(*context) let mut array: Uint32Array = rval.get());
         array.as_mut().unwrap().update(&[2, 4, 6]);
         assert_eq!(array.unwrap().as_slice(), &[2, 4, 6][..]);
 
-        rooted!(in(context) let rval = ptr::null_mut::<JSObject>());
-        typedarray!(in(context) let array: Uint8Array = rval.get());
+        rooted!(in(*context) let rval = ptr::null_mut::<JSObject>());
+        typedarray!(in(*context) let array: Uint8Array = rval.get());
         assert!(array.is_err());
 
-        rooted!(in(context) let mut rval = ptr::null_mut::<JSObject>());
-        assert!(Uint32Array::create(context, CreateWith::Length(5), rval.handle_mut()).is_ok());
+        rooted!(in(*context) let mut rval = ptr::null_mut::<JSObject>());
+        assert!(Uint32Array::create(*context, CreateWith::Length(5), rval.handle_mut()).is_ok());
 
-        typedarray!(in(context) let array: Uint32Array = rval.get());
+        typedarray!(in(*context) let array: Uint32Array = rval.get());
         assert_eq!(array.unwrap().as_slice(), &[0, 0, 0, 0, 0]);
 
-        typedarray!(in(context) let mut array: Uint32Array = rval.get());
+        typedarray!(in(*context) let mut array: Uint32Array = rval.get());
         array.as_mut().unwrap().update(&[0, 1, 2, 3]);
         assert_eq!(array.unwrap().as_slice(), &[0, 1, 2, 3, 0]);
 
-        typedarray!(in(context) let view: ArrayBufferView = rval.get());
+        typedarray!(in(*context) let view: ArrayBufferView = rval.get());
         assert_eq!(view.unwrap().get_array_type(), Type::Uint32);
 
-        typedarray!(in(context) let view: ArrayBufferView = rval.get());
+        typedarray!(in(*context) let view: ArrayBufferView = rval.get());
         assert_eq!(view.unwrap().is_shared(), false);
     }
 }

--- a/mozjs/tests/typedarray_panic.rs
+++ b/mozjs/tests/typedarray_panic.rs
@@ -20,22 +20,22 @@ fn typedarray_update_panic() {
     let c_option = RealmOptions::default();
 
     unsafe {
-        rooted!(in(context) let global = JS_NewGlobalObject(
-            context,
+        rooted!(in(*context) let global = JS_NewGlobalObject(
+            *context,
             &SIMPLE_GLOBAL_CLASS,
             ptr::null_mut(),
             h_option,
             &*c_option,
         ));
-        let _ac = JSAutoRealm::new(context, global.get());
+        let _ac = JSAutoRealm::new(*context, global.get());
 
-        rooted!(in(context) let mut rval = ptr::null_mut::<JSObject>());
+        rooted!(in(*context) let mut rval = ptr::null_mut::<JSObject>());
         let _ = Uint32Array::create(
-            context,
+            *context,
             CreateWith::Slice(&[1, 2, 3, 4, 5]),
             rval.handle_mut(),
         );
-        typedarray!(in(context) let mut array: Uint32Array = rval.get());
+        typedarray!(in(*context) let mut array: Uint32Array = rval.get());
         array.as_mut().unwrap().update(&[0, 2, 4, 6, 8, 10]);
     }
 }

--- a/mozjs/tests/vec_conversion.rs
+++ b/mozjs/tests/vec_conversion.rs
@@ -22,35 +22,35 @@ fn vec_conversion() {
 
     #[cfg(feature = "debugmozjs")]
     unsafe {
-        mozjs::jsapi::SetGCZeal(context, 2, 1);
+        mozjs::jsapi::SetGCZeal(*context, 2, 1);
     }
 
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = RealmOptions::default();
 
     unsafe {
-        rooted!(in(context) let global = JS_NewGlobalObject(
-            context,
+        rooted!(in(*context) let global = JS_NewGlobalObject(
+            *context,
             &SIMPLE_GLOBAL_CLASS,
             ptr::null_mut(),
             h_option,
             &*c_option,
         ));
-        let _ac = JSAutoRealm::new(context, global.get());
-        assert!(InitRealmStandardClasses(context));
+        let _ac = JSAutoRealm::new(*context, global.get());
+        assert!(InitRealmStandardClasses(*context));
 
-        rooted!(in(context) let mut rval = UndefinedValue());
+        rooted!(in(*context) let mut rval = UndefinedValue());
 
         let orig_vec: Vec<f32> = vec![1.0, 2.9, 3.0];
-        orig_vec.to_jsval(context, rval.handle_mut());
-        let converted = Vec::<f32>::from_jsval(context, rval.handle(), ()).unwrap();
+        orig_vec.to_jsval(*context, rval.handle_mut());
+        let converted = Vec::<f32>::from_jsval(*context, rval.handle(), ()).unwrap();
 
         assert_eq!(&orig_vec, converted.get_success_value().unwrap());
 
         let orig_vec: Vec<i32> = vec![1, 2, 3];
-        orig_vec.to_jsval(context, rval.handle_mut());
+        orig_vec.to_jsval(*context, rval.handle_mut());
         let converted =
-            Vec::<i32>::from_jsval(context, rval.handle(), ConversionBehavior::Default).unwrap();
+            Vec::<i32>::from_jsval(*context, rval.handle(), ConversionBehavior::Default).unwrap();
 
         assert_eq!(&orig_vec, converted.get_success_value().unwrap());
 
@@ -64,14 +64,14 @@ fn vec_conversion() {
             )
             .is_ok());
         let converted =
-            Vec::<i32>::from_jsval(context, rval.handle(), ConversionBehavior::Default).unwrap();
+            Vec::<i32>::from_jsval(*context, rval.handle(), ConversionBehavior::Default).unwrap();
 
         assert_eq!(&orig_vec, converted.get_success_value().unwrap());
 
         assert!(runtime
             .evaluate_script(global.handle(), "({})", "test", 1, rval.handle_mut())
             .is_ok());
-        let converted = Vec::<i32>::from_jsval(context, rval.handle(), ConversionBehavior::Default);
+        let converted = Vec::<i32>::from_jsval(*context, rval.handle(), ConversionBehavior::Default);
         assert!(match converted {
             Ok(ConversionResult::Failure(_)) => true,
             _ => false,


### PR DESCRIPTION
This adapts the [JSContext](https://github.com/servo/servo/blob/d733abfca02cdb9fd2af4f0d82ff050e25f71829/components/script/script_runtime.rs#L893) type from Servo's bindings, making it more reliable because we can associate it directly with the underlying runtime wrapper.

This wrapper will enable us in the future to remove the unsafety from traits like ToJSValConvertible and FromJSValConvertible, as well as introduce higher-level wrappers of the JSAPI that do not require using unsafe.