### PR TITLE
Remove unneeded icu_capi features 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
         features: ["debugmozjs", '""']
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.85.0
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
@@ -117,7 +117,7 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.85.0
         with:
           targets: ${{ matrix.target }}
       - name: Install deps
@@ -177,7 +177,7 @@ jobs:
         with:
           ndk-version: r28
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.85.0
         with:
           targets: ${{ matrix.target }}
       - name: Build
@@ -210,7 +210,7 @@ jobs:
         with:
           version: "4.1"
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.85.0
         with:
           targets: ${{ matrix.target }}
       - name: Build (arch ${{ matrix.target }} )
@@ -242,7 +242,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.85.0
         with:
           targets: ${{ matrix.target }}
       - run: cargo test --tests --examples --target ${{ matrix.target }}
@@ -253,7 +253,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.85.0
       - name: Check Rust formatting
         run: cargo fmt --check
       - name: Check C++ formatting

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: [main]
+    branches: [main, icu_min]
   pull_request:
   workflow_dispatch:
   merge_group:

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           ndk-version: r28
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.85.0
         with:
           targets: ${{ matrix.target }}
       - name: Download prebuilt mozjs from artifact
@@ -109,7 +109,7 @@ jobs:
         with:
           version: "4.1"
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.85.0
         with:
           targets: ${{ matrix.target }}
       - name: Download prebuilt mozjs from artifact

--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -35,7 +35,8 @@ libz-sys = "1.1.19"
 encoding_c = "0.9.8"
 encoding_c_mem = "0.2.6"
 # unicode-bidi-ffi = { path = "./mozjs/intl/bidi/rust/unicode-bidi-ffi" }
-icu_capi = "=1.5.0" # keep in sync with intl/icu_capi/Cargo.toml
+# keep in sync with intl/icu_capi/Cargo.toml
+icu_capi = {  version = "=1.5.0", default-features = false, features = ["compiled_data", "icu_segmenter"] }
 
 [build-dependencies]
 bindgen.workspace = true

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,10 @@
+[toolchain]
+# Keep this in sync with the Minimum-supported Rust version (MSRV) of servo!
+# When updating also search the github worflows .yml files for the old version
+# and update all occurences.
+channel = "1.85.0"
+
+components = [
+    "clippy",
+    "rustfmt"
+]


### PR DESCRIPTION
We don't need all default features, which are quite a few: https://github.com/unicode-org/icu4x/blob/599f3366f901eb0cc0af9de6c9de99998734bb8a/ffi/capi/Cargo.toml#L38
This reduces servo binary size by around 15% in production mode.

Companion PR: https://github.com/servo/servo/pull/38666