### PR TITLE
Remove MutableHandle::new

### DIFF
--- a/mozjs/src/gc/root.rs
+++ b/mozjs/src/gc/root.rs
@@ -199,7 +199,10 @@ impl<'a, T> Deref for Handle<'a, T> {
 
 impl<'a, T> MutableHandle<'a, T> {
     pub unsafe fn from_marked_location(ptr: *mut T) -> Self {
-        MutableHandle::new(&mut *ptr)
+        Self {
+            ptr,
+            anchor: PhantomData,
+        }
     }
 
     pub unsafe fn from_raw(handle: RawMutableHandle<T>) -> Self {
@@ -208,13 +211,6 @@ impl<'a, T> MutableHandle<'a, T> {
 
     pub fn handle(&self) -> Handle<T> {
         unsafe { Handle::new(&*self.ptr) }
-    }
-
-    pub(crate) fn new(ptr: &'a mut T) -> Self {
-        Self {
-            ptr,
-            anchor: PhantomData,
-        }
     }
 
     pub fn get(&self) -> T


### PR DESCRIPTION
`MutableHandle::new` was unused except from `from_marked_location`. It was unsound when called from `from_marked_location` because`from_marked_location` converted the ptr to an `&mut` reference invalidating the pointer the GC holds. This was an oversight in #572. This fixes that by constructing the `MutableHandle` directly in `from_marked_location` and then removing the now unused function.

There is some discussion in https://github.com/servo/mozjs/pull/688#issuecomment-3689737344  that `from_marked_location` might also be being called with null pointers. I don't think that's happening based on a quick test with putting an assert in and running servo's tests, and if it is we should consider changing the API so that it doesn't happen in the future. In the meantime this makes that sound as a side benefit (so long as the `MutableHandle` isn't then used to read or write the null pointer).

Nothing in the public API changes.