### PR TITLE
mozjs: Allow using mozjs-sys from crates.io

### DIFF
--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -26,7 +26,7 @@ crown = ["mozjs_sys/crown"]
 encoding_rs = "0.8.35"
 libc.workspace = true
 log = "0.4"
-mozjs_sys = { version = "0.140.5-6", path = "../mozjs-sys" }
+mozjs_sys = { version = "=0.140.5-6", path = "../mozjs-sys" }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 criterion = { version = "0.6", default-features = false, features = ["html_reports"] }


### PR DESCRIPTION
Adding both version and path is the common way to support both local workspace development, and crates.io usage.