### PR TITLE
ohos: Use custom domain when logging with hilog

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "140.13.0-0"
+version = "140.13.0-1"
 authors = ["Mozilla", "The Servo Project Developers"]
 links = "mozjs"
 license.workspace = true

--- a/mozjs-sys/etc/patches/0036-Redirect_errors_to_hilog_on_OpenHarmony.patch
+++ b/mozjs-sys/etc/patches/0036-Redirect_errors_to_hilog_on_OpenHarmony.patch
@@ -2,11 +2,12 @@ diff --git a/build/moz.configure/init.configure b/build/moz.configure/init.confi
 index e0e14bf60..179de2592 100644
 --- a/build/moz.configure/init.configure
 +++ b/build/moz.configure/init.configure
-@@ -956,6 +956,7 @@ def target_is_ohos(target):
+@@ -956,6 +956,8 @@ def target_is_ohos(target):
 
 
  set_define("XP_OHOS", target_is_ohos)
 +set_config("OHOS", target_is_ohos)
++set_define("OHOS_LOG_DOMAIN", "0xE0C4", when=target_is_ohos)
 
 
  @depends(target)
@@ -34,7 +35,7 @@ index 3cfc92533..9c487ac45 100644
 +#ifdef ANDROID
 +  __android_log_print(ANDROID_LOG_ERROR, "Gecko", "mozalloc_abort: %s", msg);
 +#elif defined(XP_OHOS)
-+    (void) OH_LOG_Print(0 /* LOG_APP */, 7 /* LOG_FATAL */, 0, "Gecko",
++    (void) OH_LOG_Print(0 /* LOG_APP */, 7 /* LOG_FATAL */, OHOS_LOG_DOMAIN, "Gecko",
 +         "mozalloc_abort: %{public}s\n", msg);
 +#else
    fputs(msg, stderr);
@@ -65,7 +66,7 @@ index 0b7395177..e84d76aba 100644
                              /* aMaxFrames */ 0);
  #  endif
 +#elif defined(XP_OHOS)
-+    (void) OH_LOG_Print(0 /* LOG_APP */, 7 /* LOG_FATAL */, 0, "MOZ_Assert",
++    (void) OH_LOG_Print(0 /* LOG_APP */, 7 /* LOG_FATAL */, OHOS_LOG_DOMAIN, "MOZ_Assert",
 +     "Assertion failure: %{public}s, at %{public}s:%{public}d\n",
 +     aStr, aFilename, aLine);
  #else
@@ -80,7 +81,7 @@ index 0b7395177..e84d76aba 100644
                              /* aMaxFrames */ 0);
  #  endif
 +#elif defined(XP_OHOS)
-+  (void) OH_LOG_Print(0 /* LOG_APP */, 7 /* LOG_FATAL */, 0, "MOZ_CRASH",
++  (void) OH_LOG_Print(0 /* LOG_APP */, 7 /* LOG_FATAL */, OHOS_LOG_DOMAIN, "MOZ_CRASH",
 +   "Hit MOZ_CRASH(%{public}s), at %{public}s:%{public}d\n",
 +   aStr, aFilename, aLine);
  #else
@@ -111,7 +112,7 @@ index 3247b993c..c7039d5f8 100644
 +#if defined(ANDROID)
    __android_log_print(ANDROID_LOG_INFO, "Gecko", "%s", s.str().c_str());
 +#elif defined(XP_OHOS)
-+    (void) OH_LOG_Print(0 /* LOG_APP */, 4 /* LOG_INFO */, 0, "Gecko", "%{public}s\n", s.str().c_str());
++    (void) OH_LOG_Print(0 /* LOG_APP */, 4 /* LOG_INFO */, OHOS_LOG_DOMAIN, "Gecko", "%{public}s\n", s.str().c_str());
  #else
    fputs(s.str().c_str(), stderr);
  #endif
@@ -144,7 +145,7 @@ index c3a2ca89e..3fea33f4b 100644
 +    // OH_LOG_VPrint is available with API-level 18 (19?) or higher.
 +    char buffer[1024];
 +    VsprintfBuf(buffer, 1024, aFmt, aArgs);
-+   (void) OH_LOG_Print(0 /* LOG_APP */, 4 /* LOG_INFO */, 0, "Gecko", "%{public}s", buffer);
++   (void) OH_LOG_Print(0 /* LOG_APP */, 4 /* LOG_INFO */, OHOS_LOG_DOMAIN, "Gecko", "%{public}s", buffer);
 +}
  #elif defined(FUZZING_SNAPSHOT)
  MFBT_API void vprintf_stderr(const char* aFmt, va_list aArgs) {
@@ -162,7 +163,7 @@ index c3a2ca89e..3fea33f4b 100644
    std::string line;
    while (std::getline(aStr, line)) {
 +#  ifdef XP_OHOS
-+    (void) OH_LOG_Print(0 /* LOG_APP */, 4 /* LOG_INFO */, 0, "Gecko", "%{public}s", line.c_str());
++    (void) OH_LOG_Print(0 /* LOG_APP */, 4 /* LOG_INFO */, OHOS_LOG_DOMAIN, "Gecko", "%{public}s", line.c_str());
 +#  else
      printf_stderr("%s\n", line.c_str());
 +#  endif
@@ -186,7 +187,7 @@ index 52bd6abc5..781402d56 100644
  #endif
  
  /*
-@@ -108,6 +110,19 @@ static void OutputDebugStringA(const char* msg) {
+@@ -108,6 +110,20 @@ static void OutputDebugStringA(const char* msg) {
        PR_Write(fd, buf, nb);                               \
      }                                                      \
      PR_END_MACRO
@@ -196,8 +197,9 @@ index 52bd6abc5..781402d56 100644
 +    if (fd == _pr_stderr) {                                  \
 +        char savebyte = buf[nb];                             \
 +        buf[nb] = '\0';                                      \
-+        (void) OH_LOG_Print(0 /* LOG_APP */, 4 /* LOG_INFO */,   \
-+               0, "PRLog", "%{public}s\n", buf);             \
++        (void) OH_LOG_Print(0 /* LOG_APP */,                 \
++                4 /* LOG_INFO */, OHOS_LOG_DOMAIN, "PRLog",  \
++               "%{public}s\n", buf);                         \
 +        buf[nb] = savebyte;                                  \
 +    } else {                                                 \
 +        PR_Write(fd, buf, nb);                               \
@@ -211,7 +213,7 @@ index 52bd6abc5..781402d56 100644
  #ifdef ANDROID
    __android_log_write(ANDROID_LOG_ERROR, "PRLog", "Aborting");
 +#elif defined(XP_OHOS)
-+  (void) OH_LOG_Print(0 /* LOG_APP */, 7 /* LOG_FATAL */, 0, "PRLog", "Aborting\n");
++  (void) OH_LOG_Print(0 /* LOG_APP */, 7 /* LOG_FATAL */, OHOS_LOG_DOMAIN, "PRLog", "Aborting\n");
  #endif
    abort();
  }
@@ -220,7 +222,7 @@ index 52bd6abc5..781402d56 100644
    __android_log_assert(NULL, "PRLog", "Assertion failure: %s, at %s:%d\n", s,
                         file, ln);
 +#elif defined(XP_OHOS)
-+  (void) OH_LOG_Print(0 /* LOG_APP */, 7 /* LOG_FATAL */, 0, "PRLog",
++  (void) OH_LOG_Print(0 /* LOG_APP */, 7 /* LOG_FATAL */, OHOS_LOG_DOMAIN, "PRLog",
 +                      "Assertion failure: %{public}s, at %{public}s:%{public}d\n",s, file, ln);
  #endif
    abort();

--- a/mozjs-sys/mozjs/build/moz.configure/init.configure
+++ b/mozjs-sys/mozjs/build/moz.configure/init.configure
@@ -917,6 +917,7 @@ def target_is_ohos(target):
 
 set_define("XP_OHOS", target_is_ohos)
 set_config("OHOS", target_is_ohos)
+set_define("OHOS_LOG_DOMAIN", "0xE0C4", when=target_is_ohos)
 
 
 @depends(target)

--- a/mozjs-sys/mozjs/memory/mozalloc/mozalloc_abort.cpp
+++ b/mozjs-sys/mozjs/memory/mozalloc/mozalloc_abort.cpp
@@ -29,7 +29,7 @@ void mozalloc_abort(const char* const msg) {
 #ifdef ANDROID
   __android_log_print(ANDROID_LOG_ERROR, "Gecko", "mozalloc_abort: %s", msg);
 #elif defined(XP_OHOS)
-    (void) OH_LOG_Print(0 /* LOG_APP */, 7 /* LOG_FATAL */, 0, "Gecko",
+    (void) OH_LOG_Print(0 /* LOG_APP */, 7 /* LOG_FATAL */, OHOS_LOG_DOMAIN, "Gecko",
          "mozalloc_abort: %{public}s\n", msg);
 #else
   fputs(msg, stderr);

--- a/mozjs-sys/mozjs/mfbt/Assertions.h
+++ b/mozjs-sys/mozjs/mfbt/Assertions.h
@@ -133,7 +133,7 @@ MOZ_ReportAssertionFailure(const char* aStr, const char* aFilename,
                             /* aMaxFrames */ 0);
 #  endif
 #elif defined(XP_OHOS)
-    (void) OH_LOG_Print(0 /* LOG_APP */, 7 /* LOG_FATAL */, 0, "MOZ_Assert",
+    (void) OH_LOG_Print(0 /* LOG_APP */, 7 /* LOG_FATAL */, OHOS_LOG_DOMAIN, "MOZ_Assert",
      "Assertion failure: %{public}s, at %{public}s:%{public}d\n",
      aStr, aFilename, aLine);
 #else
@@ -165,7 +165,7 @@ MOZ_MAYBE_UNUSED static MOZ_COLD MOZ_NEVER_INLINE void MOZ_ReportCrash(
                             /* aMaxFrames */ 0);
 #  endif
 #elif defined(XP_OHOS)
-  (void) OH_LOG_Print(0 /* LOG_APP */, 7 /* LOG_FATAL */, 0, "MOZ_CRASH",
+  (void) OH_LOG_Print(0 /* LOG_APP */, 7 /* LOG_FATAL */, OHOS_LOG_DOMAIN, "MOZ_CRASH",
    "Hit MOZ_CRASH(%{public}s), at %{public}s:%{public}d\n",
    aStr, aFilename, aLine);
 #else

--- a/mozjs-sys/mozjs/mfbt/DbgMacro.h
+++ b/mozjs-sys/mozjs/mfbt/DbgMacro.h
@@ -104,7 +104,7 @@ auto&& MozDbg(const char* aFile, int aLine, const char* aExpression,
 #if defined(ANDROID)
   __android_log_print(ANDROID_LOG_INFO, "Gecko", "%s", s.str().c_str());
 #elif defined(XP_OHOS)
-    (void) OH_LOG_Print(0 /* LOG_APP */, 4 /* LOG_INFO */, 0, "Gecko", "%{public}s\n", s.str().c_str());
+    (void) OH_LOG_Print(0 /* LOG_APP */, 4 /* LOG_INFO */, OHOS_LOG_DOMAIN, "Gecko", "%{public}s\n", s.str().c_str());
 #else
   fputs(s.str().c_str(), stderr);
 #endif

--- a/mozjs-sys/mozjs/mozglue/misc/Debug.cpp
+++ b/mozjs-sys/mozjs/mozglue/misc/Debug.cpp
@@ -76,7 +76,7 @@ MFBT_API void vprintf_stderr(const char* aFmt, va_list aArgs) {
     // OH_LOG_VPrint is available with API-level 18 (19?) or higher.
     char buffer[1024];
     VsprintfBuf(buffer, 1024, aFmt, aArgs);
-   (void) OH_LOG_Print(0 /* LOG_APP */, 4 /* LOG_INFO */, 0, "Gecko", "%{public}s", buffer);
+   (void) OH_LOG_Print(0 /* LOG_APP */, 4 /* LOG_INFO */, OHOS_LOG_DOMAIN, "Gecko", "%{public}s", buffer);
 }
 #elif defined(FUZZING_SNAPSHOT)
 MFBT_API void vprintf_stderr(const char* aFmt, va_list aArgs) {
@@ -120,7 +120,7 @@ MFBT_API void print_stderr(std::stringstream& aStr) {
   std::string line;
   while (std::getline(aStr, line)) {
 #  ifdef XP_OHOS
-    (void) OH_LOG_Print(0 /* LOG_APP */, 4 /* LOG_INFO */, 0, "Gecko", "%{public}s", line.c_str());
+    (void) OH_LOG_Print(0 /* LOG_APP */, 4 /* LOG_INFO */, OHOS_LOG_DOMAIN, "Gecko", "%{public}s", line.c_str());
 #  else
     printf_stderr("%s\n", line.c_str());
 #  endif

--- a/mozjs-sys/mozjs/nsprpub/pr/src/io/prlog.c
+++ b/mozjs-sys/mozjs/nsprpub/pr/src/io/prlog.c
@@ -123,8 +123,9 @@ static void OutputDebugStringA(const char* msg) {
     if (fd == _pr_stderr) {                                  \
         char savebyte = buf[nb];                             \
         buf[nb] = '\0';                                      \
-        (void) OH_LOG_Print(0 /* LOG_APP */, 4 /* LOG_INFO */,   \
-               0, "PRLog", "%{public}s\n", buf);             \
+        (void) OH_LOG_Print(0 /* LOG_APP */,                 \
+                4 /* LOG_INFO */, OHOS_LOG_DOMAIN, "PRLog",  \
+               "%{public}s\n", buf);                         \
         buf[nb] = savebyte;                                  \
     } else {                                                 \
         PR_Write(fd, buf, nb);                               \
@@ -556,7 +557,7 @@ PR_IMPLEMENT(void) PR_Abort(void) {
 #ifdef ANDROID
   __android_log_write(ANDROID_LOG_ERROR, "PRLog", "Aborting");
 #elif defined(XP_OHOS)
-  (void) OH_LOG_Print(0 /* LOG_APP */, 7 /* LOG_FATAL */, 0, "PRLog", "Aborting\n");
+  (void) OH_LOG_Print(0 /* LOG_APP */, 7 /* LOG_FATAL */, OHOS_LOG_DOMAIN, "PRLog", "Aborting\n");
 #endif
   abort();
 }
@@ -571,7 +572,7 @@ PR_IMPLEMENT(void) PR_Assert(const char* s, const char* file, PRIntn ln) {
   __android_log_assert(NULL, "PRLog", "Assertion failure: %s, at %s:%d\n", s,
                        file, ln);
 #elif defined(XP_OHOS)
-  (void) OH_LOG_Print(0 /* LOG_APP */, 7 /* LOG_FATAL */, 0, "PRLog",
+  (void) OH_LOG_Print(0 /* LOG_APP */, 7 /* LOG_FATAL */, OHOS_LOG_DOMAIN, "PRLog",
                       "Assertion failure: %{public}s, at %{public}s:%{public}d\n",s, file, ln);
 #endif
   abort();

--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.21.0"
+version = "0.21.1"
 authors = ["The Servo Project Developers"]
 license.workspace = true
 edition.workspace = true
@@ -27,7 +27,7 @@ encoding_rs = "0.8.35"
 libc.workspace = true
 log = "0.4"
 # When doing non-version changes also update ../mozjs-sys/etc/sm-security-bump.py
-mozjs_sys = { version = "=140.13.0-0", path = "../mozjs-sys" }
+mozjs_sys = { version = "=140.13.0-1", path = "../mozjs-sys" }
 num-traits = "0.2"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]


### PR DESCRIPTION
This modifies the existing patch to redirect log messages to hilog to use a non-zero domain, which allows us to filter logs via the domain on ohos devices.
We set 0xE0C3 for Rust code in servo, using a different number allows us to seperate spidermonkey from servo logs if wanted.

Fixes #582