### PR TITLE
Revert "Fix OHOS define"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -227,7 +227,6 @@ jobs:
     strategy:
       matrix:
         target: ["aarch64-unknown-linux-ohos", "x86_64-unknown-linux-ohos"]
-        features: [ "", "--features debugmozjs"]
     steps:
       - uses: actions/checkout@v4
       - name: Setup OpenHarmony SDK
@@ -246,15 +245,15 @@ jobs:
         env:
           OHOS_SDK_NATIVE: ${{ steps.setup_sdk.outputs.ohos_sdk_native }}
         run: |
-          ./ohos-build cargo +${{ steps.toolchain.outputs.name }} build --target="${{ matrix.target }}" ${{ matrix.features }}
+          ./ohos-build cargo +${{ steps.toolchain.outputs.name }} build --target="${{ matrix.target }}"
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
-        if: ${{ inputs.release && matrix.features == '' }}
+        if: ${{ inputs.release }}
         with:
           subject-path: "./target/libmozjs-${{ matrix.target }}.tar.gz"
       - name: Upload artifact
         uses: actions/upload-artifact@v4
-        if: ${{ env.NEW_RUST_CHECK == 'false' && matrix.features == '' }}
+        if: ${{ env.NEW_RUST_CHECK == 'false' }}
         with:
           path: ./target/libmozjs-${{ matrix.target }}.tar.gz
           name: libmozjs-${{ matrix.target }}.tar.gz

--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.140.5-4"
+version = "0.140.5-3"
 authors = ["Mozilla", "The Servo Project Developers"]
 links = "mozjs"
 license.workspace = true

--- a/mozjs-sys/etc/patches/0034-build__Add_compile_definition_for_ohos.patch
+++ b/mozjs-sys/etc/patches/0034-build__Add_compile_definition_for_ohos.patch
@@ -1,15 +1,13 @@
 diff --git a/build/moz.configure/init.configure b/build/moz.configure/init.configure
 --- a/build/moz.configure/init.configure	(revision dbffebd0937c14d3c73ce9be4798da15cb2f369d)
 +++ b/build/moz.configure/init.configure	(revision 8a1dbb7da45148151dbb0d05d969118103cfa8d0)
-@@ -950,6 +950,16 @@
+@@ -950,6 +950,14 @@
  set_define("ANDROID", target_is_android)
 
 
 +@depends(target)
 +def target_is_ohos(target):
-+    if target.raw_os.endswith("-ohos"):
-+        return True
-+    return None
++    return target.raw_os.endswith("-ohos")
 +
 +
 +set_define("XP_OHOS", target_is_ohos)

--- a/mozjs-sys/etc/patches/0036-Redirect_errors_to_hilog_on_OpenHarmony.patch
+++ b/mozjs-sys/etc/patches/0036-Redirect_errors_to_hilog_on_OpenHarmony.patch
@@ -30,15 +30,12 @@ diff --git a/memory/mozalloc/mozalloc_abort.cpp b/memory/mozalloc/mozalloc_abort
 index 3cfc92533..9c487ac45 100644
 --- a/memory/mozalloc/mozalloc_abort.cpp
 +++ b/memory/mozalloc/mozalloc_abort.cpp
-@@ -9,6 +9,11 @@
+@@ -9,6 +9,8 @@
 
  #ifdef ANDROID
  #  include <android/log.h>
-+#elif defined(XP_OHOS)
-+  extern "C" {
-+    int OH_LOG_Print(unsigned int type, unsigned int level, unsigned int domain, const char *tag, const char *fmt, ...)
-+        __attribute__((__format__(os_log, 5, 6)));
-+  }
++#elif defined(OHOS)
++#  include <hilog/log.h>
  #endif
  #ifdef MOZ_WIDGET_ANDROID
  #  include "APKOpen.h"
@@ -49,8 +46,8 @@ index 3cfc92533..9c487ac45 100644
 -#ifndef ANDROID
 +#ifdef ANDROID
 +  __android_log_print(ANDROID_LOG_ERROR, "Gecko", "mozalloc_abort: %s", msg);
-+#elif defined(XP_OHOS)
-+    (void) OH_LOG_Print(0 /* LOG_APP */, 7 /* LOG_FATAL */, 0, "Gecko",
++#elif defined(OHOS)
++    (void) OH_LOG_Print(LOG_APP, LOG_ERROR, 0, "Gecko",
 +         "mozalloc_abort: %{public}s\n", msg);
 +#else
    fputs(msg, stderr);
@@ -64,15 +61,12 @@ diff --git a/mfbt/Assertions.h b/mfbt/Assertions.h
 index 0b7395177..e84d76aba 100644
 --- a/mfbt/Assertions.h
 +++ b/mfbt/Assertions.h
-@@ -88,6 +88,11 @@ MOZ_END_EXTERN_C
+@@ -88,6 +88,8 @@ MOZ_END_EXTERN_C
  #endif
  #ifdef ANDROID
  #  include <android/log.h>
-+#elif defined(XP_OHOS)
-+MOZ_BEGIN_EXTERN_C
-+int OH_LOG_Print(unsigned int type, unsigned int level, unsigned int domain, const char *tag, const char *fmt, ...)
-+    __attribute__((__format__(os_log, 5, 6)));
-+MOZ_END_EXTERN_C
++#elif defined(OHOS)
++#  include <hilog/log.h>
  #endif
 
  MOZ_BEGIN_EXTERN_C
@@ -80,42 +74,37 @@ index 0b7395177..e84d76aba 100644
    MozWalkTheStackWithWriter(MOZ_ReportAssertionFailurePrintFrame, CallerPC(),
                              /* aMaxFrames */ 0);
  #  endif
-+#elif defined(XP_OHOS)
-+    (void) OH_LOG_Print(0 /* LOG_APP */, 7 /* LOG_FATAL */, 0, "MOZ_Assert",
++#elif defined(OHOS)
++    (void) OH_LOG_Print(LOG_APP, LOG_FATAL, 0, "MOZ_Assert",
 +     "Assertion failure: %{public}s, at %{public}s:%{public}d\n",
 +     aStr, aFilename, aLine);
  #else
  #  if defined(MOZ_BUFFER_STDERR)
    char msg[1024] = "";
-@@ -144,8 +150,12 @@ MOZ_MAYBE_UNUSED static MOZ_COLD MOZ_NEVER_INLINE void MOZ_ReportCrash(
+@@ -144,6 +150,10 @@ MOZ_MAYBE_UNUSED static MOZ_COLD MOZ_NEVER_INLINE void MOZ_ReportCrash(
    __android_log_print(ANDROID_LOG_FATAL, "MOZ_CRASH",
                        "[%d] Hit MOZ_CRASH(%s) at %s:%d\n", MOZ_GET_PID(), aStr,
                        aFilename, aLine);
++#elif defined(OHOS)
++  (void) OH_LOG_Print(LOG_APP, LOG_FATAL, 0, "MOZ_CRASH",
++   "Hit MOZ_CRASH(%{public}s), at %{public}s:%{public}d\n",
++   aStr, aFilename, aLine);
  #  if defined(MOZ_DUMP_ASSERTION_STACK)
    MozWalkTheStackWithWriter(MOZ_CrashPrintFrame, CallerPC(),
                              /* aMaxFrames */ 0);
- #  endif
-+#elif defined(XP_OHOS)
-+  (void) OH_LOG_Print(0 /* LOG_APP */, 7 /* LOG_FATAL */, 0, "MOZ_CRASH",
-+   "Hit MOZ_CRASH(%{public}s), at %{public}s:%{public}d\n",
-+   aStr, aFilename, aLine);
- #else
 diff --git a/mfbt/DbgMacro.h b/mfbt/DbgMacro.h
 index 3247b993c..c7039d5f8 100644
 --- a/mfbt/DbgMacro.h
 +++ b/mfbt/DbgMacro.h
-@@ -18,8 +18,13 @@
+@@ -18,8 +18,10 @@
  template <typename T>
  class nsTSubstring;
 
 -#ifdef ANDROID
 +#if defined(ANDROID)
  #  include <android/log.h>
-+#elif defined(XP_OHOS)
-+  MOZ_BEGIN_EXTERN_C
-+  int OH_LOG_Print(unsigned int type, unsigned int level, unsigned int domain, const char *tag, const char *fmt, ...)
-+      __attribute__((__format__(os_log, 5, 6)));
-+  MOZ_END_EXTERN_C
++#elif defined(OHOS)
++#  include <hilog/log.h>
  #endif
 
  namespace mozilla {
@@ -126,8 +115,8 @@ index 3247b993c..c7039d5f8 100644
 -#ifdef ANDROID
 +#if defined(ANDROID)
    __android_log_print(ANDROID_LOG_INFO, "Gecko", "%s", s.str().c_str());
-+#elif defined(XP_OHOS)
-+    (void) OH_LOG_Print(0 /* LOG_APP */, 4 /* LOG_INFO */, 0, "Gecko", "%{public}s\n", s.str().c_str());
++#elif defined(OHOS)
++    (void) OH_LOG_Print(LOG_APP, LOG_INFO, 0, "Gecko", "%{public}s\n", s.str().c_str());
  #else
    fputs(s.str().c_str(), stderr);
  #endif
@@ -135,32 +124,26 @@ diff --git a/mozglue/misc/Debug.cpp b/mozglue/misc/Debug.cpp
 index c3a2ca89e..3fea33f4b 100644
 --- a/mozglue/misc/Debug.cpp
 +++ b/mozglue/misc/Debug.cpp
-@@ -18,9 +18,14 @@
+@@ -18,9 +18,11 @@
 
  #ifdef ANDROID
  #  include <android/log.h>
-+#elif defined(XP_OHOS)
-+  extern "C" {
-+    int OH_LOG_Print(unsigned int type, unsigned int level, unsigned int domain, const char *tag, const char *fmt, ...)
-+        __attribute__((__format__(os_log, 5, 6)));
-+  }
++#elif defined(OHOS)
++#  include <hilog/log.h>
  #endif
 
 -#ifndef ANDROID
-+#if ! (defined(ANDROID) || defined(XP_OHOS))
++#if ! (defined(ANDROID) || defined(OHOS))
  static void vprintf_stderr_buffered(const char* aFmt, va_list aArgs) {
    // Avoid interleaving by writing to an on-stack buffer and then writing in one
    // go with fputs, as long as the output fits into the buffer.
-@@ -66,6 +68,13 @@ MFBT_API void vprintf_stderr(const char* aFmt, va_list aArgs) {
+@@ -66,6 +68,10 @@ MFBT_API void vprintf_stderr(const char* aFmt, va_list aArgs) {
  MFBT_API void vprintf_stderr(const char* aFmt, va_list aArgs) {
    __android_log_vprint(ANDROID_LOG_INFO, "Gecko", aFmt, aArgs);
  }
-+#elif defined(XP_OHOS)
++#elif defined(OHOS)
 +MFBT_API void vprintf_stderr(const char* aFmt, va_list aArgs) {
-+    // OH_LOG_VPrint is available with API-level 18 (19?) or higher.
-+    char buffer[1024];
-+    VsprintfBuf(buffer, 1024, aFmt, aArgs);
-+   (void) OH_LOG_Print(0 /* LOG_APP */, 4 /* LOG_INFO */, 0, "Gecko", "%{public}s", buffer);
++   (void) OH_LOG_Print(LOG_APP, LOG_INFO, 0, "Gecko", aFmt, aArgs);
 +}
  #elif defined(FUZZING_SNAPSHOT)
  MFBT_API void vprintf_stderr(const char* aFmt, va_list aArgs) {
@@ -170,15 +153,15 @@ index c3a2ca89e..3fea33f4b 100644
 
  MFBT_API void print_stderr(std::stringstream& aStr) {
 -#if defined(ANDROID)
-+#if defined(ANDROID) || defined(XP_OHOS)
++#if defined(ANDROID) || defined(OHOS)
    // On Android logcat output is truncated to 1024 chars per line, and
    // we usually use std::stringstream to build up giant multi-line gobs
    // of output. So to avoid the truncation we find the newlines and
    // print the lines individually.
    std::string line;
    while (std::getline(aStr, line)) {
-+#  ifdef XP_OHOS
-+    (void) OH_LOG_Print(0 /* LOG_APP */, 4 /* LOG_INFO */, 0, "Gecko", "%{public}s", line.c_str());
++#  ifdef OHOS
++    printf_stderr("%{public}s\n", line.c_str());
 +#  else
      printf_stderr("%s\n", line.c_str());
 +#  endif
@@ -189,16 +172,15 @@ diff --git a/nsprpub/pr/src/io/prlog.c b/nsprpub/pr/src/io/prlog.c
 index 52bd6abc5..781402d56 100644
 --- a/nsprpub/pr/src/io/prlog.c
 +++ b/nsprpub/pr/src/io/prlog.c
-@@ -8,8 +8,11 @@
+@@ -8,8 +8,10 @@
  #include "prenv.h"
  #include "prprf.h"
  #include <string.h>
 -#ifdef ANDROID
 +#if defined(ANDROID)
  #  include <android/log.h>
-+#elif defined(XP_OHOS)
-+  int OH_LOG_Print(unsigned int type, unsigned int level, unsigned int domain, const char *tag, const char *fmt, ...)
-+      __attribute__((__format__(os_log, 5, 6)));
++#elif defined(OHOS)
++#  include <hilog/log.h>
  #endif
  
  /*
@@ -206,14 +188,14 @@ index 52bd6abc5..781402d56 100644
        PR_Write(fd, buf, nb);                               \
      }                                                      \
      PR_END_MACRO
-+#elif defined(XP_OHOS)
-+#  define _PUT_LOG(fd, buf, nb)                              \
++#elif defined(OHOS)
++#define _PUT_LOG(fd, buf, nb)                                \
 +    PR_BEGIN_MACRO                                           \
 +    if (fd == _pr_stderr) {                                  \
 +        char savebyte = buf[nb];                             \
 +        buf[nb] = '\0';                                      \
-+        (void) OH_LOG_Print(0 /* LOG_APP */, 4 /* LOG_INFO */,   \
-+               0, "PRLog", "%{public}s\n", buf);             \
++        (void) OH_LOG_Print(LOG_APP, LOG_INFO, 0, "PRLog",   \
++               "%{public}s\n", buf);             \
 +        buf[nb] = savebyte;                                  \
 +    } else {                                                 \
 +        PR_Write(fd, buf, nb);                               \
@@ -226,8 +208,8 @@ index 52bd6abc5..781402d56 100644
    PR_LogPrint("Aborting");
  #ifdef ANDROID
    __android_log_write(ANDROID_LOG_ERROR, "PRLog", "Aborting");
-+#elif defined(XP_OHOS)
-+  (void) OH_LOG_Print(0 /* LOG_APP */, 7 /* LOG_FATAL */, 0, "PRLog", "Aborting\n");
++#elif defined(OHOS)
++  (void) OH_LOG_Print(LOG_APP, LOG_ERROR, 0, "PRLog", "Aborting\n");
  #endif
    abort();
  }
@@ -235,8 +217,8 @@ index 52bd6abc5..781402d56 100644
  #elif defined(ANDROID)
    __android_log_assert(NULL, "PRLog", "Assertion failure: %s, at %s:%d\n", s,
                         file, ln);
-+#elif defined(XP_OHOS)
-+  (void) OH_LOG_Print(0 /* LOG_APP */, 7 /* LOG_FATAL */, 0, "PRLog",
++#elif defined(OHOS)
++  (void) OH_LOG_Print(LOG_APP, LOG_ERROR, 0, "PRLog",
 +                      "Assertion failure: %{public}s, at %{public}s:%{public}d\n",s, file, ln);
  #endif
    abort();

--- a/mozjs-sys/mozjs/build/moz.configure/init.configure
+++ b/mozjs-sys/mozjs/build/moz.configure/init.configure
@@ -910,9 +910,7 @@ set_define("ANDROID", target_is_android)
 
 @depends(target)
 def target_is_ohos(target):
-    if target.raw_os.endswith("-ohos"):
-        return True
-    return None
+    return target.raw_os.endswith("-ohos")
 
 
 set_define("XP_OHOS", target_is_ohos)

--- a/mozjs-sys/mozjs/memory/mozalloc/mozalloc_abort.cpp
+++ b/mozjs-sys/mozjs/memory/mozalloc/mozalloc_abort.cpp
@@ -9,11 +9,8 @@
 
 #ifdef ANDROID
 #  include <android/log.h>
-#elif defined(XP_OHOS)
-  extern "C" {
-    int OH_LOG_Print(unsigned int type, unsigned int level, unsigned int domain, const char *tag, const char *fmt, ...)
-        __attribute__((__format__(os_log, 5, 6)));
-  }
+#elif defined(OHOS)
+#  include <hilog/log.h>
 #endif
 #ifdef MOZ_WIDGET_ANDROID
 #  include "APKOpen.h"
@@ -28,8 +25,8 @@
 void mozalloc_abort(const char* const msg) {
 #ifdef ANDROID
   __android_log_print(ANDROID_LOG_ERROR, "Gecko", "mozalloc_abort: %s", msg);
-#elif defined(XP_OHOS)
-    (void) OH_LOG_Print(0 /* LOG_APP */, 7 /* LOG_FATAL */, 0, "Gecko",
+#elif defined(OHOS)
+    (void) OH_LOG_Print(LOG_APP, LOG_ERROR, 0, "Gecko",
          "mozalloc_abort: %{public}s\n", msg);
 #else
   fputs(msg, stderr);

--- a/mozjs-sys/mozjs/mfbt/Assertions.h
+++ b/mozjs-sys/mozjs/mfbt/Assertions.h
@@ -92,11 +92,8 @@ MOZ_END_EXTERN_C
 #endif
 #ifdef ANDROID
 #  include <android/log.h>
-#elif defined(XP_OHOS)
-MOZ_BEGIN_EXTERN_C
-int OH_LOG_Print(unsigned int type, unsigned int level, unsigned int domain, const char *tag, const char *fmt, ...)
-    __attribute__((__format__(os_log, 5, 6)));
-MOZ_END_EXTERN_C
+#elif defined(OHOS)
+#  include <hilog/log.h>
 #endif
 
 MOZ_BEGIN_EXTERN_C
@@ -132,8 +129,8 @@ MOZ_ReportAssertionFailure(const char* aStr, const char* aFilename,
   MozWalkTheStackWithWriter(MOZ_ReportAssertionFailurePrintFrame, CallerPC(),
                             /* aMaxFrames */ 0);
 #  endif
-#elif defined(XP_OHOS)
-    (void) OH_LOG_Print(0 /* LOG_APP */, 7 /* LOG_FATAL */, 0, "MOZ_Assert",
+#elif defined(OHOS)
+    (void) OH_LOG_Print(LOG_APP, LOG_FATAL, 0, "MOZ_Assert",
      "Assertion failure: %{public}s, at %{public}s:%{public}d\n",
      aStr, aFilename, aLine);
 #else
@@ -160,14 +157,14 @@ MOZ_MAYBE_UNUSED static MOZ_COLD MOZ_NEVER_INLINE void MOZ_ReportCrash(
   __android_log_print(ANDROID_LOG_FATAL, "MOZ_CRASH",
                       "[%d] Hit MOZ_CRASH(%s) at %s:%d\n", MOZ_GET_PID(), aStr,
                       aFilename, aLine);
+#elif defined(OHOS)
+  (void) OH_LOG_Print(LOG_APP, LOG_FATAL, 0, "MOZ_CRASH",
+   "Hit MOZ_CRASH(%{public}s), at %{public}s:%{public}d\n",
+   aStr, aFilename, aLine);
 #  if defined(MOZ_DUMP_ASSERTION_STACK)
   MozWalkTheStackWithWriter(MOZ_CrashPrintFrame, CallerPC(),
                             /* aMaxFrames */ 0);
 #  endif
-#elif defined(XP_OHOS)
-  (void) OH_LOG_Print(0 /* LOG_APP */, 7 /* LOG_FATAL */, 0, "MOZ_CRASH",
-   "Hit MOZ_CRASH(%{public}s), at %{public}s:%{public}d\n",
-   aStr, aFilename, aLine);
 #else
 #  if defined(MOZ_BUFFER_STDERR)
   char msg[1024] = "";

--- a/mozjs-sys/mozjs/mfbt/DbgMacro.h
+++ b/mozjs-sys/mozjs/mfbt/DbgMacro.h
@@ -20,11 +20,8 @@ class nsTSubstring;
 
 #if defined(ANDROID)
 #  include <android/log.h>
-#elif defined(XP_OHOS)
-  MOZ_BEGIN_EXTERN_C
-  int OH_LOG_Print(unsigned int type, unsigned int level, unsigned int domain, const char *tag, const char *fmt, ...)
-      __attribute__((__format__(os_log, 5, 6)));
-  MOZ_END_EXTERN_C
+#elif defined(OHOS)
+#  include <hilog/log.h>
 #endif
 
 namespace mozilla {
@@ -103,8 +100,8 @@ auto&& MozDbg(const char* aFile, int aLine, const char* aExpression,
   s << '\n';
 #if defined(ANDROID)
   __android_log_print(ANDROID_LOG_INFO, "Gecko", "%s", s.str().c_str());
-#elif defined(XP_OHOS)
-    (void) OH_LOG_Print(0 /* LOG_APP */, 4 /* LOG_INFO */, 0, "Gecko", "%{public}s\n", s.str().c_str());
+#elif defined(OHOS)
+    (void) OH_LOG_Print(LOG_APP, LOG_INFO, 0, "Gecko", "%{public}s\n", s.str().c_str());
 #else
   fputs(s.str().c_str(), stderr);
 #endif

--- a/mozjs-sys/mozjs/mozglue/misc/Debug.cpp
+++ b/mozjs-sys/mozjs/mozglue/misc/Debug.cpp
@@ -18,14 +18,11 @@
 
 #ifdef ANDROID
 #  include <android/log.h>
-#elif defined(XP_OHOS)
-  extern "C" {
-    int OH_LOG_Print(unsigned int type, unsigned int level, unsigned int domain, const char *tag, const char *fmt, ...)
-        __attribute__((__format__(os_log, 5, 6)));
-  }
+#elif defined(OHOS)
+#  include <hilog/log.h>
 #endif
 
-#if ! (defined(ANDROID) || defined(XP_OHOS))
+#if ! (defined(ANDROID) || defined(OHOS))
 static void vprintf_stderr_buffered(const char* aFmt, va_list aArgs) {
   // Avoid interleaving by writing to an on-stack buffer and then writing in one
   // go with fputs, as long as the output fits into the buffer.
@@ -71,12 +68,9 @@ MFBT_API void vprintf_stderr(const char* aFmt, va_list aArgs) {
 MFBT_API void vprintf_stderr(const char* aFmt, va_list aArgs) {
   __android_log_vprint(ANDROID_LOG_INFO, "Gecko", aFmt, aArgs);
 }
-#elif defined(XP_OHOS)
+#elif defined(OHOS)
 MFBT_API void vprintf_stderr(const char* aFmt, va_list aArgs) {
-    // OH_LOG_VPrint is available with API-level 18 (19?) or higher.
-    char buffer[1024];
-    VsprintfBuf(buffer, 1024, aFmt, aArgs);
-   (void) OH_LOG_Print(0 /* LOG_APP */, 4 /* LOG_INFO */, 0, "Gecko", "%{public}s", buffer);
+   (void) OH_LOG_Print(LOG_APP, LOG_INFO, 0, "Gecko", aFmt, aArgs);
 }
 #elif defined(FUZZING_SNAPSHOT)
 MFBT_API void vprintf_stderr(const char* aFmt, va_list aArgs) {
@@ -112,15 +106,15 @@ MFBT_API void fprintf_stderr(FILE* aFile, const char* aFmt, ...) {
 }
 
 MFBT_API void print_stderr(std::stringstream& aStr) {
-#if defined(ANDROID) || defined(XP_OHOS)
+#if defined(ANDROID) || defined(OHOS)
   // On Android logcat output is truncated to 1024 chars per line, and
   // we usually use std::stringstream to build up giant multi-line gobs
   // of output. So to avoid the truncation we find the newlines and
   // print the lines individually.
   std::string line;
   while (std::getline(aStr, line)) {
-#  ifdef XP_OHOS
-    (void) OH_LOG_Print(0 /* LOG_APP */, 4 /* LOG_INFO */, 0, "Gecko", "%{public}s", line.c_str());
+#  ifdef OHOS
+    printf_stderr("%{public}s\n", line.c_str());
 #  else
     printf_stderr("%s\n", line.c_str());
 #  endif

--- a/mozjs-sys/mozjs/nsprpub/pr/src/io/prlog.c
+++ b/mozjs-sys/mozjs/nsprpub/pr/src/io/prlog.c
@@ -10,9 +10,8 @@
 #include <string.h>
 #if defined(ANDROID)
 #  include <android/log.h>
-#elif defined(XP_OHOS)
-  int OH_LOG_Print(unsigned int type, unsigned int level, unsigned int domain, const char *tag, const char *fmt, ...)
-      __attribute__((__format__(os_log, 5, 6)));
+#elif defined(OHOS)
+#  include <hilog/log.h>
 #endif
 
 /*
@@ -117,14 +116,14 @@ static void OutputDebugStringA(const char* msg) {
       PR_Write(fd, buf, nb);                               \
     }                                                      \
     PR_END_MACRO
-#elif defined(XP_OHOS)
-#  define _PUT_LOG(fd, buf, nb)                              \
+#elif defined(OHOS)
+#define _PUT_LOG(fd, buf, nb)                                \
     PR_BEGIN_MACRO                                           \
     if (fd == _pr_stderr) {                                  \
         char savebyte = buf[nb];                             \
         buf[nb] = '\0';                                      \
-        (void) OH_LOG_Print(0 /* LOG_APP */, 4 /* LOG_INFO */,   \
-               0, "PRLog", "%{public}s\n", buf);             \
+        (void) OH_LOG_Print(LOG_APP, LOG_INFO, 0, "PRLog",   \
+               "%{public}s\n", buf);             \
         buf[nb] = savebyte;                                  \
     } else {                                                 \
         PR_Write(fd, buf, nb);                               \
@@ -555,8 +554,8 @@ PR_IMPLEMENT(void) PR_Abort(void) {
   PR_LogPrint("Aborting");
 #ifdef ANDROID
   __android_log_write(ANDROID_LOG_ERROR, "PRLog", "Aborting");
-#elif defined(XP_OHOS)
-  (void) OH_LOG_Print(0 /* LOG_APP */, 7 /* LOG_FATAL */, 0, "PRLog", "Aborting\n");
+#elif defined(OHOS)
+  (void) OH_LOG_Print(LOG_APP, LOG_ERROR, 0, "PRLog", "Aborting\n");
 #endif
   abort();
 }
@@ -570,8 +569,8 @@ PR_IMPLEMENT(void) PR_Assert(const char* s, const char* file, PRIntn ln) {
 #elif defined(ANDROID)
   __android_log_assert(NULL, "PRLog", "Assertion failure: %s, at %s:%d\n", s,
                        file, ln);
-#elif defined(XP_OHOS)
-  (void) OH_LOG_Print(0 /* LOG_APP */, 7 /* LOG_FATAL */, 0, "PRLog",
+#elif defined(OHOS)
+  (void) OH_LOG_Print(LOG_APP, LOG_ERROR, 0, "PRLog",
                       "Assertion failure: %{public}s, at %{public}s:%{public}d\n",s, file, ln);
 #endif
   abort();


### PR DESCRIPTION
Reverts servo/mozjs#666

https://github.com/servo/servo/pull/40855 is failing, and I'm struggling to find the reason, so we should revert the previous PR until I figure out why the linker is failing to find the log function now...