### PR TITLE
Remove DerefMut impl for `JS::MutableHandle`

### DIFF
--- a/mozjs-sys/src/jsimpls.rs
+++ b/mozjs-sys/src/jsimpls.rs
@@ -112,6 +112,13 @@ impl<T> JS::MutableHandle<T> {
     {
         unsafe { *self.ptr = v }
     }
+
+    /// The returned pointer is aliased by a pointer that the GC will read
+    /// through, and thus `&mut` references created from it must not be held
+    /// across GC pauses.
+    pub fn as_ptr(self) -> *mut T {
+        self.ptr
+    }
 }
 
 impl JS::HandleValue {

--- a/mozjs-sys/src/jsimpls.rs
+++ b/mozjs-sys/src/jsimpls.rs
@@ -27,7 +27,6 @@ use crate::jsval::{JSVal, UndefinedValue};
 use std::marker::PhantomData;
 use std::mem;
 use std::ops::Deref;
-use std::ops::DerefMut;
 use std::ptr;
 
 impl<T> Deref for JS::Handle<T> {
@@ -43,12 +42,6 @@ impl<T> Deref for JS::MutableHandle<T> {
 
     fn deref<'a>(&'a self) -> &'a T {
         unsafe { &*self.ptr }
-    }
-}
-
-impl<T> DerefMut for JS::MutableHandle<T> {
-    fn deref_mut<'a>(&'a mut self) -> &'a mut T {
-        unsafe { &mut *self.ptr }
     }
 }
 


### PR DESCRIPTION
Like with #572 and #573 this impl allows for improper aliasing with the GC. With this type it also allows for outright use after frees, since `JS::MutableHandle`, like a raw pointer, has no lifetime attached to it. Eventually that's a justification for removing the `Deref` impl as well, but once thing at a time.

There's only one use of this in servo, which is removed in the accompanying PR: https://github.com/servo/servo/pull/36161

Like with #572 and #573 I added an unsafe `as_mut` method, though it is unused locally this time as well as in servo. It feels like a reasonable escape hatch to share even if it isn't currently used.

Part of #569, and can be merged entirely independently from #572 and #573.