### PR TITLE
Remove `Traceable for Value` impl

### DIFF
--- a/mozjs-sys/src/trace.rs
+++ b/mozjs-sys/src/trace.rs
@@ -109,13 +109,6 @@ unsafe impl Traceable for Heap<Value> {
     }
 }
 
-unsafe impl Traceable for Value {
-    #[inline]
-    unsafe fn trace(&self, trc: *mut JSTracer) {
-        CallValueRootTracer(trc, self as *const _ as *mut Self, c"value".as_ptr());
-    }
-}
-
 unsafe impl Traceable for Heap<jsid> {
     #[inline]
     unsafe fn trace(&self, trc: *mut JSTracer) {


### PR DESCRIPTION
I'm not sure this is the right approach, but pushing this for discussion purposes.

Accompanying servo branch [here](https://github.com/gmorenz/servo/tree/rooted_vec_heap_value)