### PR TITLE
CI: use macos-15-intel instead of macos-13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         features: ["debugmozjs", '""']
         platform:
           - { target: aarch64-apple-darwin, os: macos-14 }
-          - { target: x86_64-apple-darwin, os: macos-13 }
+          - { target: x86_64-apple-darwin, os: macos-15-intel }
     runs-on: ${{ matrix.platform.os }}
     env:
       RUSTC_WRAPPER: sccache


### PR DESCRIPTION
to avoid burnouts