### PR TITLE
Use Arc::get_mut instead of Arc::strong_count == 1

### DIFF
--- a/mozjs/src/rust.rs
+++ b/mozjs/src/rust.rs
@@ -431,9 +431,8 @@ impl Runtime {
 impl Drop for Runtime {
     fn drop(&mut self) {
         self.thread_safe_handle.write().unwrap().take();
-        assert_eq!(
-            Arc::strong_count(&self.outstanding_children),
-            1,
+        assert!(
+            Arc::get_mut(&mut self.outstanding_children).is_some(),
             "This runtime still has live children."
         );
         unsafe {


### PR DESCRIPTION
Arc::strong_count doesn't come with memory ordering guarantees. As such it should be possible to destory the context multiple times with the previous version of this check. I haven't actually seen or attempted to force that to happen, just came across this while reading code.

See https://github.com/rust-lang/rust/issues/117485

Note: The new code is slightly slower (3 atomic operations when only 1 should be necessary, because it checks for weak pointers as well). I can't imagine we care.