### PR TITLE
Allow embedder to indicate whether scripts are inline

### DIFF
--- a/mozjs/examples/eval.rs
+++ b/mozjs/examples/eval.rs
@@ -45,13 +45,7 @@ fn run(rt: Runtime) {
     let source: &'static str = "40 + 2";
 
     let options = rt.new_compile_options(filename, lineno);
-    let res = rt.evaluate_script(
-        global.handle(),
-        source,
-        filename,
-        rval.handle_mut(),
-        options,
-    );
+    let res = rt.evaluate_script(global.handle(), source, rval.handle_mut(), options);
 
     if res.is_ok() {
         /* Should get a number back from the example source. */

--- a/mozjs/tests/callback.rs
+++ b/mozjs/tests/callback.rs
@@ -49,13 +49,7 @@ fn callback() {
         rooted!(in(context) let mut rval = UndefinedValue());
         let options = runtime.new_compile_options("test.js", 0);
         assert!(runtime
-            .evaluate_script(
-                global.handle(),
-                javascript,
-                "test.js",
-                rval.handle_mut(),
-                options
-            )
+            .evaluate_script(global.handle(), javascript, rval.handle_mut(), options)
             .is_ok());
     }
 }

--- a/mozjs/tests/capture_stack.rs
+++ b/mozjs/tests/capture_stack.rs
@@ -74,13 +74,7 @@ fn capture_stack() {
         rooted!(in(context) let mut rval = UndefinedValue());
         let options = runtime.new_compile_options("test.js", 0);
         assert!(runtime
-            .evaluate_script(
-                global.handle(),
-                javascript,
-                "test.js",
-                rval.handle_mut(),
-                options
-            )
+            .evaluate_script(global.handle(), javascript, rval.handle_mut(), options)
             .is_ok());
     }
 }

--- a/mozjs/tests/enforce_range.rs
+++ b/mozjs/tests/enforce_range.rs
@@ -59,7 +59,6 @@ impl SM {
                 .evaluate_script(
                     HandleObject::from_raw(self.global.handle()),
                     js,
-                    "test",
                     rval.handle_mut(),
                     options,
                 )

--- a/mozjs/tests/enumerate.rs
+++ b/mozjs/tests/enumerate.rs
@@ -36,13 +36,7 @@ fn enumerate() {
         rooted!(in(context) let mut rval = UndefinedValue());
         let options = runtime.new_compile_options("test", 1);
         assert!(runtime
-            .evaluate_script(
-                global.handle(),
-                "({ 'a': 7 })",
-                "test",
-                rval.handle_mut(),
-                options,
-            )
+            .evaluate_script(global.handle(), "({ 'a': 7 })", rval.handle_mut(), options,)
             .is_ok());
         assert!(rval.is_object());
 

--- a/mozjs/tests/evaluate.rs
+++ b/mozjs/tests/evaluate.rs
@@ -33,7 +33,7 @@ fn evaluate() {
         rooted!(in(context) let mut rval = UndefinedValue());
         let options = runtime.new_compile_options("test", 1);
         assert!(runtime
-            .evaluate_script(global.handle(), "1 + 1", "test", rval.handle_mut(), options)
+            .evaluate_script(global.handle(), "1 + 1", rval.handle_mut(), options)
             .is_ok());
         assert_eq!(rval.get().to_int32(), 2);
     }

--- a/mozjs/tests/iterate_stack.rs
+++ b/mozjs/tests/iterate_stack.rs
@@ -94,13 +94,7 @@ fn iterate_stack_frames() {
         rooted!(in(context) let mut rval = UndefinedValue());
         let options = runtime.new_compile_options("test.js", 0);
         assert!(runtime
-            .evaluate_script(
-                global.handle(),
-                javascript,
-                "test.js",
-                rval.handle_mut(),
-                options
-            )
+            .evaluate_script(global.handle(), javascript, rval.handle_mut(), options)
             .is_ok());
     }
 }

--- a/mozjs/tests/jsvalue.rs
+++ b/mozjs/tests/jsvalue.rs
@@ -25,7 +25,7 @@ unsafe fn tester<F: Fn(RootedGuard<JSVal>)>(
     rooted!(in(cx) let mut rval = UndefinedValue());
     let options = rt.new_compile_options("test", 1);
     assert!(rt
-        .evaluate_script(global, js, "test", rval.handle_mut(), options)
+        .evaluate_script(global, js, rval.handle_mut(), options)
         .is_ok());
     test(rval);
 

--- a/mozjs/tests/panic.rs
+++ b/mozjs/tests/panic.rs
@@ -46,13 +46,7 @@ fn test_panic() {
 
         rooted!(in(context) let mut rval = UndefinedValue());
         let options = runtime.new_compile_options("test.js", 0);
-        let _ = runtime.evaluate_script(
-            global.handle(),
-            "test();",
-            "test.js",
-            rval.handle_mut(),
-            options,
-        );
+        let _ = runtime.evaluate_script(global.handle(), "test();", rval.handle_mut(), options);
     }
 }
 

--- a/mozjs/tests/stack_limit.rs
+++ b/mozjs/tests/stack_limit.rs
@@ -35,7 +35,6 @@ fn stack_limit() {
             .evaluate_script(
                 global.handle(),
                 "function f() { f.apply() } f()",
-                "test",
                 rval.handle_mut(),
                 options,
             )

--- a/mozjs/tests/typedarray.rs
+++ b/mozjs/tests/typedarray.rs
@@ -39,7 +39,6 @@ fn typedarray() {
             .evaluate_script(
                 global.handle(),
                 "new Uint8Array([0, 2, 4])",
-                "test",
                 rval.handle_mut(),
                 options,
             )

--- a/mozjs/tests/vec_conversion.rs
+++ b/mozjs/tests/vec_conversion.rs
@@ -59,7 +59,6 @@ fn vec_conversion() {
             .evaluate_script(
                 global.handle(),
                 "new Set([1, 2, 3])",
-                "test",
                 rval.handle_mut(),
                 options,
             )
@@ -71,7 +70,7 @@ fn vec_conversion() {
 
         let options = runtime.new_compile_options("test", 1);
         assert!(runtime
-            .evaluate_script(global.handle(), "({})", "test", rval.handle_mut(), options)
+            .evaluate_script(global.handle(), "({})", rval.handle_mut(), options)
             .is_ok());
         let converted = Vec::<i32>::from_jsval(context, rval.handle(), ConversionBehavior::Default);
         assert!(match converted {


### PR DESCRIPTION
to use the [SpiderMonkey Debugger API](https://firefox-source-docs.mozilla.org/js/Debugger/) as the single source of truth about scripts and their sources for devtools purposes (servo/servo#38334), the debugger script needs to be able to distinguish inline scripts from other scripts, because inline scripts are a special case where the source contents need to come from the Servo parser.

the mechanism for this is [Debugger.Script.prototype.**introductionType**](https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.Source.html#introductiontype), which is `inlineScript` for inline scripts or a variety of other values for other kinds of scripts, but only the embedder can provide this information.

this patch expands on CompileOptionsWrapper, making it a safe wrapper around CompileOptions. to construct one from safe code, use Runtime::new_compile_options(). then you can call `set_introduction_type(&'static CStr)` on the new instance. we also make Runtime::evaluate_script() take a CompileOptionsWrapper from the caller, instead of constructing one internally.

Servo patch: servo/servo#38363
Fixes: part of servo/servo#38378