### PR TITLE
Implement JSAutoStructuredCloneBufferWrapper

### DIFF
--- a/mozjs/src/rust.rs
+++ b/mozjs/src/rust.rs
@@ -48,10 +48,7 @@ use crate::jsapi::{InitSelfHostedCode, IsWindowSlow};
 use crate::jsapi::{
     JSAutoRealm, JS_SetGCParameter, JS_SetNativeStackQuota, JS_WrapObject, JS_WrapValue,
 };
-use crate::jsapi::{
-    JSAutoStructuredCloneBuffer, JSStructuredCloneCallbacks, JSStructuredCloneData,
-    StructuredCloneScope,
-};
+use crate::jsapi::{JSAutoStructuredCloneBuffer, JSStructuredCloneCallbacks, StructuredCloneScope};
 use crate::jsapi::{JSClass, JSClassOps, JSContext, Realm, JSCLASS_RESERVED_SLOTS_SHIFT};
 use crate::jsapi::{JSErrorReport, JSFunctionSpec, JSGCParamKey};
 use crate::jsapi::{JSObject, JSPropertySpec, JSRuntime};

--- a/mozjs/src/rust.rs
+++ b/mozjs/src/rust.rs
@@ -535,7 +535,7 @@ impl Drop for CompileOptionsWrapper {
 }
 
 pub struct JSAutoStructuredCloneBufferWrapper {
-    pub ptr: *mut JSAutoStructuredCloneBuffer,
+    ptr: NonNull<JSAutoStructuredCloneBuffer>,
 }
 
 impl JSAutoStructuredCloneBufferWrapper {
@@ -543,16 +543,21 @@ impl JSAutoStructuredCloneBufferWrapper {
         scope: StructuredCloneScope,
         callbacks: *const JSStructuredCloneCallbacks,
     ) -> Self {
-        let ptr = NewJSAutoStructuredCloneBuffer(scope, callbacks);
-        assert!(!ptr.is_null());
-        Self { ptr }
+        let raw_ptr = NewJSAutoStructuredCloneBuffer(scope, callbacks);
+        Self {
+            ptr: NonNull::new(raw_ptr).unwrap(),
+        }
+    }
+
+    pub fn as_raw_ptr(&self) -> *mut JSAutoStructuredCloneBuffer {
+        self.ptr.as_ptr()
     }
 }
 
 impl Drop for JSAutoStructuredCloneBufferWrapper {
     fn drop(&mut self) {
         unsafe {
-            DeleteJSAutoStructuredCloneBuffer(self.ptr);
+            DeleteJSAutoStructuredCloneBuffer(self.ptr.as_ptr());
         }
     }
 }

--- a/mozjs/src/rust.rs
+++ b/mozjs/src/rust.rs
@@ -543,9 +543,9 @@ impl JSAutoStructuredCloneBufferWrapper {
         scope: StructuredCloneScope,
         callbacks: *const JSStructuredCloneCallbacks,
     ) -> Self {
-        Self {
-            ptr: NewJSAutoStructuredCloneBuffer(scope, callbacks),
-        }
+        let ptr = NewJSAutoStructuredCloneBuffer(scope, callbacks);
+        assert!(!ptr.is_null());
+        Self { ptr }
     }
 }
 

--- a/mozjs/src/rust.rs
+++ b/mozjs/src/rust.rs
@@ -28,6 +28,7 @@ use crate::glue::{CreateRootedIdVector, CreateRootedObjectVector};
 use crate::glue::{
     DeleteCompileOptions, DeleteRootedObjectVector, DescribeScriptedCaller, DestroyRootedIdVector,
 };
+use crate::glue::{DeleteJSAutoStructuredCloneBuffer, NewJSAutoStructuredCloneBuffer};
 use crate::glue::{
     GetIdVectorAddress, GetObjectVectorAddress, NewCompileOptions, SliceRootedIdVector,
 };
@@ -46,6 +47,10 @@ use crate::jsapi::{Evaluate2, HandleValueArray, StencilRelease};
 use crate::jsapi::{InitSelfHostedCode, IsWindowSlow};
 use crate::jsapi::{
     JSAutoRealm, JS_SetGCParameter, JS_SetNativeStackQuota, JS_WrapObject, JS_WrapValue,
+};
+use crate::jsapi::{
+    JSAutoStructuredCloneBuffer, JSStructuredCloneCallbacks, JSStructuredCloneData,
+    StructuredCloneScope,
 };
 use crate::jsapi::{JSClass, JSClassOps, JSContext, Realm, JSCLASS_RESERVED_SLOTS_SHIFT};
 use crate::jsapi::{JSErrorReport, JSFunctionSpec, JSGCParamKey};
@@ -529,6 +534,29 @@ impl CompileOptionsWrapper {
 impl Drop for CompileOptionsWrapper {
     fn drop(&mut self) {
         unsafe { DeleteCompileOptions(self.ptr) }
+    }
+}
+
+pub struct JSAutoStructuredCloneBufferWrapper {
+    pub ptr: *mut JSAutoStructuredCloneBuffer,
+}
+
+impl JSAutoStructuredCloneBufferWrapper {
+    pub unsafe fn new(
+        scope: StructuredCloneScope,
+        callbacks: *const JSStructuredCloneCallbacks,
+    ) -> Self {
+        Self {
+            ptr: NewJSAutoStructuredCloneBuffer(scope, callbacks),
+        }
+    }
+}
+
+impl Drop for JSAutoStructuredCloneBufferWrapper {
+    fn drop(&mut self) {
+        unsafe {
+            DeleteJSAutoStructuredCloneBuffer(self.ptr);
+        }
     }
 }
 


### PR DESCRIPTION
Implement a safe wrapper of `*mut JSAutoStructuredCloneBuffer` that Implements the Drop trait to prevent leakage.