### PR TITLE
Support passing null property descriptor to SetPropertyIgnoringNamedGetter

### DIFF
--- a/mozjs-sys/src/jsapi.cpp
+++ b/mozjs-sys/src/jsapi.cpp
@@ -295,15 +295,14 @@ bool JS_GetUCPropertyDescriptor(JSContext* cx, JS::HandleObject obj,
   return result;
 }
 
-bool SetPropertyIgnoringNamedGetter(JSContext* cx, JS::HandleObject obj,
-                                    JS::HandleId id, JS::HandleValue v,
-                                    JS::HandleValue receiver,
-                                    JS::Handle<JS::PropertyDescriptor> ownDesc,
-                                    JS::ObjectOpResult& result) {
+bool SetPropertyIgnoringNamedGetter(
+    JSContext* cx, JS::HandleObject obj, JS::HandleId id, JS::HandleValue v,
+    JS::HandleValue receiver, const JS::Handle<JS::PropertyDescriptor>* ownDesc,
+    JS::ObjectOpResult& result) {
   return js::SetPropertyIgnoringNamedGetter(
       cx, obj, id, v, receiver,
       JS::Rooted<mozilla::Maybe<JS::PropertyDescriptor>>(
-          cx, mozilla::ToMaybe(&ownDesc)),
+          cx, mozilla::ToMaybe(ownDesc)),
       result);
 }
 

--- a/mozjs/src/jsapi_wrappers.in.rs
+++ b/mozjs/src/jsapi_wrappers.in.rs
@@ -358,6 +358,6 @@ wrap!(jsapi: pub fn JS_GetOwnPropertyDescriptor(cx: *mut JSContext, obj: HandleO
 wrap!(jsapi: pub fn JS_GetOwnUCPropertyDescriptor(cx: *mut JSContext, obj: HandleObject, name: *const u16, namelen: usize, desc: MutableHandle<PropertyDescriptor>, isNone: *mut bool) -> bool);
 wrap!(jsapi: pub fn JS_GetPropertyDescriptorById(cx: *mut JSContext, obj: HandleObject, id: HandleId, desc: MutableHandle<PropertyDescriptor>, holder: MutableHandleObject, isNone: *mut bool) -> bool);
 wrap!(jsapi: pub fn JS_GetUCPropertyDescriptor(cx: *mut JSContext, obj: HandleObject, name: *const u16, namelen: usize, desc: MutableHandle<PropertyDescriptor>, holder: MutableHandleObject, isNone: *mut bool) -> bool);
-wrap!(jsapi: pub fn SetPropertyIgnoringNamedGetter(cx: *mut JSContext, obj: HandleObject, id: HandleId, v: HandleValue, receiver: HandleValue, ownDesc: Handle<PropertyDescriptor>, result: *mut ObjectOpResult) -> bool);
+wrap!(jsapi: pub fn SetPropertyIgnoringNamedGetter(cx: *mut JSContext, obj: HandleObject, id: HandleId, v: HandleValue, receiver: HandleValue, ownDesc: *const Handle<PropertyDescriptor>, result: *mut ObjectOpResult) -> bool);
 wrap!(jsapi: pub fn CreateError(cx: *mut JSContext, type_: JSExnType, stack: HandleObject, fileName: HandleString, lineNumber: u32, columnNumber: u32, report: *mut JSErrorReport, message: HandleString, cause: HandleValue, rval: MutableHandleValue) -> bool);
 wrap!(jsapi: pub fn GetExceptionCause(exc: *mut JSObject, dest: MutableHandleValue));

--- a/mozjs/src/rust.rs
+++ b/mozjs/src/rust.rs
@@ -1072,6 +1072,9 @@ pub mod wrappers {
         // @inner (input args) <> (accumulator) <> unparsed tokens
         // when `unparsed tokens == \eps`, accumulator contains the final result
 
+        (@inner $saved:tt <> ($($acc:expr,)*) <> $arg:ident: *const Handle<$gentype:ty>, $($rest:tt)*) => {
+            wrap!(@inner $saved <> ($($acc,)* if $arg.is_null() { std::ptr::null() } else { &(*$arg).into() },) <> $($rest)*);
+        };
         (@inner $saved:tt <> ($($acc:expr,)*) <> $arg:ident: Handle<$gentype:ty>, $($rest:tt)*) => {
             wrap!(@inner $saved <> ($($acc,)* $arg.into(),) <> $($rest)*);
         };


### PR DESCRIPTION
This is needed for https://github.com/servo/servo/issues/34709, when we obtain a Nothing property descriptor from InvokeGetOwnPropertyDescriptor and need to pass it to SetPropertyIgnoringNamedGetter.