### PR TITLE
ci: Fix package name in publish script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,7 +74,7 @@ jobs:
       # publish mozjs-sys. We ignore the error if the version is already published, but abort the workflow
       # on other errors.
       - run: |
-          cargo publish -p mozjs-sys 2> err.log || grep "already exists on crates.io" err.log || ( cat err.log ; exit 1)
+          cargo publish -p mozjs_sys 2> err.log || grep "already exists on crates.io" err.log || ( cat err.log ; exit 1)
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
       # Wait a bit to ensure the release is published


### PR DESCRIPTION
The package was misspelt, see https://github.com/servo/mozjs/actions/runs/20304013884/job/58319150404