### PR TITLE
CI: Do not upload artifacts stabel/beta toolchains tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
           subject-path: ./target/libmozjs-${{ matrix.platform.target }}.tar.gz
 
       - name: Upload artifact
-        if: ${{ matrix.features != 'debugmozjs' && !env.NEW_RUST_CHECK }}
+        if: ${{ matrix.features != 'debugmozjs' && env.NEW_RUST_CHECK == 'false' }}
         uses: actions/upload-artifact@v4
         with:
           path: ./target/libmozjs-${{ matrix.platform.target }}.tar.gz
@@ -108,7 +108,7 @@ jobs:
           subject-path: ./target/libmozjs-x86_64-unknown-linux-gnu.tar.gz
 
       - name: Upload artifact
-        if: ${{ matrix.features != 'debugmozjs'  && !env.NEW_RUST_CHECK }}
+        if: ${{ matrix.features != 'debugmozjs'  && env.NEW_RUST_CHECK == 'false' }}
         uses: actions/upload-artifact@v4
         with:
           path: ./target/libmozjs-x86_64-unknown-linux-gnu.tar.gz
@@ -167,7 +167,7 @@ jobs:
           subject-path: ./target/${{ matrix.target }}/libmozjs-x86_64-pc-windows-msvc.tar.gz
 
       - name: Upload artifact
-        if: ${{ !contains(matrix.target, 'aarch64') && matrix.features != 'debugmozjs' && !env.NEW_RUST_CHECK }}
+        if: ${{ !contains(matrix.target, 'aarch64') && matrix.features != 'debugmozjs' && env.NEW_RUST_CHECK == 'false' }}
         uses: actions/upload-artifact@v4
         with:
           path: ./target/${{ matrix.target }}/libmozjs-x86_64-pc-windows-msvc.tar.gz
@@ -209,7 +209,7 @@ jobs:
           subject-path: "./target/libmozjs-${{ matrix.target }}.tar.gz"
       - name: Upload artifact
         uses: actions/upload-artifact@v4
-        if: ${{ !env.NEW_RUST_CHECK }}
+        if: ${{ env.NEW_RUST_CHECK == 'false' }}
         with:
           path: ./target/libmozjs-${{ matrix.target }}.tar.gz
           name: libmozjs-${{ matrix.target }}.tar.gz
@@ -245,7 +245,7 @@ jobs:
           subject-path: "./target/libmozjs-${{ matrix.target }}.tar.gz"
       - name: Upload artifact
         uses: actions/upload-artifact@v4
-        if: ${{ !env.NEW_RUST_CHECK }}
+        if: ${{ env.NEW_RUST_CHECK == 'false' }}
         with:
           path: ./target/libmozjs-${{ matrix.target }}.tar.gz
           name: libmozjs-${{ matrix.target }}.tar.gz
@@ -293,7 +293,7 @@ jobs:
           subject-path: "./target/libmozjs-wasm32-${{ matrix.target }}.tar.gz"
       - name: Upload artifact
         uses: actions/upload-artifact@v4
-        if: ${{ !env.NEW_RUST_CHECK }}
+        if: ${{ env.NEW_RUST_CHECK == 'false' }}
         with:
           path: ./target/libmozjs-wasm32-${{ matrix.target }}.tar.gz
           name: libmozjs-wasm32-${{ matrix.target }}.tar.gz


### PR DESCRIPTION
This will make scheduled runs actually useful, because right now they fail due too conflict in artifact names.