### PR TITLE
Use crates.io Trusted publishing to publish releases to crates.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,14 +42,10 @@ jobs:
           git fetch --tags --quiet
           if ! git show-ref --tags --verify --quiet "refs/tags/${RELEASE_TAG}" ; then
             gh release create ${RELEASE_TAG} ./*.tar.gz
-            echo "CREATE_RELEASE=true" >> ${GITHUB_OUTPUT}
-          else
-            echo "CREATE_RELEASE=false" >> ${GITHUB_OUTPUT}
           fi
           echo "RELEASE_TAG=${RELEASE_TAG}" >> ${GITHUB_OUTPUT}
     outputs:
       release-tag: ${{ steps.check-tag.outputs.RELEASE_TAG }}
-      create-release: ${{ steps.check-tag.outputs.CREATE_RELEASE }}
 
   verify-release:
     name: Verify release
@@ -61,7 +57,7 @@ jobs:
       rust_version: stable
 
   # Our CI testing ensures that mozjs-sys and mozjs are always bumped together.
-  # We always publish both versions, since mozjs depends on a speciifc version
+  # We always publish both versions, since mozjs depends on a specific version
   # of mozjs-sys
   publish-crates-io:
     name: Publish to crates.io
@@ -71,17 +67,20 @@ jobs:
       - verify-release
     permissions:
       id-token: write
-    if: ${{ needs.publish-github-release.outputs.create-release }}
     steps:
       - uses: actions/checkout@v6
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth
-      # publish mozjs-sys
-      - run: cargo publish -p mozjs-sys
+      # publish mozjs-sys. We ignore the error if the version is already published, but abort the workflow
+      # on other errors.
+      - run: |
+          cargo publish -p mozjs-sys 2> err.log || grep "already exists on crates.io" err.log || ( cat err.log ; exit 1)
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
       # Wait a bit to ensure the release is published
       - run: sleep 5
-      - run: cargo publish -p mozjs
+      - run: |
+          rm -f err.log
+          cargo publish -p mozjs 2> err.log || grep "already exists on crates.io" err.log || ( cat err.log ; exit 1)
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
Depends on #676 and #677

See the [official crates.io trusted publishing documentation](https://crates.io/docs/trusted-publishing).

This requires a crates.io owner of mozjs to allow trusted-publishing!

>  Configure your crate on crates.io:
>    Go to your crate's Settings → Trusted Publishing
>    Click the "Add" button and select your platform (GitHub or GitLab)
>    Fill in the platform-specific fields and save the configuration

