### PR TITLE
mozjs-sys: Build from source if the jitspew feature is enabled

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.140.8-2"
+version = "0.140.8-3"
 authors = ["Mozilla", "The Servo Project Developers"]
 links = "mozjs"
 license.workspace = true

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -475,6 +475,9 @@ fn should_build_from_source() -> bool {
     } else if !env::var_os("CARGO_FEATURE_JIT").is_some() {
         println!("jit feature is NOT enabled. Building from source directly.");
         true
+    } else if env::var_os("CARGO_FEATURE_JITSPEW").is_some() {
+        println!("jitspew feature is enabled. Building from source directly.");
+        true
     } else {
         false
     }

--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.15.7"
+version = "0.15.8"
 authors = ["The Servo Project Developers"]
 license.workspace = true
 edition.workspace = true
@@ -27,7 +27,7 @@ encoding_rs = "0.8.35"
 libc.workspace = true
 log = "0.4"
 # When doing non-version changes also update ../mozjs-sys/etc/sm-security-bump.py
-mozjs_sys = { version = "=0.140.8-2", path = "../mozjs-sys" }
+mozjs_sys = { version = "=0.140.8-3", path = "../mozjs-sys" }
 num-traits = "0.2"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]


### PR DESCRIPTION
Otherwise the `IONFLAGS` environment variable does nothing.

Testing: We don't have tests for the build process
Servo companion PR: https://github.com/servo/servo/pull/44010
