### PR TITLE
Refactor Rooted<T>

### DIFF
--- a/mozjs-sys/src/jsgc.rs
+++ b/mozjs-sys/src/jsgc.rs
@@ -104,7 +104,7 @@ pub trait Rootable: crate::trace::Traceable + Sized {
     unsafe extern "C" fn trace(this: *mut c_void, trc: *mut JSTracer, _name: *const c_char) {
         let rooted = this as *mut Rooted<Self>;
         let rooted = rooted.as_mut().unwrap();
-        <Self as crate::trace::Traceable>::trace(&mut rooted.ptr, trc);
+        <Self as crate::trace::Traceable>::trace(&mut rooted.data, trc);
     }
 }
 
@@ -132,7 +132,7 @@ pub struct RootedBase {
 pub struct Rooted<T: RootKind> {
     pub vtable: T::Vtable,
     pub base: RootedBase,
-    pub ptr: T,
+    pub data: T,
 }
 
 /// Trait that provides a GC-safe default value for the given type, if one exists.

--- a/mozjs-sys/src/jsimpls.rs
+++ b/mozjs-sys/src/jsimpls.rs
@@ -143,7 +143,7 @@ impl<const N: usize> From<&Rooted<ValueArray<N>>> for JS::HandleValueArray {
     fn from(array: &Rooted<ValueArray<N>>) -> JS::HandleValueArray {
         JS::HandleValueArray {
             length_: N,
-            elements_: array.ptr.get_ptr(),
+            elements_: array.data.get_ptr(),
         }
     }
 }
@@ -435,7 +435,7 @@ impl<T: RootKind> JS::Rooted<T> {
                 stack: ptr::null_mut(),
                 prev: ptr::null_mut(),
             },
-            ptr: initial,
+            data: initial,
         }
     }
 

--- a/mozjs-sys/src/jsimpls.rs
+++ b/mozjs-sys/src/jsimpls.rs
@@ -25,7 +25,6 @@ use crate::jsid::VoidId;
 use crate::jsval::{JSVal, UndefinedValue};
 
 use std::marker::PhantomData;
-use std::mem;
 use std::ops::Deref;
 use std::ptr;
 
@@ -144,7 +143,7 @@ impl<const N: usize> From<&Rooted<ValueArray<N>>> for JS::HandleValueArray {
     fn from(array: &Rooted<ValueArray<N>>) -> JS::HandleValueArray {
         JS::HandleValueArray {
             length_: N,
-            elements_: unsafe { array.ptr.assume_init_ref().get_ptr() },
+            elements_: array.ptr.get_ptr(),
         }
     }
 }
@@ -429,14 +428,14 @@ impl RootedBase {
 }
 
 impl<T: RootKind> JS::Rooted<T> {
-    pub fn new_unrooted() -> JS::Rooted<T> {
+    pub fn new_unrooted(initial: T) -> JS::Rooted<T> {
         JS::Rooted {
             vtable: T::VTABLE,
             base: RootedBase {
                 stack: ptr::null_mut(),
                 prev: ptr::null_mut(),
             },
-            ptr: mem::MaybeUninit::zeroed(),
+            ptr: initial,
         }
     }
 

--- a/mozjs/src/conversions.rs
+++ b/mozjs/src/conversions.rs
@@ -722,8 +722,8 @@ impl<C: Clone, T: FromJSValConvertible<Config = C>> FromJSValConvertible for Vec
         let zero = mem::zeroed();
         let mut iterator = ForOfIterator {
             cx_: cx,
-            iterator: RootedObject::new_unrooted(),
-            nextMethod: RootedValue::new_unrooted(),
+            iterator: RootedObject::new_unrooted(ptr::null_mut()),
+            nextMethod: RootedValue::new_unrooted(JSVal { asBits_: 0 }),
             index: ::std::u32::MAX, // NOT_ARRAY
             ..zero
         };
@@ -737,7 +737,7 @@ impl<C: Clone, T: FromJSValConvertible<Config = C>> FromJSValConvertible for Vec
             return Err(());
         }
 
-        if iterator.iterator.ptr.assume_init_ref().is_null() {
+        if iterator.iterator.ptr.is_null() {
             return Ok(ConversionResult::Failure("Value is not iterable".into()));
         }
 

--- a/mozjs/src/conversions.rs
+++ b/mozjs/src/conversions.rs
@@ -737,7 +737,7 @@ impl<C: Clone, T: FromJSValConvertible<Config = C>> FromJSValConvertible for Vec
             return Err(());
         }
 
-        if iterator.iterator.ptr.is_null() {
+        if iterator.iterator.data.is_null() {
             return Ok(ConversionResult::Failure("Value is not iterable".into()));
         }
 

--- a/mozjs/src/gc/macros.rs
+++ b/mozjs/src/gc/macros.rs
@@ -1,15 +1,15 @@
 #[macro_export]
 macro_rules! rooted {
 	(in($cx:expr) let $($var:ident)+ = $init:expr) => {
-        let mut __root = $crate::jsapi::Rooted::new_unrooted();
+        let mut __root = ::std::mem::MaybeUninit::uninit();
         let $($var)+ = $crate::gc::RootedGuard::new($cx, &mut __root, $init);
     };
 	(in($cx:expr) let $($var:ident)+: $type:ty = $init:expr) => {
-        let mut __root = $crate::jsapi::Rooted::new_unrooted();
+        let mut __root = ::std::mem::MaybeUninit::uninit();
         let $($var)+: $crate::gc::RootedGuard<$type> = $crate::gc::RootedGuard::new($cx, &mut __root, $init);
     };
 	(in($cx:expr) let $($var:ident)+: $type:ty) => {
-        let mut __root = $crate::jsapi::Rooted::new_unrooted();
+        let mut __root = ::std::mem::MaybeUninit::uninit();
         // SAFETY:
         // We're immediately storing the initial value in a rooted location.
         let $($var)+: $crate::gc::RootedGuard<$type> = $crate::gc::RootedGuard::new(

--- a/mozjs/src/gc/root.rs
+++ b/mozjs/src/gc/root.rs
@@ -48,7 +48,7 @@ impl<'a, T: 'a + RootKind> RootedGuard<'a, T> {
 
     pub fn as_ptr(&self) -> *mut T {
         // SAFETY: self.root points to an inbounds allocation
-        unsafe { (&raw mut (*self.root).ptr) }
+        unsafe { (&raw mut (*self.root).data) }
     }
 
     /// Safety: GC must not run during the lifetime of the returned reference.
@@ -85,7 +85,7 @@ where
 impl<'a, T: 'a + RootKind> Deref for RootedGuard<'a, T> {
     type Target = T;
     fn deref(&self) -> &T {
-        unsafe { &(*self.root).ptr }
+        unsafe { &(*self.root).data }
     }
 }
 


### PR DESCRIPTION
 - Instead of storing `MaybeUninit<T>` in `Rooted<T>`, and initializing `RootedGuard` from a `&mut Rooted<T>`, store `T` in `Rooted<T>` and initialize `RootedGuard` from an `&mut MaybeUninit<Rooted<T>>`.
  
   Currently every time we touch the data through `RootedGuard<T>`, we need to re-assert to the compiler that it is initialized. Adding one more thing to think about in an already complicated safety dance. By instead getting rid of the half initialized state, and passing the entire place in as uninitialized memory, this part of initialization can happen through entirely safe functions, and access never needs to worry about it.
 - Correctly mark `ValueArray::get_ptr` as safe - it's doing things with the pointer that might be unsafe.
 
   This lets us drop the unsafe block in `fn from(array: &Rooted<ValueArray<N>>) -> JS::HandleValueArray`
 - Rename `Rooted::ptr` to `Rooted::data`, whenever working with this type via `RootedGuard`, we currently have a pointer to a field name `ptr` which is in fact not (necessarily) a pointer. This is... confusing. Let's change the name to something else.
 
None of these changes are necessary for correctness or anything, they would just make me happier when reading the code.

Servo still builds with this change, we're technically changing public APIs, but not ones that are actually directly used.