### PR TITLE
Add CI check to ensure mozjs is bumped

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -389,6 +389,19 @@ jobs:
             exit 1
           fi
 
+      - name: Ensure mozjs version is bumped if mozjs-sys version bumped
+        if: ${{ github.event_name == 'pull_request' && steps.changes.outputs.needs_mozjs_sys_bump == 'true' }}
+        run: |
+          CHANGED=$(git diff origin/main -- mozjs/Cargo.toml | grep '^+\s*version\s*=' || true)
+          if [ -n "$CHANGED" ]; then
+          echo "✅ mozjs version bumped: $CHANGED"
+          exit 0
+          else
+          echo "❌ No mozjs version bump found."
+          echo "Please bump mozjs version to trigger publishing a new crates.io release on landing."
+          exit 1
+          fi
+
   publish-release:
     name: Check version and publish release
     runs-on: ubuntu-latest


### PR DESCRIPTION
For purposes of publishing to crates.io, we should also bump the `mozjs` version number, and update the dependency on mozjs-sys. `cargo` will give an error, if we update the mozjs-sys version in `mozjs-sys/Cargo.toml`, but forget to update the dependency in `mozjs/Cargo.toml` since we depend on an exact version by using the `=` specifier. 
The only thing we need to check in CI is that the mozjs version is also bumped, since that would prevent publishing to crates.io (without further changes).