### PR TITLE
build: Remove deprecated cc-rs static_flag(true) call.

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.140.5-0"
+version = "0.140.5-1"
 authors = ["Mozilla", "The Servo Project Developers"]
 links = "mozjs"
 license.workspace = true

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -256,7 +256,6 @@ fn build_spidermonkey(build_dir: &Path) {
             .for_each(|obj| {
                 make_static.object(obj);
             });
-        make_static.static_flag(true);
         make_static.compile("js_static");
     }
 


### PR DESCRIPTION
This method has been deprecated in cc-rs, since cc-rs will only build static libraries. See the deprecation notice in the latest version:
https://docs.rs/cc/latest/cc/struct.Build.html#method.static_flag