### PR TITLE
feat: Add wrapper type `Utf8Chars<'a>`

### DIFF
--- a/mozjs/src/conversions.rs
+++ b/mozjs/src/conversions.rs
@@ -852,7 +852,7 @@ impl FromJSValConvertible for *mut JS::Symbol {
 /// A wrapper type over [`crate::jsapi::UTF8Chars`]. This is created to help transferring
 /// a rust string to mozjs. The inner [`crate::jsapi::UTF8Chars`] can be accessed via the
 /// [`std::ops::Deref`] trait.
-pub(crate) struct Utf8Chars<'a> {
+pub struct Utf8Chars<'a> {
     lt_marker: std::marker::PhantomData<&'a ()>,
     inner: crate::jsapi::UTF8Chars,
 }


### PR DESCRIPTION
Per discussion in https://github.com/servo/servo/pull/39799, this PR adds a helper type `Utf8Chars<'a>`, which is a wrapper over `jsapi::UTF8Chars` with lifetime `'a`. The added lifetime helps safer use of `jsapi::UTF8Chars`