### PR TITLE
Arc should not be Traceable

### DIFF
--- a/mozjs-sys/src/trace.rs
+++ b/mozjs-sys/src/trace.rs
@@ -138,13 +138,6 @@ unsafe impl<T: Traceable> Traceable for Rc<T> {
     }
 }
 
-unsafe impl<T: Traceable> Traceable for Arc<T> {
-    #[inline]
-    unsafe fn trace(&self, trc: *mut JSTracer) {
-        (**self).trace(trc);
-    }
-}
-
 unsafe impl<T: Traceable + ?Sized> Traceable for Box<T> {
     #[inline]
     unsafe fn trace(&self, trc: *mut JSTracer) {


### PR DESCRIPTION
Traceable works under the assumption that only one thread will be looking at values. The entire purpose of `Arc` is to share things between threads. This never works (unless the Arc could be replaced by a Rc), and won't no matter how mutability is handled.

Nothing in this crate or servo uses this impl. Let's just delete this.