### PR TITLE
Remove DerefMut impl for Mutable Handle

### DIFF
--- a/mozjs/src/gc/root.rs
+++ b/mozjs/src/gc/root.rs
@@ -216,6 +216,14 @@ impl<'a, T> MutableHandle<'a, T> {
         unsafe { *self.ptr = v }
     }
 
+    /// Safety: GC must not run during the lifetime of the returned reference.
+    pub unsafe fn as_mut<'b>(&'b mut self) -> &'b mut T
+    where
+        'a: 'b,
+    {
+        &mut *(self.ptr)
+    }
+
     /// Creates a copy of this object, with a shorter lifetime, that holds a
     /// mutable borrow on the original object. When you write code that wants
     /// to use a `MutableHandle` more than once, you will typically need to
@@ -238,6 +246,13 @@ impl<'a, T> MutableHandle<'a, T> {
 
     pub(crate) fn raw(&mut self) -> RawMutableHandle<T> {
         unsafe { RawMutableHandle::from_marked_location(self.ptr) }
+    }
+}
+
+impl<'a, T> MutableHandle<'a, Option<T>> {
+    pub fn take(&mut self) -> Option<T> {
+        // Safety: No GC occurs during take call
+        unsafe { self.as_mut().take() }
     }
 }
 

--- a/mozjs/src/gc/root.rs
+++ b/mozjs/src/gc/root.rs
@@ -249,12 +249,6 @@ impl<'a, T> Deref for MutableHandle<'a, T> {
     }
 }
 
-impl<'a, T> DerefMut for MutableHandle<'a, T> {
-    fn deref_mut(&mut self) -> &mut T {
-        unsafe { &mut *self.ptr }
-    }
-}
-
 impl HandleValue<'static> {
     pub fn null() -> Self {
         unsafe { Self::from_raw(RawHandleValue::null()) }


### PR DESCRIPTION
Removes the `deref_mut` impl, and replaces it with an unsafe `as_mut` method. As discussed in #569 (and other recent issues) `deref_mut` is unsafe since it aliases with the GC, and cannot be made safe or marked unsafe.

The accompanying servo change (servo/servo#36160) does not need the `as_mut` method, it feels like an appropriate escape hatch to include though.

It also includes a `MutableHandle::<Option<_>>::take` method, since like in #572 that's a safe method, and #572's servo change results in it being used on `MutableHandle`.

Independent from (the obviously related) #572 and the similar incoming PR for `JS::MutableHandle`. Doing these all at roughly the same time feels like the right move, since otherwise we might accidentally encourage someone to convert from one of these types another to access the `DerefMut` function instead of using actual alternatives.