### PR TITLE
Silence unnecessary_transmutes warning in bindgen code

### DIFF
--- a/mozjs-sys/src/glue.rs
+++ b/mozjs-sys/src/glue.rs
@@ -4,6 +4,7 @@ mod generated {
     #![allow(non_upper_case_globals)]
     #![allow(non_camel_case_types)]
     #![allow(non_snake_case)]
+    #![allow(unnessecary_transmutes)]
     include!(concat!(env!("OUT_DIR"), "/build/gluebindings.rs"));
 }
 

--- a/mozjs-sys/src/lib.rs
+++ b/mozjs-sys/src/lib.rs
@@ -34,6 +34,7 @@ pub use crate::generated::root as jsapi;
 #[doc(hidden)]
 #[allow(dead_code)]
 mod generated {
+    #![allow(unnecessary_transmutes)]
     include!(concat!(env!("OUT_DIR"), "/build/jsapi.rs"));
 }
 


### PR DESCRIPTION
This lint needs to be fixed in bindgen, so we can only silence it for now.