### PR TITLE
Improve the speed of `latin1_to_string`

### DIFF
--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -17,10 +17,19 @@ profilemozjs = ['mozjs_sys/profilemozjs']
 crown = ['mozjs_sys/crown']
 
 [dependencies]
+encoding_rs = "0.8.35"
 libc.workspace = true
 log = "0.4"
 mozjs_sys = { path = "../mozjs-sys" }
 
+[dev-dependencies]
+criterion = "0.6"
+
 [build-dependencies]
 cc.workspace = true
 bindgen.workspace = true
+
+
+[[bench]]
+name = "latin1_string_conversion"
+harness = false

--- a/mozjs/benches/latin1_string_conversion.rs
+++ b/mozjs/benches/latin1_string_conversion.rs
@@ -1,0 +1,127 @@
+use criterion::measurement::WallTime;
+use criterion::{
+    criterion_group, criterion_main, BenchmarkGroup, BenchmarkId, Criterion, Throughput,
+};
+use mozjs::conversions::jsstr_to_string;
+use mozjs::glue::{CreateJSExternalStringCallbacks, JSExternalStringCallbacksTraps};
+use mozjs::jsapi::{
+    JSAutoRealm, JS_NewExternalStringLatin1, JS_NewGlobalObject, OnNewGlobalHookOption,
+};
+use mozjs::rooted;
+use mozjs::rust::{JSEngine, RealmOptions, Runtime, SIMPLE_GLOBAL_CLASS};
+use mozjs_sys::jsapi::JSContext;
+use std::ffi::c_void;
+use std::{iter, ptr};
+
+// TODO: Create a trait for creating a latin1 string of a required length, so that we can
+// try different kinds of content.
+fn bench_str_repetition(
+    group: &mut BenchmarkGroup<WallTime>,
+    context: *mut JSContext,
+    variant_name: &str,
+    latin1str_16_bytes: &[u8],
+) {
+    assert_eq!(latin1str_16_bytes.len(), 16);
+    for repetitions in [1, 4, 16, 64, 256, 1024, 4096].iter() {
+        let str_len = repetitions * latin1str_16_bytes.len();
+        let latin1_base = iter::repeat_n(latin1str_16_bytes, *repetitions).fold(
+            Vec::with_capacity(str_len),
+            |mut acc, x| {
+                acc.extend_from_slice(x);
+                acc
+            },
+        );
+        let latin1_boxed = latin1_base.into_boxed_slice();
+        let latin1_chars = Box::into_raw(latin1_boxed).cast::<u8>();
+        let callbacks = unsafe {
+            CreateJSExternalStringCallbacks(
+                &EXTERNAL_STRING_CALLBACKS_TRAPS,
+                str_len as *mut c_void,
+            )
+        };
+        rooted!(in(context) let latin1_jsstr = unsafe { JS_NewExternalStringLatin1(
+            context,
+            latin1_chars,
+            str_len,
+            callbacks
+        )});
+        group.throughput(Throughput::Bytes(str_len as u64));
+        group.bench_with_input(
+            BenchmarkId::new(variant_name, str_len),
+            &latin1_jsstr,
+            |b, js_str| {
+                b.iter(|| {
+                    unsafe { jsstr_to_string(context, js_str.get()) };
+                })
+            },
+        );
+    }
+}
+fn external_string(c: &mut Criterion) {
+    let engine = JSEngine::init().unwrap();
+    let runtime = Runtime::new(engine.handle());
+    let context = runtime.cx();
+    let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
+    let c_option = RealmOptions::default();
+    rooted!(in(context) let global = unsafe { JS_NewGlobalObject(
+        context,
+        &SIMPLE_GLOBAL_CLASS,
+        ptr::null_mut(),
+        h_option,
+        &*c_option,
+    )});
+    let _ac = JSAutoRealm::new(context, global.get());
+
+    let mut group = c.benchmark_group("Latin1 conversion");
+
+    let ascii_example = b"test latin-1 tes";
+    bench_str_repetition(&mut group, context, "ascii a-z", ascii_example);
+    // fastpath for the first few characters, then slowpath for the remaining (long part)
+    // TODO: make generator functions, so we can define at which percentage of the size
+    // the first high byte shows up (which forces the slow path).
+    let ascii_with_high = b"test latin-1 \xD6\xC0\xFF";
+    bench_str_repetition(&mut group, context, "ascii with high", ascii_with_high);
+}
+
+static EXTERNAL_STRING_CALLBACKS_TRAPS: JSExternalStringCallbacksTraps =
+    JSExternalStringCallbacksTraps {
+        latin1Finalize: Some(latin1::finalize),
+        latin1SizeOfBuffer: Some(latin1::size_of),
+        utf16Finalize: Some(utf16::finalize),
+        utf16SizeOfBuffer: Some(utf16::size_of),
+    };
+
+mod latin1 {
+    use std::ffi::c_void;
+    use std::slice;
+
+    use mozjs::jsapi::mozilla::MallocSizeOf;
+
+    pub unsafe extern "C" fn finalize(data: *const c_void, chars: *mut u8) {
+        let slice = slice::from_raw_parts_mut(chars, data as usize);
+        let _ = Box::from_raw(slice);
+    }
+
+    pub unsafe extern "C" fn size_of(data: *const c_void, _: *const u8, _: MallocSizeOf) -> usize {
+        data as usize
+    }
+}
+
+mod utf16 {
+    use std::ffi::c_void;
+    use std::slice;
+
+    use mozjs::jsapi::mozilla::MallocSizeOf;
+
+    pub unsafe extern "C" fn finalize(data: *const c_void, chars: *mut u16) {
+        let slice = slice::from_raw_parts_mut(chars, data as usize);
+        let _ = Box::from_raw(slice);
+    }
+
+    pub unsafe extern "C" fn size_of(data: *const c_void, _: *const u16, _: MallocSizeOf) -> usize {
+        data as usize
+    }
+}
+
+criterion_group!(benches, external_string);
+criterion_main!(benches);

--- a/mozjs/tests/external_string.rs
+++ b/mozjs/tests/external_string.rs
@@ -37,23 +37,44 @@ fn external_string() {
         ));
         let _ac = JSAutoRealm::new(context, global.get());
 
-        let latin1_base = "test latin-1";
-        let latin1_boxed = latin1_base.as_bytes().to_vec().into_boxed_slice();
-        let latin1_chars = Box::into_raw(latin1_boxed).cast::<u8>();
-
-        let callbacks = CreateJSExternalStringCallbacks(
-            &EXTERNAL_STRING_CALLBACKS_TRAPS,
-            latin1_base.len() as *mut c_void,
-        );
-        rooted!(in(context) let latin1_jsstr = JS_NewExternalStringLatin1(
+        test_latin1_string(context, "test latin1");
+        test_latin1_string(context, "abcdefghijklmnop"); // exactly 16 bytes
+        test_latin1_string(context, "abcdefghijklmnopq"); // 17 bytes
+        test_latin1_string(context, "abcdefghijklmno"); // 15 bytes
+        test_latin1_string(context, "abcdefghijklmnopqrstuvwxyzabcdef"); //32 bytes
+        test_latin1_string(context, "abcdefghijklmnopqrstuvwxyzabcde"); //31 bytes
+        test_latin1_string(context, "abcdefghijklmnopqrstuvwxyzabcdefg"); //33 bytes
+                                                                          //test_latin1_string(context, "test latin-1 Ö"); //testing whole latin1 range.
+                                                                          // whole latin1 table
+        test_latin1_string(context, "   ! 	\" 	# 	$ 	% 	& 	' 	( 	) 	* 	+ 	, 	- 	. 	/");
+        test_latin1_string(context, "0 	1 	2 	3 	4 	5 	6 	7 	8 	9 	: 	; 	< 	= 	> 	?");
+        test_latin1_string(context, "@ 	A 	B 	C 	D 	E 	F 	G 	H 	I 	J 	K 	L 	M 	N 	O");
+        test_latin1_string(context, "P 	Q 	R 	S 	T 	U 	V 	W 	X 	Y 	Z 	[ 	\\ 	] 	^ 	_");
+        test_latin1_string(context, "` 	a 	b 	c 	d 	e 	f 	g 	h 	i 	j 	k 	l 	m 	n 	o");
+        test_latin1_string(context, "p 	q 	r 	s 	t 	u 	v 	w 	x 	y 	z 	{ 	| 	} 	~");
+        test_latin1_string_bytes(
             context,
-            latin1_chars,
-            latin1_base.len(),
-            callbacks
-        ));
-        assert_eq!(
-            jsstr_to_string(context, NonNull::new(latin1_jsstr.get()).unwrap()),
-            latin1_base
+            b"\xA0\xA1\xA2\xA3\xA4\xA5\xA6\xA7\xA8\xA9\xAA\xAB\xAC\xAD\xAE\xAF",
+        );
+        test_latin1_string_bytes(
+            context,
+            b"\xB0\xB1\xB2\xB3\xB4\xB5\xB6\xB7\xB8\xB9\xBA\xBB\xBC\xBD\xBE\xBF",
+        );
+        test_latin1_string_bytes(
+            context,
+            b"\xC0\xC1\xC2\xC3\xC4\xC5\xC6\xC7\xC8\xC9\xCA\xCB\xCC\xCD\xCE\xCF",
+        );
+        test_latin1_string_bytes(
+            context,
+            b"\xD0\xD1\xD2\xD3\xD4\xD5\xD6\xD7\xD8\xD9\xDA\xDB\xDC\xDD\xDE\xDF",
+        );
+        test_latin1_string_bytes(
+            context,
+            b"\xE0\xE1\xE2\xE3\xE4\xE5\xE6\xE7\xE8\xE9\xEA\xEB\xEC\xED\xEE\xEF",
+        );
+        test_latin1_string_bytes(
+            context,
+            b"\xF0\xF1\xF2\xF3\xF4\xF5\xF6\xF7\xF8\xF9\xFA\xFB\xFC\xFD\xFE\xFF",
         );
 
         let utf16_base = "test utf-16 $€ \u{10437}\u{24B62}";
@@ -79,6 +100,48 @@ fn external_string() {
             utf16_base
         );
     }
+}
+
+#[cfg(test)]
+unsafe fn test_latin1_string(context: *mut mozjs::jsapi::JSContext, latin1_base: &str) {
+    let latin1_boxed = latin1_base.as_bytes().to_vec().into_boxed_slice();
+    let latin1_chars = Box::into_raw(latin1_boxed).cast::<u8>();
+
+    let callbacks = CreateJSExternalStringCallbacks(
+        &EXTERNAL_STRING_CALLBACKS_TRAPS,
+        latin1_base.len() as *mut c_void,
+    );
+    rooted!(in(context) let latin1_jsstr = JS_NewExternalStringLatin1(
+        context,
+        latin1_chars,
+        latin1_base.len(),
+        callbacks
+    ));
+    assert_eq!(
+        jsstr_to_string(context, NonNull::new(latin1_jsstr.get()).unwrap()),
+        latin1_base
+    );
+}
+
+#[cfg(test)]
+unsafe fn test_latin1_string_bytes(context: *mut mozjs::jsapi::JSContext, latin1_base: &[u8]) {
+    let latin1_boxed = latin1_base.to_vec().into_boxed_slice();
+    let latin1_chars = Box::into_raw(latin1_boxed).cast::<u8>();
+
+    let callbacks = CreateJSExternalStringCallbacks(
+        &EXTERNAL_STRING_CALLBACKS_TRAPS,
+        latin1_base.len() as *mut c_void,
+    );
+    rooted!(in(context) let latin1_jsstr = JS_NewExternalStringLatin1(
+        context,
+        latin1_chars,
+        latin1_base.len(),
+        callbacks
+    ));
+    assert_eq!(
+        jsstr_to_string(context, NonNull::new(latin1_jsstr.get()).unwrap()),
+        encoding_rs::mem::decode_latin1(latin1_base)
+    );
 }
 
 static EXTERNAL_STRING_CALLBACKS_TRAPS: JSExternalStringCallbacksTraps =


### PR DESCRIPTION
Improvements to the speed of latin1_to_string.
On the benchmark it improves the encoding from around 9 microsends to 6
microseconds.

This PR also includes the benchmark and setup as criterion benchmark.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>
