### PR TITLE
fix icu_capi version

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -35,7 +35,7 @@ libz-sys = "1.1.19"
 encoding_c = "0.9.8"
 encoding_c_mem = "0.2.6"
 # unicode-bidi-ffi = { path = "./mozjs/intl/bidi/rust/unicode-bidi-ffi" }
-icu_capi = "1.4.0" # keep in sync with intl/icu_capi/Cargo.toml
+icu_capi = "=1.5.0" # keep in sync with intl/icu_capi/Cargo.toml
 
 [build-dependencies]
 bindgen.workspace = true

--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.137.0-0"
+version = "0.137.0-1"
 authors = ["Mozilla"]
 links = "mozjs"
 license.workspace = true


### PR DESCRIPTION
The vendored version of icu_capi was bumped to 1.5.0 in the SM 137
 update, so we need to update the version in the Cargo.toml too.
Additionally, we use `=1.5.0` to force selecting the same version as the vendored one.
The vendored icu_capi is never built, only its headers are used.