### PR TITLE
Fix all the warnings

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -27,6 +27,7 @@ debugmozjs = []
 profilemozjs = []
 jitspew = []
 crown = []
+oom_with_hook = []
 
 [dependencies]
 libc.workspace = true

--- a/mozjs-sys/src/glue.rs
+++ b/mozjs-sys/src/glue.rs
@@ -11,7 +11,7 @@ use core::mem;
 
 pub use generated::root::*;
 
-pub type EncodedStringCallback = fn(*const core::ffi::c_char);
+pub type EncodedStringCallback = unsafe extern "C" fn(*const core::ffi::c_char);
 
 // manual glue stuff
 unsafe impl Sync for ProxyTraps {}

--- a/mozjs-sys/src/lib.rs
+++ b/mozjs-sys/src/lib.rs
@@ -5,6 +5,7 @@
 #![allow(unused_extern_crates)]
 #![cfg_attr(feature = "crown", feature(register_tool))]
 #![cfg_attr(feature = "crown", register_tool(crown))]
+#![cfg_attr(feature = "oom_with_hook", feature(alloc_error_hook))]
 
 // These extern crates are needed for linking
 extern crate encoding_c;

--- a/mozjs-sys/src/trace.rs
+++ b/mozjs-sys/src/trace.rs
@@ -32,7 +32,6 @@ use std::sync::atomic::{
     AtomicBool, AtomicI16, AtomicI32, AtomicI64, AtomicI8, AtomicIsize, AtomicU16, AtomicU32,
     AtomicU64, AtomicU8, AtomicUsize,
 };
-use std::sync::Arc;
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant, SystemTime};
 

--- a/mozjs/src/lib.rs
+++ b/mozjs/src/lib.rs
@@ -31,6 +31,10 @@
 //!
 
 pub mod jsapi {
+    // Resolve ambiguous imports
+    pub use mozjs_sys::jsapi::js::detail;
+    pub use mozjs_sys::jsapi::JS::{FrontendContext, MemoryUse};
+
     pub use mozjs_sys::jsapi::glue::*;
     pub use mozjs_sys::jsapi::js::detail::*;
     pub use mozjs_sys::jsapi::js::*;

--- a/mozjs/tests/callback.rs
+++ b/mozjs/tests/callback.rs
@@ -64,12 +64,13 @@ unsafe extern "C" fn puts(context: *mut JSContext, argc: u32, vp: *mut Value) ->
     let arg = mozjs::rust::Handle::from_raw(args.get(0));
     let js = mozjs::rust::ToString(context, arg);
     rooted!(in(context) let message_root = js);
-    EncodeStringToUTF8(context, message_root.handle().into(), |message| {
+    unsafe extern "C" fn cb(message: *const core::ffi::c_char) {
         let message = CStr::from_ptr(message);
         let message = str::from_utf8(message.to_bytes()).unwrap();
         assert_eq!(message, "Test Iñtërnâtiônàlizætiøn ┬─┬ノ( º _ ºノ) ");
         println!("{}", message);
-    });
+    }
+    EncodeStringToUTF8(context, message_root.handle().into(), cb);
 
     args.rval().set(UndefinedValue());
     true


### PR DESCRIPTION
 - `alloc_error_hook` has evidently been unused for... quite awhile. As far as I can tell the code should still work, up to adding back (conditionally) a nightly feature, so I've done that. 
 - `EncodedStringCallback` is a function called from the C++ glue, it needs to be `extern "C"`. I've also marked this as an `unsafe` fn since it takes a raw pointer as an argument, and to be able to do anything with that it needs to be `unsafe`.
 -  Remove an unused import, this one is my fault.
 - jsapi has conflicting imports from two sets of bindgen, `js` and `JS` - currently this means that neither are imported. To silence these warnings, we pick one.
   - Both have a `mod detail` with different contents, `detail::*` is also re-exported for both, so just pick one arbitrarily.
   - `FrontendContext` exists and has different functions using it in both, the `JS` functions look more likely to be called via servo, so re-export that one.
   - `MemoryUse` exists in both, but only the `JS` one has any functions using it, so re-export that one. 