### PR TITLE
jsglue: add a method to retrieve ErrorInfo from the pending exception stack

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.140.10-0"
+version = "0.140.10-1"
 authors = ["Mozilla", "The Servo Project Developers"]
 links = "mozjs"
 license.workspace = true

--- a/mozjs-sys/src/jsglue.cpp
+++ b/mozjs-sys/src/jsglue.cpp
@@ -1232,6 +1232,42 @@ bool DescribeScriptedCaller(JSContext* cx, char* buffer, size_t buflen,
   return true;
 }
 
+typedef void (*StringCallback)(const char* ptr, size_t len, void* target);
+
+bool PendingExceptionStackInfo(JSContext* cx, StringCallback callback,
+                               void* message_target, void* filename_target,
+                               uint32_t* line, uint32_t* col,
+                               JS::MutableHandleValue dest) {
+  JS::ExceptionStack stack(cx);
+  JS::ErrorReportBuilder builder(cx);
+  if (JS::StealPendingExceptionStack(cx, &stack) &&
+      builder.init(cx, stack, JS::ErrorReportBuilder::WithSideEffects)) {
+    JSErrorReport* aReport = builder.report();
+
+    if (!aReport || aReport->isWarning()) {
+      return false;
+    }
+
+    const char* message = aReport->message().c_str();
+    if (!message) {
+      message = builder.toStringResult().c_str();
+    }
+
+    callback(message, strlen(message), message_target);
+
+    const char* filename = aReport->filename.c_str();
+    callback(filename, strlen(filename), filename_target);
+
+    *line = aReport->lineno;
+    *col = aReport->column.oneOriginValue();
+    dest.set(stack.exception());
+
+    return true;
+  }
+
+  return false;
+}
+
 void SetDataPropertyDescriptor(JS::MutableHandle<JS::PropertyDescriptor> desc,
                                JS::HandleValue value, uint32_t attrs) {
   desc.set(JS::PropertyDescriptor::Data(value, attrs));

--- a/mozjs-sys/src/jsglue.cpp
+++ b/mozjs-sys/src/jsglue.cpp
@@ -1256,7 +1256,9 @@ bool PendingExceptionStackInfo(JSContext* cx, StringCallback callback,
     callback(message, strlen(message), message_target);
 
     const char* filename = aReport->filename.c_str();
-    callback(filename, strlen(filename), filename_target);
+    if (filename) {
+      callback(filename, strlen(filename), filename_target);
+    }
 
     *line = aReport->lineno;
     *col = aReport->column.oneOriginValue();

--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.15.10"
+version = "0.15.11"
 authors = ["The Servo Project Developers"]
 license.workspace = true
 edition.workspace = true
@@ -27,7 +27,7 @@ encoding_rs = "0.8.35"
 libc.workspace = true
 log = "0.4"
 # When doing non-version changes also update ../mozjs-sys/etc/sm-security-bump.py
-mozjs_sys = { version = "=0.140.10-0", path = "../mozjs-sys" }
+mozjs_sys = { version = "=0.140.10-1", path = "../mozjs-sys" }
 num-traits = "0.2"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/mozjs/src/glue2_wrappers.in.rs
+++ b/mozjs/src/glue2_wrappers.in.rs
@@ -37,6 +37,7 @@ wrap!(glue: pub fn EncodeStringToUTF8(cx: &mut JSContext, str_: HandleString, cb
 wrap!(glue: pub fn SetUpEventLoopDispatch(cx: &mut JSContext, callback: RustDispatchToEventLoopCallback, closure: *mut ::std::os::raw::c_void));
 wrap!(glue: pub fn DispatchableRun(cx: &mut JSContext, ptr: *mut DispatchablePointer, mb: Dispatchable_MaybeShuttingDown));
 wrap!(glue: pub fn DescribeScriptedCaller(cx: &mut JSContext, buffer: *mut ::std::os::raw::c_char, buflen: usize, line: *mut u32, col: *mut u32) -> bool);
+wrap!(glue: pub fn PendingExceptionStackInfo(cx: &mut JSContext, callback: StringCallback, message_target: *mut ::std::os::raw::c_void, filename_target: *mut ::std::os::raw::c_void, line: *mut u32, col: *mut u32, dest: MutableHandleValue) -> bool);
 wrap!(glue: pub fn SetDataPropertyDescriptor(desc: MutableHandle<PropertyDescriptor>, value: HandleValue, attrs: u32));
 wrap!(glue: pub fn SetAccessorPropertyDescriptor(desc: MutableHandle<PropertyDescriptor>, getter: HandleObject, setter: HandleObject, attrs: u32));
 wrap!(glue: pub fn DumpJSStack(cx: &mut JSContext, showArgs: bool, showLocals: bool, showThisProps: bool));

--- a/mozjs/src/glue_wrappers.in.rs
+++ b/mozjs/src/glue_wrappers.in.rs
@@ -22,6 +22,7 @@ wrap!(glue: pub fn JS_GetModulePrivate(module: *mut JSObject, dest: MutableHandl
 wrap!(glue: pub fn JS_GetScriptedCallerPrivate(cx: *mut JSContext, dest: MutableHandleValue));
 wrap!(glue: pub fn JS_GetRegExpFlags(cx: *mut JSContext, obj: HandleObject, flags: *mut RegExpFlags));
 wrap!(glue: pub fn EncodeStringToUTF8(cx: *mut JSContext, str_: HandleString, cb: EncodedStringCallback));
+wrap!(glue: pub fn PendingExceptionStackInfo(cx: *mut JSContext, callback: StringCallback, message_target: *mut ::std::os::raw::c_void, filename_target: *mut ::std::os::raw::c_void, line: *mut u32, col: *mut u32, dest: MutableHandleValue) -> bool);
 wrap!(glue: pub fn SetDataPropertyDescriptor(desc: MutableHandle<PropertyDescriptor>, value: HandleValue, attrs: u32));
 wrap!(glue: pub fn SetAccessorPropertyDescriptor(desc: MutableHandle<PropertyDescriptor>, getter: HandleObject, setter: HandleObject, attrs: u32));
 wrap!(glue: pub fn StackGCVectorValueLength(vec: Handle<StackGCVector<Value, TempAllocPolicy>>) -> u32);

--- a/mozjs/src/rust.rs
+++ b/mozjs/src/rust.rs
@@ -7,7 +7,7 @@
 use std::cell::Cell;
 use std::char;
 use std::default::Default;
-use std::ffi::{CStr, CString};
+use std::ffi::{c_char, c_void, CStr, CString};
 use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 use std::ops::{Deref, DerefMut};
@@ -30,6 +30,7 @@ use crate::glue::AppendToRootedObjectVector;
 use crate::glue::{CreateRootedIdVector, CreateRootedObjectVector};
 use crate::glue::{
     DeleteCompileOptions, DeleteRootedObjectVector, DescribeScriptedCaller, DestroyRootedIdVector,
+    PendingExceptionStackInfo,
 };
 use crate::glue::{DeleteJSAutoStructuredCloneBuffer, NewJSAutoStructuredCloneBuffer};
 use crate::glue::{
@@ -45,6 +46,7 @@ use crate::jsapi::HandleObjectVector as RawHandleObjectVector;
 use crate::jsapi::HandleValue as RawHandleValue;
 use crate::jsapi::JS_AddExtraGCRootsTracer;
 use crate::jsapi::MutableHandleIdVector as RawMutableHandleIdVector;
+use crate::jsapi::MutableHandleValue as RawMutableHandleValue;
 use crate::jsapi::{already_AddRefed, jsid};
 use crate::jsapi::{BuildStackString, CaptureCurrentStack, StackFormat};
 use crate::jsapi::{HandleValueArray, StencilRelease};
@@ -1056,6 +1058,56 @@ pub unsafe fn describe_scripted_caller(cx: *mut JSContext) -> Result<ScriptedCal
     })
 }
 
+pub struct ErrorInfo {
+    pub message: String,
+    pub filename: String,
+    pub line: u32,
+    pub col: u32,
+}
+
+unsafe extern "C" fn fill_string_callback(ptr: *const c_char, len: usize, target: *mut c_void) {
+    let target = &mut *(target as *mut String);
+
+    if ptr.is_null() {
+        return;
+    }
+
+    let slice = slice::from_raw_parts(ptr as *const u8, len);
+    *target = str::from_utf8_unchecked(slice).to_owned();
+}
+
+/// Retrieve error info from the pending exception stack, by clearing it.
+/// Return None if there isn't one or if it is a warning.
+pub unsafe fn error_info_from_exception_stack(
+    cx: *mut JSContext,
+    rval: RawMutableHandleValue,
+) -> Option<ErrorInfo> {
+    let mut message = String::new();
+    let mut filename = String::new();
+
+    let mut line = 0;
+    let mut col = 0;
+
+    if !PendingExceptionStackInfo(
+        cx,
+        Some(fill_string_callback),
+        &mut message as *mut String as *mut c_void,
+        &mut filename as *mut String as *mut c_void,
+        &mut line,
+        &mut col,
+        rval,
+    ) {
+        return None;
+    }
+
+    Some(ErrorInfo {
+        message,
+        filename,
+        line,
+        col,
+    })
+}
+
 pub struct CapturedJSStack<'a> {
     cx: *mut JSContext,
     stack: RootedGuard<'a, *mut JSObject>,
@@ -1299,6 +1351,7 @@ pub mod wrappers {
     use super::*;
     use crate::glue;
     use crate::glue::EncodedStringCallback;
+    use crate::glue::StringCallback;
     use crate::jsapi;
     use crate::jsapi::js::TempAllocPolicy;
     use crate::jsapi::jsid;

--- a/mozjs/src/rust.rs
+++ b/mozjs/src/rust.rs
@@ -1066,14 +1066,11 @@ pub struct ErrorInfo {
 }
 
 unsafe extern "C" fn fill_string_callback(ptr: *const c_char, len: usize, target: *mut c_void) {
+    assert!(!ptr.is_null());
     let target = &mut *(target as *mut String);
 
-    if ptr.is_null() {
-        return;
-    }
-
     let slice = slice::from_raw_parts(ptr as *const u8, len);
-    *target = str::from_utf8_unchecked(slice).to_owned();
+    target.push_str(str::from_utf8_unchecked(slice));
 }
 
 /// Retrieve error info from the pending exception stack, by clearing it.
@@ -1091,8 +1088,8 @@ pub unsafe fn error_info_from_exception_stack(
     if !PendingExceptionStackInfo(
         cx,
         Some(fill_string_callback),
-        &mut message as *mut String as *mut c_void,
-        &mut filename as *mut String as *mut c_void,
+        &raw mut message as *mut c_void,
+        &raw mut filename as *mut c_void,
         &mut line,
         &mut col,
         rval,


### PR DESCRIPTION
Attempt to retrieve `ErrorInfo` from the stack of the pending exception, to avoid empty messages on uncaught exceptions.

Testing: Need to test it with servo.
Servo PR: [servo/43632](https://github.com/servo/servo/pull/43632)
