### PR TITLE
Publish mozjs 0.14.4.

### DIFF
--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.14.3"
+version = "0.14.4"
 authors = ["The Servo Project Developers"]
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
Incorporates #688 and #689.