### PR TITLE
Further fixes to offline builds with vendored sources

### DIFF
--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -149,6 +149,7 @@ fn get_icu_capi_include_path() -> String {
         .manifest_path(manifest_path)
         // icu_capi is feature guarded behind the `intl` feature.
         .features(CargoOpt::SomeFeatures(vec!["intl".into()]))
+        .other_options(vec!["--offline".into()])
         .exec()
         .unwrap();
     let packages = metadata.packages;


### PR DESCRIPTION
- When invoking cargo metadata explicitly set the manifest path and the cwd. Since the cwd is in the target directory, and vendored sources can be placed at arbitrary locations, not setting the cwd / manifest path can cause the invocation to fail.
- We need `--offline` to prevent cargo metadata from attempting to access the internet (which fails in offline builds). Internet access is not needed for the data we are interested in. 

Manually tested in servo with the following process:

1. checkout servo main
2. patch mozjs to point to this PRs repo and branch
3. `cargo update -p mozjs`
4. `cargo clean`
5. `cargo vendor`
6. edit `.cargo/config.toml` according to the vendor instructions
7. disconnect internet
8. `./mach build --frozen`