### PR TITLE
Bump mozjs-sys version.

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.128.9-0"
+version = "0.128.9-1"
 authors = ["Mozilla"]
 links = "mozjs"
 build = "build.rs"


### PR DESCRIPTION
https://github.com/servo/mozjs/pull/579/ modified the compiled C++ code, so we need to publish new compiled libraries.