### PR TITLE
Expose function to obtain a PropertyKey from a JSString.

### DIFF
--- a/mozjs-sys/src/jsid.rs
+++ b/mozjs-sys/src/jsid.rs
@@ -44,6 +44,13 @@ pub fn SymbolId(symbol: *mut Symbol) -> jsid {
     AsPropertyKey((symbol as usize) | (PropertyKeyTag::Symbol as usize))
 }
 
+#[inline(always)]
+pub fn StringId(s: *mut JSString) -> jsid {
+    assert!(!s.is_null());
+    assert_eq!((s as usize) & JSID_TYPE_MASK, 0);
+    AsPropertyKey((s as usize) | (PropertyKeyTag::String as usize))
+}
+
 impl jsid {
     #[inline(always)]
     fn asBits(&self) -> usize {

--- a/mozjs-sys/src/jsid.rs
+++ b/mozjs-sys/src/jsid.rs
@@ -45,6 +45,7 @@ pub fn SymbolId(symbol: *mut Symbol) -> jsid {
 }
 
 #[inline(always)]
+/// <https://searchfox.org/mozilla-central/rev/1f65969e57c757146e3e548614b49d3a4168eeb8/js/public/Id.h#183>
 pub fn StringId(s: *mut JSString) -> jsid {
     assert!(!s.is_null());
     assert_eq!((s as usize) & JSID_TYPE_MASK, 0);


### PR DESCRIPTION
This is needed to replicate https://searchfox.org/mozilla-central/rev/1f65969e57c757146e3e548614b49d3a4168eeb8/js/public/Id.h#183 for https://github.com/servo/servo/issues/34686.