### PR TITLE
ci: build aarch64-linux in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,11 +72,14 @@ jobs:
       RUSTC_WRAPPER: "sccache"
       CCACHE: sccache
       SCCACHE_GHA_ENABLED: "true"
-    runs-on: ubuntu-22.04 # Needed for artifacts to work on older systems (due to glibc)
     strategy:
       fail-fast: false
       matrix:
         features: ["debugmozjs", ""]
+        platform:
+          - { target: aarch64-unknown-linux-gnu, image: ubuntu-22.04-arm }
+          - { target: x86_64-unknown-linux-gnu, image: ubuntu-22.04 }
+    runs-on: ${{ matrix.platform.image }}
     steps:
       - uses: actions/checkout@v6
       - name: Free Disk Space (Ubuntu)
@@ -115,8 +118,8 @@ jobs:
         if: ${{ env.NEW_RUST_CHECK == 'false' }}
         uses: actions/upload-artifact@v7
         with:
-          path: ./target/libmozjs-x86_64-unknown-linux-gnu${{ matrix.features && '-debugmozjs' || '' }}.tar.gz
-          name: libmozjs-x86_64-unknown-linux-gnu${{ matrix.features && '-debugmozjs' || '' }}.tar.gz
+          path: ./target/libmozjs-${{matrix.platform.target }}${{ matrix.features && '-debugmozjs' || '' }}.tar.gz
+          name: libmozjs-${{matrix.platform.target }}${{ matrix.features && '-debugmozjs' || '' }}.tar.gz
 
   windows:
     runs-on: ${{ matrix.platform.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -290,7 +290,6 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - aarch64-unknown-linux-gnu
           - armv7-unknown-linux-gnueabihf
     container: ghcr.io/servo/cross-${{ matrix.target }}:main
     steps:

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -27,6 +27,7 @@ jobs:
         platform:
           - { target: aarch64-apple-darwin, os: macos-14 }
           - { target: x86_64-apple-darwin, os: macos-15-intel }
+          - { target: aarch64-unknown-linux-gnu, os: ubuntu-arm-24.04 }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest }
           - { target: x86_64-pc-windows-msvc, os: windows-latest }
           - { target: aarch64-pc-windows-msvc, os: windows-11-arm }

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -27,7 +27,7 @@ jobs:
         platform:
           - { target: aarch64-apple-darwin, os: macos-14 }
           - { target: x86_64-apple-darwin, os: macos-15-intel }
-          - { target: aarch64-unknown-linux-gnu, os: ubuntu-arm-24.04 }
+          - { target: aarch64-unknown-linux-gnu, os: ubuntu-24.04-arm }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest }
           - { target: x86_64-pc-windows-msvc, os: windows-latest }
           - { target: aarch64-pc-windows-msvc, os: windows-11-arm }


### PR DESCRIPTION
Having the prebuilt mozjs artifact available is mainly useful for users using docker on arm Macs.

Testing: This modifies CI workflow files. 
Fixes: #730
