### PR TITLE
mozjs_sys: Honor the `CXXSTDLIB` environment variable

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.137.0-2"
+version = "0.137.0-3"
 authors = ["Mozilla"]
 links = "mozjs"
 license.workspace = true

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -386,13 +386,15 @@ fn link_static_lib_binaries(build_dir: &Path) {
         println!("cargo:rustc-link-lib=user32");
         println!("cargo:rustc-link-lib=Dbghelp");
         println!("cargo:rustc-link-lib=advapi32");
-        if target.contains("gnu") {
-            println!("cargo:rustc-link-lib=stdc++");
-        }
+    }
+    if let Some(cxxstdlib) = env::var("CXXSTDLIB").ok() {
+        println!("cargo:rustc-link-lib={cxxstdlib}");
     } else if target.contains("apple") || target.contains("freebsd") || target.contains("ohos") {
         println!("cargo:rustc-link-lib=c++");
-    } else {
+    } else if target.contains("windows") && target.contains("gnu") {
         println!("cargo:rustc-link-lib=stdc++");
+    } else if !target.contains("windows") {
+        println!("cargo:rustc-link-lib=stdc++")
     }
 }
 


### PR DESCRIPTION
`CXXSTDLIB` is an environment variable used by `cc` and many other crates which lets developers to choose a standard C++ library of their choice.

Make use of that variable in mozjs_sys's build.rs as well.

One of the use cases is supporting Linux distributions which use LLVM instead of GCC as the main toolchain (e.g. Chimera, Gentoo musl-llvm profile, OpenMandriva).