### PR TITLE
Make `clamp_to` compliant with the WebIDL specification

### DIFF
--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -27,6 +27,7 @@ encoding_rs = "0.8.35"
 libc.workspace = true
 log = "0.4"
 mozjs_sys = { version = "=0.140.5-7", path = "../mozjs-sys" }
+num-traits = "0.2"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 criterion = { version = "0.6", default-features = false, features = ["html_reports"] }

--- a/mozjs/src/conversions.rs
+++ b/mozjs/src/conversions.rs
@@ -46,6 +46,7 @@ use crate::rust::{ToBoolean, ToInt32, ToInt64, ToNumber, ToUint16, ToUint32, ToU
 use libc;
 use log::debug;
 use mozjs_sys::jsgc::Rooted;
+use num_traits::PrimInt;
 use std::borrow::Cow;
 use std::mem;
 use std::ptr::NonNull;
@@ -235,7 +236,7 @@ where
 /// integer WebIDL type. Using it with non-integer types would be incorrect.
 fn clamp_to<D>(d: f64) -> D
 where
-    D: Number + As<f64>,
+    D: Number + PrimInt + As<f64>,
     f64: As<D>,
 {
     // NaN maps to zero.
@@ -267,7 +268,7 @@ where
         // number or we have an odd number but the number we want is one closer to
         // 0. So just unconditionally masking out the ones bit should do the trick
         // to get us the value we want.
-        truncated = (((truncated.cast() as i64) & !1) as f64).cast();
+        truncated = truncated & !D::one();
     }
 
     truncated
@@ -324,7 +325,7 @@ unsafe fn convert_int_from_jsval<T, M>(
     convert_fn: unsafe fn(*mut JSContext, HandleValue) -> Result<M, ()>,
 ) -> Result<ConversionResult<T>, ()>
 where
-    T: Number + As<f64>,
+    T: Number + As<f64> + PrimInt,
     M: Number + As<T>,
     f64: As<T>,
 {


### PR DESCRIPTION
This PR fixes the implementation of WebIDL clamp numeric conversions to match the behavior required by the WebIDL specification and [Firefox](https://searchfox.org/firefox-main/rev/aee7c0f24f488cd7f5a835803b48dd0c0cb2fd5f/dom/bindings/PrimitiveConversions.h#225-269).

Companion PR: https://github.com/servo/servo/pull/41640