### PR TITLE
Remove DerefMut impl for RootedGuard

### DIFF
--- a/mozjs/src/gc/root.rs
+++ b/mozjs/src/gc/root.rs
@@ -43,7 +43,13 @@ impl<'a, T: 'a + RootKind> RootedGuard<'a, T> {
     }
 
     pub fn handle_mut(&mut self) -> MutableHandle<T> {
-        unsafe { MutableHandle::from_marked_location(self.deref_mut()) }
+        unsafe { MutableHandle::from_marked_location(self.as_ptr()) }
+    }
+
+    pub fn as_ptr(&self) -> *mut T {
+        // SAFETY: self.root points to an inbounds allocation
+        unsafe { (&raw mut (*self.root).ptr).cast() }
+    }
     }
 
     pub fn get(&self) -> T

--- a/mozjs/src/gc/root.rs
+++ b/mozjs/src/gc/root.rs
@@ -128,6 +128,10 @@ impl<T> Clone for Handle<'_, T> {
 
 impl<T> Copy for Handle<'_, T> {}
 
+#[cfg_attr(
+    feature = "crown",
+    crown::unrooted_must_root_lint::allow_unrooted_interior
+)]
 pub struct MutableHandle<'a, T: 'a> {
     pub(crate) ptr: *mut T,
     anchor: PhantomData<&'a mut T>,


### PR DESCRIPTION
 - We no longer construct `MutableHandle` via `deref_mut`. Doing so meant that the raw pointer in `MutableHandle` was only valid for as long as the mutable reference created in `deref_mut` would be. I.e. until the next time GC runs. This is an extension of #564, and doesn't require a change in public API.
 - It removes the `deref_mut` impl entirely, as it's an unsafe footgun that isn't just marked as safe, but is silently invoked.
 - Creates a helper `take` function for `RootedGuard<Option<T>>`, since that was the primary use of `DerefMut` in servo, and is a safe thing to do.
 - It adds `allow_unrooted_interior` to `MutableHandle` because the accompanying servo PR requires that crown understand `MutableHandle` may point to things that must be rooted over GC passes.
 
Accompanying servo PR: https://github.com/servo/servo/pull/36158

 Addresses a small part of #569.