### PR TITLE
Update token for github release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,8 @@ jobs:
       - run: ls -l ./*.tar.gz
       - name: Publish release if tag doesn't exist
         id: check-tag
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           RELEASE_TAG=mozjs-sys-v$(cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | select(.name == "mozjs_sys") | .version')
           git fetch --tags --quiet


### PR DESCRIPTION
Adding the token was missed when refactoring the publish workflow. This fixes a failure to publish the github release (which happens before the cargo release step). 

Tested by merging into main in my fork: https://github.com/jschwe/mozjs/actions/runs/20316884731
The publish (to github) step succeeded