### PR TITLE
Return a slice when querying contents of a typed array

### DIFF
--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.16.4"
+version = "0.17.0"
 authors = ["The Servo Project Developers"]
 license.workspace = true
 edition.workspace = true

--- a/mozjs/src/typedarray.rs
+++ b/mozjs/src/typedarray.rs
@@ -63,7 +63,6 @@ use crate::rust::{HandleValue, MutableHandleObject, MutableHandleValue};
 
 use std::cell::Cell;
 use std::ptr;
-use std::slice;
 
 /// Trait that specifies how pointers to wrapped objects are stored. It supports
 /// two variants, one with bare pointer (to be rooted on stack using
@@ -126,7 +125,7 @@ pub enum CreateWith<'a, T: 'a> {
 /// A typed array wrapper.
 pub struct TypedArray<T: TypedArrayElement, S: JSObjectStorage> {
     object: S,
-    computed: Cell<Option<(*mut T::Element, usize)>>,
+    computed: Cell<Option<*mut [T::Element]>>,
 }
 
 unsafe impl<T> CustomTrace for TypedArray<T, *mut JSObject>
@@ -159,7 +158,7 @@ impl<T: TypedArrayElement, S: JSObjectStorage> TypedArray<T, S> {
         }
     }
 
-    fn data(&self) -> (*mut T::Element, usize) {
+    fn data(&self) -> *mut [T::Element] {
         if let Some(data) = self.computed.get() {
             return data;
         }
@@ -171,7 +170,7 @@ impl<T: TypedArrayElement, S: JSObjectStorage> TypedArray<T, S> {
 
     /// Returns the number of elements in the underlying typed array.
     pub fn len(&self) -> usize {
-        self.data().1 as usize
+        self.data().len()
     }
 
     /// # Unsafety
@@ -204,8 +203,7 @@ impl<T: TypedArrayElement, S: JSObjectStorage> TypedArray<T, S> {
     /// The returned slice can be invalidated if the underlying typed array
     /// is neutered.
     pub unsafe fn as_slice(&self) -> &[T::Element] {
-        let (pointer, length) = self.data();
-        slice::from_raw_parts(pointer as *const T::Element, length as usize)
+        &*self.data()
     }
 
     /// # Unsafety
@@ -216,8 +214,7 @@ impl<T: TypedArrayElement, S: JSObjectStorage> TypedArray<T, S> {
     /// The underlying `JSObject` can be aliased, which can lead to
     /// Undefined Behavior due to mutable aliasing.
     pub unsafe fn as_mut_slice(&mut self) -> &mut [T::Element] {
-        let (pointer, length) = self.data();
-        slice::from_raw_parts_mut(pointer, length as usize)
+        &mut *self.data()
     }
 
     /// Return a boolean flag which denotes whether the underlying buffer
@@ -260,9 +257,9 @@ impl<T: TypedArrayElementCreator + TypedArrayElement, S: JSObjectStorage> TypedA
     }
 
     unsafe fn update_raw(data: &[T::Element], result: *mut JSObject) {
-        let (buf, length) = T::length_and_data(result);
-        assert!(data.len() <= length as usize);
-        ptr::copy_nonoverlapping(data.as_ptr(), buf, data.len());
+        let buffer = T::length_and_data(result);
+        assert!(data.len() <= buffer.len());
+        ptr::copy_nonoverlapping(data.as_ptr(), buffer as *mut T::Element, data.len());
     }
 }
 
@@ -274,7 +271,7 @@ pub trait TypedArrayElement {
     /// Unwrap a typed array JS reflector for this element type.
     unsafe fn unwrap_array(obj: *mut JSObject) -> *mut JSObject;
     /// Retrieve the length and data of a typed array's buffer for this element type.
-    unsafe fn length_and_data(obj: *mut JSObject) -> (*mut Self::Element, usize);
+    unsafe fn length_and_data(obj: *mut JSObject) -> *mut [Self::Element];
 }
 
 /// Internal trait for creating new typed arrays.
@@ -299,13 +296,13 @@ macro_rules! typed_array_element {
                 $unwrap(obj)
             }
 
-            unsafe fn length_and_data(obj: *mut JSObject) -> (*mut Self::Element, usize) {
+            unsafe fn length_and_data(obj: *mut JSObject) -> *mut [Self::Element] {
                 let mut len = 0;
                 let mut shared = false;
                 let mut data = ptr::null_mut();
                 $length_and_data(obj, &mut len, &mut shared, &mut data);
                 assert!(!shared);
-                (data, len)
+                std::ptr::slice_from_raw_parts_mut(data, len)
             }
         }
     };


### PR DESCRIPTION
In rust there is no need to pass `(*mut T, usize)` around, as that is just a `*mut [T]`. This makes out-of-bounds access to typed arrays harder to do by accident.

Testing: Behaviour should be unchanged, no new tests are written
Companion PR: https://github.com/servo/servo/pull/42688