### PR TITLE
Bump mozjs versions to publish a release

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.140.5-6"
+version = "0.140.5-7"
 authors = ["Mozilla", "The Servo Project Developers"]
 links = "mozjs"
 license.workspace = true

--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.14.2"
+version = "0.14.3"
 authors = ["The Servo Project Developers"]
 license.workspace = true
 edition.workspace = true
@@ -26,7 +26,7 @@ crown = ["mozjs_sys/crown"]
 encoding_rs = "0.8.35"
 libc.workspace = true
 log = "0.4"
-mozjs_sys = { version = "=0.140.5-6", path = "../mozjs-sys" }
+mozjs_sys = { version = "=0.140.5-7", path = "../mozjs-sys" }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 criterion = { version = "0.6", default-features = false, features = ["html_reports"] }


### PR DESCRIPTION
This is intended to test the automatic publish functionality.

We can see that not publishing, if the version hasn't been bumped works as expected, since cargo publish will detect that and fail: https://github.com/servo/mozjs/actions/runs/20306908971/job/58330354531

If the crates.io permissions and the github workflow side have been configured correctly, then this should push a release to crates.io