### PR TITLE
Bump mozjs-sys version

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.128.13-1"
+version = "0.128.13-2"
 authors = ["Mozilla"]
 links = "mozjs"
 license.workspace = true


### PR DESCRIPTION
We forget to do this in #595, talked in zulip: https://servo.zulipchat.com/#narrow/channel/263398-general/topic/Building.20new.20mozjs-sys.20artifacts