### PR TITLE
Switch x86 macos image to macos-15-intel

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         platform:
           - { target: aarch64-apple-darwin, os: macos-14 }
-          - { target: x86_64-apple-darwin, os: macos-13 }
+          - { target: x86_64-apple-darwin, os: macos-15-intel }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest }
           - { target: x86_64-pc-windows-msvc, os: windows-latest }
     runs-on: ${{ matrix.platform.os }}


### PR DESCRIPTION
CI is failing due to a brownout of the macos-13 image. Switch to the macos-15-intel image instead.