### PR TITLE
CI: Use sccache v0.12.0 on mac

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,10 @@ jobs:
           components: "rustfmt"
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
+        # The sccache 0.13.0 release is missing intel mac builds
+        # see <https://github.com/mozilla/sccache/issues/2554>
+        with:
+          version: "v0.12.0"
       - name: Build
         run: |
           cargo +${{ steps.toolchain.outputs.name }} build --verbose --features ${{ matrix.features }}


### PR DESCRIPTION
as a workaround for https://github.com/mozilla/sccache/issues/2554
this should unblock CI
