### PR TITLE
build: Ignore CLANGFLAGS

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.140.8-3"
+version = "0.140.8-4"
 authors = ["Mozilla", "The Servo Project Developers"]
 links = "mozjs"
 license.workspace = true

--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "140.13.0-1"
+version = "140.13.0-2"
 authors = ["Mozilla", "The Servo Project Developers"]
 links = "mozjs"
 license.workspace = true

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -16,7 +16,6 @@ const ENV_VARS: &'static [&'static str] = &[
     "AS",
     "CC",
     "CFLAGS",
-    "CLANGFLAGS",
     "CPP",
     "CPPFLAGS",
     "CXX",
@@ -39,7 +38,6 @@ const SM_TARGET_ENV_VARS: &'static [&'static str] = &[
     "AS",
     "CC",
     "CFLAGS",
-    "CLANGFLAGS",
     "CPP",
     "CPPFLAGS",
     "CXX",
@@ -354,12 +352,6 @@ fn build_bindings(build_dir: &Path, target: BuildTarget) {
     }
 
     if let Some(flags) = get_cc_rs_env("CXXFLAGS") {
-        for flag in flags.split_whitespace() {
-            builder = builder.clang_arg(flag);
-        }
-    }
-
-    if let Some(flags) = get_cc_rs_env("CLANGFLAGS") {
         for flag in flags.split_whitespace() {
             builder = builder.clang_arg(flag);
         }

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -16,7 +16,6 @@ const ENV_VARS: &'static [&'static str] = &[
     "AS",
     "CC",
     "CFLAGS",
-    "CLANGFLAGS",
     "CPP",
     "CPPFLAGS",
     "CXX",
@@ -39,7 +38,6 @@ const SM_TARGET_ENV_VARS: &'static [&'static str] = &[
     "AS",
     "CC",
     "CFLAGS",
-    "CLANGFLAGS",
     "CPP",
     "CPPFLAGS",
     "CXX",
@@ -386,12 +384,6 @@ fn build_bindings(build_dir: &Path, target: BuildTarget) {
     }
 
     if let Some(flags) = get_cc_rs_env("CXXFLAGS") {
-        for flag in flags.split_whitespace() {
-            builder = builder.clang_arg(flag);
-        }
-    }
-
-    if let Some(flags) = get_cc_rs_env("CLANGFLAGS") {
         for flag in flags.split_whitespace() {
             builder = builder.clang_arg(flag);
         }

--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.15.8"
+version = "0.15.9"
 authors = ["The Servo Project Developers"]
 license.workspace = true
 edition.workspace = true
@@ -27,7 +27,7 @@ encoding_rs = "0.8.35"
 libc.workspace = true
 log = "0.4"
 # When doing non-version changes also update ../mozjs-sys/etc/sm-security-bump.py
-mozjs_sys = { version = "=0.140.8-3", path = "../mozjs-sys" }
+mozjs_sys = { version = "=0.140.8-4", path = "../mozjs-sys" }
 num-traits = "0.2"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.21.1"
+version = "0.21.2"
 authors = ["The Servo Project Developers"]
 license.workspace = true
 edition.workspace = true
@@ -27,7 +27,7 @@ encoding_rs = "0.8.35"
 libc.workspace = true
 log = "0.4"
 # When doing non-version changes also update ../mozjs-sys/etc/sm-security-bump.py
-mozjs_sys = { version = "=140.13.0-1", path = "../mozjs-sys" }
+mozjs_sys = { version = "=140.13.0-2", path = "../mozjs-sys" }
 num-traits = "0.2"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]


### PR DESCRIPTION
CLANGFLAGS was only applied to bindgen.
cc-rs is not documented to use it, and SM also doesn't reference it. In servo I also couldn't see us setting this variable. This is a preparation for unifying our common build flags across cc-rs, SM build and bindgen.

Testing: Not tested.