### PR TITLE
Remove unneeded icu_capi features

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -36,7 +36,7 @@ encoding_c = "0.9.8"
 encoding_c_mem = "0.2.6"
 # unicode-bidi-ffi = { path = "./mozjs/intl/bidi/rust/unicode-bidi-ffi" }
 # keep in sync with intl/icu_capi/Cargo.toml
-icu_capi = { version = "=1.5.0", default-features = false, features = ["compiled_data", "icu_segmenter"] }
+icu_capi = { version = "=1.5.0", default-features = false, features = ["compiled_data", "icu_calendar", "icu_properties", "icu_segmenter"] }
 
 [build-dependencies]
 bindgen.workspace = true

--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -35,7 +35,8 @@ libz-sys = "1.1.19"
 encoding_c = "0.9.8"
 encoding_c_mem = "0.2.6"
 # unicode-bidi-ffi = { path = "./mozjs/intl/bidi/rust/unicode-bidi-ffi" }
-icu_capi = "=1.5.0" # keep in sync with intl/icu_capi/Cargo.toml
+# keep in sync with intl/icu_capi/Cargo.toml
+icu_capi = {  version = "=1.5.0", default-features = false, features = ["compiled_data", "icu_segmenter"] }
 
 [build-dependencies]
 bindgen.workspace = true

--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.137.0-1"
+version = "0.137.0-2"
 authors = ["Mozilla"]
 links = "mozjs"
 license.workspace = true
@@ -36,7 +36,7 @@ encoding_c = "0.9.8"
 encoding_c_mem = "0.2.6"
 # unicode-bidi-ffi = { path = "./mozjs/intl/bidi/rust/unicode-bidi-ffi" }
 # keep in sync with intl/icu_capi/Cargo.toml
-icu_capi = {  version = "=1.5.0", default-features = false, features = ["compiled_data", "icu_segmenter"] }
+icu_capi = { version = "=1.5.0", default-features = false, features = ["compiled_data", "icu_segmenter"] }
 
 [build-dependencies]
 bindgen.workspace = true

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -385,6 +385,7 @@ fn link_static_lib_binaries(build_dir: &Path) {
         println!("cargo:rustc-link-lib=psapi");
         println!("cargo:rustc-link-lib=user32");
         println!("cargo:rustc-link-lib=Dbghelp");
+        println!("cargo:rustc-link-lib=advapi32");
         if target.contains("gnu") {
             println!("cargo:rustc-link-lib=stdc++");
         }


### PR DESCRIPTION
We don't need all default features, which are quite a few: https://github.com/unicode-org/icu4x/blob/599f3366f901eb0cc0af9de6c9de99998734bb8a/ffi/capi/Cargo.toml#L38
This reduces servo binary size by around 15% in production mode.

Companion PR: https://github.com/servo/servo/pull/38666