### PR TITLE
Expose more compile options through CompileOptionsWrapper

### DIFF
--- a/mozjs/src/rust.rs
+++ b/mozjs/src/rust.rs
@@ -556,6 +556,24 @@ impl CompileOptionsWrapper {
             (*self.ptr)._base.introductionType = introduction_type.as_ptr();
         }
     }
+
+    pub fn set_muted_errors(&mut self, muted_errors: bool) {
+        unsafe {
+            (*self.ptr)._base.mutedErrors_ = muted_errors;
+        }
+    }
+
+    pub fn set_is_run_once(&mut self, is_run_once: bool) {
+        unsafe {
+            (*self.ptr).isRunOnce = is_run_once;
+        }
+    }
+
+    pub fn set_no_script_rval(&mut self, no_script_rval: bool) {
+        unsafe {
+            (*self.ptr).noScriptRval = no_script_rval;
+        }
+    }
 }
 
 impl Drop for CompileOptionsWrapper {


### PR DESCRIPTION
Added `set_muted_errors`, `set_is_run_once`, `set_no_script_rval` allowing Servo to follow Gecko's configuration. `isRunOnce` and `noScriptRval` are probably just some small optimizations.

Testing: Not required, allows setting more `CompileOptions`
Servo PR: [servo/43020](https://github.com/servo/servo/pull/43020)
