### PR TITLE
Implement saveJobQueue() for the SpiderMonkey Debugger API

### DIFF
--- a/mozjs-sys/src/jsglue.cpp
+++ b/mozjs-sys/src/jsglue.cpp
@@ -52,11 +52,11 @@ struct JobQueueTraps {
 
   // Create a new queue, push it onto an embedder-side stack, and return the new
   // queue.
-  void* (*pushNewInterruptQueue)(void* aInterruptQueues);
+  const void* (*pushNewInterruptQueue)(void* aInterruptQueues);
   // Destroy the queue most recently created by pushNewInterruptQueue(),
   // returning its address so we can check if we are restoring the saved queue
   // over the correct queue.
-  void* (*popInterruptQueue)(void* aInterruptQueues);
+  const void* (*popInterruptQueue)(void* aInterruptQueues);
 };
 
 class RustJobQueue : public JS::JobQueue {

--- a/mozjs-sys/src/jsglue.cpp
+++ b/mozjs-sys/src/jsglue.cpp
@@ -81,7 +81,8 @@ class RustJobQueue : public JS::JobQueue {
 
  private:
   virtual js::UniquePtr<SavedJobQueue> saveJobQueue(JSContext* cx) override {
-    MOZ_ASSERT(false, "saveJobQueue should not be invoked");
+    // FIXME deal with this for DebuggerGlobalScope in Servo
+    // MOZ_ASSERT(false, "saveJobQueue should not be invoked");
     return nullptr;
   }
 };

--- a/mozjs-sys/src/jsglue.cpp
+++ b/mozjs-sys/src/jsglue.cpp
@@ -57,6 +57,8 @@ struct JobQueueTraps {
   // returning its address so we can check if we are restoring the saved queue
   // over the correct queue.
   const void* (*popInterruptQueue)(void* aInterruptQueues);
+  // Destroy the embedder-side stack of interrupt queues.
+  void (*dropInterruptQueues)(void* aInterruptQueues);
 };
 
 class RustJobQueue : public JS::JobQueue {
@@ -68,6 +70,8 @@ class RustJobQueue : public JS::JobQueue {
   RustJobQueue(const JobQueueTraps& aTraps, const void* aQueue,
                void* aInterruptQueues)
       : mTraps(aTraps), mQueue(aQueue), mInterruptQueues(aInterruptQueues) {}
+
+  ~RustJobQueue() { mTraps.dropInterruptQueues(mInterruptQueues); }
 
   virtual JSObject* getIncumbentGlobal(JSContext* cx) override {
     return mTraps.getIncumbentGlobal(mQueue, cx);

--- a/mozjs-sys/src/jsglue.cpp
+++ b/mozjs-sys/src/jsglue.cpp
@@ -92,11 +92,9 @@ class RustJobQueue : public JS::JobQueue {
  private:
   class SavedQueue : public JS::JobQueue::SavedJobQueue {
    public:
-    SavedQueue(JSContext* cx, const JobQueueTraps& aTraps,
-               void* aInterruptQueues, const void** aCurrentQueue,
-               const void* aNewQueue)
-        : cx(cx),
-          mTraps(aTraps),
+    SavedQueue(const JobQueueTraps& aTraps, void* aInterruptQueues,
+               const void** aCurrentQueue, const void* aNewQueue)
+        : mTraps(aTraps),
           mInterruptQueues(aInterruptQueues),
           mCurrentQueue(aCurrentQueue),
           mNewQueue(aNewQueue),
@@ -138,8 +136,6 @@ class RustJobQueue : public JS::JobQueue {
     }
 
    private:
-    JSContext* cx;
-
     // Required for embedder FFI.
     JobQueueTraps mTraps;
     void* mInterruptQueues;
@@ -156,8 +152,8 @@ class RustJobQueue : public JS::JobQueue {
 
   virtual js::UniquePtr<SavedJobQueue> saveJobQueue(JSContext* cx) override {
     auto newQueue = mTraps.pushNewInterruptQueue(mInterruptQueues);
-    auto result = js::MakeUnique<SavedQueue>(cx, mTraps, mInterruptQueues,
-                                             &mQueue, newQueue);
+    auto result =
+        js::MakeUnique<SavedQueue>(mTraps, mInterruptQueues, &mQueue, newQueue);
     if (!result) {
       // “On OOM, this should call JS_ReportOutOfMemory on the given JSContext,
       // and return a null UniquePtr.” When the allocation in MakeUnique()

--- a/mozjs-sys/src/jsglue.cpp
+++ b/mozjs-sys/src/jsglue.cpp
@@ -54,8 +54,8 @@ struct JobQueueTraps {
   // queue.
   void* (*pushNewInterruptQueue)(void* aInterruptQueues);
   // Destroy the queue most recently created by pushNewInterruptQueue(),
-  // returning its address so we can check if we are restoring the correct
-  // queue.
+  // returning its address so we can check if we are restoring the saved queue
+  // over the correct queue.
   void* (*popInterruptQueue)(void* aInterruptQueues);
 };
 


### PR DESCRIPTION
in the [SpiderMonkey Debugger API](https://firefox-source-docs.mozilla.org/js/Debugger/), hooks like [onNewGlobalObject()](https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.html#onnewglobalobject-global) use an AutoDebuggerJobQueueInterruption to [switch to a new microtask queue](https://github.com/servo/mozjs/blob/b14aebff23ac4d5b0652060ef949334bda08b22f/mozjs-sys/mozjs/js/src/debugger/Debugger.cpp#L2834-L2841) and avoid clobbering the debuggee’s microtask queue. this in turn relies on JobQueue::saveJobQueue(), which is [not yet implemented in RustJobQueue](https://github.com/servo/mozjs/blob/b14aebff23ac4d5b0652060ef949334bda08b22f/mozjs-sys/src/jsglue.cpp#L83-L86).

this patch implements [saveJobQueue() and SavedJobQueue](https://github.com/servo/mozjs/blob/b14aebff23ac4d5b0652060ef949334bda08b22f/mozjs-sys/mozjs/js/public/Promise.h#L92-L114) for RustJobQueue by calling into Servo via two new JobQueueTraps that create and destroy extra “interrupt” queues for use by the debugger.

SpiderMonkey [does not own any job queues](https://github.com/servo/mozjs/blob/b14aebff23ac4d5b0652060ef949334bda08b22f/mozjs-sys/mozjs/js/public/Promise.h#L117-L123), so the lifetime of these queues is managed in Servo, where they are stored in a Vec-based stack. stack-like behaviour is adequate for SpiderMonkey’s save and restore patterns, as far as we can tell, but we’ve added an assertion just in case.

Servo patch: servo/servo#38232