### PR TITLE
Add default feature for JIT

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.140.5-2"
+version = "0.140.5-3"
 authors = ["Mozilla", "The Servo Project Developers"]
 links = "mozjs"
 license.workspace = true
@@ -18,6 +18,7 @@ doctest = false
 [features]
 debugmozjs = []
 profilemozjs = []
+jit = []
 jitspew = []
 libz-sys = ["dep:libz-sys"]
 libz-rs = ["dep:libz-rs-sys"]

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -463,6 +463,9 @@ fn should_build_from_source() -> bool {
     } else if env::var_os("CARGO_FEATURE_INTL").is_none() {
         println!("intl feature is disabled. Building from source directly.");
         true
+    } else if !env::var_os("CARGO_FEATURE_JIT").is_some() {
+        println!("jit feature is NOT enabled. Building from source directly.");
+        true
     } else {
         false
     }

--- a/mozjs-sys/makefile.cargo
+++ b/mozjs-sys/makefile.cargo
@@ -11,6 +11,10 @@ CONFIGURE_FLAGS := \
 	--disable-shared-js \
 	--build-backends=RecursiveMake
 
+ifeq (,$(CARGO_FEATURE_JIT))
+    CONFIGURE_FLAGS += --disable-jit
+endif
+
 ifneq (,$(CARGO_FEATURE_JITSPEW))
     CONFIGURE_FLAGS += --enable-jitspew
 endif
@@ -77,7 +81,7 @@ ifneq ($(HOST),$(TARGET))
 	endif
 
 	ifeq (aarch64-unknown-linux-gnu,$(TARGET))
-	    # Reset TARGET variable because aarch64 target name used by Rust is not 
+	    # Reset TARGET variable because aarch64 target name used by Rust is not
 		# the same as the target name needed for the CXX toolchain.
 		TARGET = aarch64-linux-gnu
 	endif

--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.14.1"
+version = "0.14.2"
 authors = ["The Servo Project Developers"]
 license.workspace = true
 edition.workspace = true
@@ -11,9 +11,10 @@ edition.workspace = true
 doctest = false
 
 [features]
-default = ["libz-sys", "intl"]
+default = ["jit", "libz-sys", "intl"]
 debugmozjs = ["mozjs_sys/debugmozjs"]
 profilemozjs = ["mozjs_sys/profilemozjs"]
+jit = ['mozjs_sys/jit']
 jitspew = ["mozjs_sys/jitspew"]
 libz-sys = ["mozjs_sys/libz-sys"]
 libz-rs = ["mozjs_sys/libz-rs"]


### PR DESCRIPTION
This is a revival of https://github.com/servo/mozjs/pull/523 - but with a slightly different background.
When building servo on Linux with the profile `production-stripped`, disabling JIT with this change shaves off 9MiB from the servo binary size, which is around 10% (80MiB vs. 89MiB).

Companion PR: https://github.com/servo/servo/pull/37972