### PR TITLE
Use `DEP_ICU_CAPI1_C_INCLUDE_DIR`

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.140.0-7"
+version = "0.140.0-8"
 authors = ["Mozilla", "The Servo Project Developers"]
 links = "mozjs"
 license.workspace = true

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -220,7 +220,7 @@ fn build_spidermonkey(build_dir: &Path) {
 
     #[cfg(feature = "intl")]
     {
-        let icu_c_include_path = env::var("DEP_ICU_CAPI_C_INCLUDE_DIR").unwrap();
+        let icu_c_include_path = env::var("DEP_ICU_CAPI1_C_INCLUDE_DIR").unwrap();
         cxxflags.push(format!("-I{}", &icu_c_include_path.replace("\\", "/")));
     }
 


### PR DESCRIPTION
draft because we are waiting for https://github.com/unicode-org/icu4x/pull/7203 to be released