### PR TITLE
Bump sccache-action to 0.0.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
           brew list -1 | grep python | while read formula; do brew unlink $formula; brew link --overwrite $formula; done
           brew install llvm yasm
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.8
+        uses: mozilla-actions/sccache-action@v0.0.9
       - name: Build
         run: |
           cargo build --verbose --features ${{ matrix.features }}
@@ -75,7 +75,7 @@ jobs:
           directory: ${{ runner.temp }}/llvm
           version: "16.0"
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.8
+        uses: mozilla-actions/sccache-action@v0.0.9
       - name: Build
         run: |
           cargo build --verbose --features ${{ matrix.features }}
@@ -134,7 +134,7 @@ jobs:
           # Prepend to path so we override the default LLVM installation in priority
           echo "C:\ProgramData\scoop\apps\llvm\current\bin;" + (Get-Content $env:GITHUB_PATH -Raw) | Set-Content $env:GITHUB_PATH
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.8
+        uses: mozilla-actions/sccache-action@v0.0.9
       - name: Build Windows
         shell: cmd
         run: |


### PR DESCRIPTION
https://github.com/servo/mozjs/actions/caches does not show any caches from sccache, so presumably something is not working. The releases-diff to 0.0.8 indicates that there was some change to the actions cache version.
https://github.com/Mozilla-Actions/sccache-action/compare/v0.0.8...v0.0.9

After opening this PR, the actions/caches tab was populated with cache entries from this PRs branch, indicating that the bump indeed fixes sccache.