### PR TITLE
Implement runJobs() for the SpiderMonkey Debugger API

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.128.13-2"
+version = "0.128.13-3"
 authors = ["Mozilla"]
 links = "mozjs"
 license.workspace = true

--- a/mozjs-sys/src/jsglue.cpp
+++ b/mozjs-sys/src/jsglue.cpp
@@ -48,6 +48,7 @@ struct JobQueueTraps {
                             JS::HandleObject promise, JS::HandleObject job,
                             JS::HandleObject allocationSite,
                             JS::HandleObject incumbentGlobal) = 0;
+  void (*runJobs)(const void* queue, JSContext* cx);
   bool (*empty)(const void* queue);
 
   // Create a new queue, push it onto an embedder-side stack, and return the new
@@ -87,9 +88,7 @@ class RustJobQueue : public JS::JobQueue {
 
   virtual bool empty() const override { return mTraps.empty(mQueue); }
 
-  virtual void runJobs(JSContext* cx) override {
-    MOZ_ASSERT(false, "runJobs should not be invoked");
-  }
+  virtual void runJobs(JSContext* cx) override { mTraps.runJobs(mQueue, cx); }
 
   bool isDrainingStopped() const override { return false; }
 


### PR DESCRIPTION
in the [SpiderMonkey Debugger API](https://firefox-source-docs.mozilla.org/js/Debugger/), hooks like [onNewGlobalObject()](https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.html#onnewglobalobject-global) use an AutoDebuggerJobQueueInterruption to [switch to a new microtask queue](https://github.com/servo/mozjs/blob/b14aebff23ac4d5b0652060ef949334bda08b22f/mozjs-sys/mozjs/js/src/debugger/Debugger.cpp#L2834-L2841) and avoid clobbering the debuggee’s microtask queue. this in turn relies on JobQueue::runJobs(), which is [not yet implemented in RustJobQueue](https://github.com/servo/mozjs/blob/b14aebff23ac4d5b0652060ef949334bda08b22f/mozjs-sys/src/jsglue.cpp#L76-L78).

this patch implements [runJobs()](https://github.com/servo/mozjs/blob/b14aebff23ac4d5b0652060ef949334bda08b22f/mozjs-sys/mozjs/js/public/Promise.h#L61-L76) for RustJobQueue by calling into Servo’s MicrotaskQueue::checkpoint() via a new function in JobQueueTraps.

SpiderMonkey [does not own any job queues](https://github.com/servo/mozjs/blob/b14aebff23ac4d5b0652060ef949334bda08b22f/mozjs-sys/mozjs/js/public/Promise.h#L117-L123), so the lifetime of these queues is managed in Servo, where they are stored in a Vec-based stack. stack-like behaviour is adequate for SpiderMonkey’s save and restore patterns, as far as we can tell, but we’ve added an assertion just in case.

Servo patch: servo/servo#38265