### PR TITLE
Implement `Copy` and `Clone` for `Handle<T>` where `T: !Copy`

### DIFF
--- a/mozjs/src/gc/root.rs
+++ b/mozjs/src/gc/root.rs
@@ -100,10 +100,17 @@ impl<'a, const N: usize> From<&RootedGuard<'a, ValueArray<N>>> for JS::HandleVal
     }
 }
 
-#[derive(Clone, Copy)]
 pub struct Handle<'a, T: 'a> {
     pub(crate) ptr: &'a T,
 }
+
+impl<T> Clone for Handle<'_, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T> Copy for Handle<'_, T> {}
 
 pub struct MutableHandle<'a, T: 'a> {
     pub(crate) ptr: *mut T,


### PR DESCRIPTION
Derive only derives these impls for types where the generics satisfy them, but shared references (and thus `Handle`) can implement them for any type `T`.

I've run into this a few times while playing around now, because `Cell` doesn't implement `Copy`. It's not entirely clear that users of the library will run into this, but at worst it doesn't hurt to define these generally.