### PR TITLE
build: Unify bindings and glue code flags with cc-rs

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.140.8-3"
+version = "0.140.8-4"
 authors = ["Mozilla", "The Servo Project Developers"]
 links = "mozjs"
 license.workspace = true

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -330,9 +330,15 @@ fn build_bindings(build_dir: &Path, target: BuildTarget) {
         .with_codegen_config(config);
 
     let mut cc_rs_builder = get_common_cc();
-    cc_rs_builder.define("RUST_BINDGEN", None);
+    cc_rs_builder
+        .define("RUST_BINDGEN", None)
+        .include(&js_config_path(build_dir));
     if cc_rs_builder.get_compiler().is_like_msvc() {
         cc_rs_builder.flag("--driver-mode=cl");
+    }
+
+    for path in target.include_paths(build_dir) {
+        cc_rs_builder.include(path);
     }
 
     for arg in cc_rs_builder.get_compiler().args() {
@@ -354,22 +360,6 @@ fn build_bindings(build_dir: &Path, target: BuildTarget) {
             .allowlist_file(target.path())
             .allowlist_recursively(false);
     }
-
-    for path in target.include_paths(build_dir) {
-        builder = builder.clang_args(&["-I", &path]);
-    }
-
-    if let Some(flags) = get_cc_rs_env("CXXFLAGS") {
-        for flag in flags.split_whitespace() {
-            builder = builder.clang_arg(flag);
-        }
-    }
-
-    let target_env = env::var("TARGET").unwrap();
-    builder = builder.clang_args(&[
-        include_file_flag(target_env.contains("windows")),
-        &js_config_path(build_dir),
-    ]);
 
     println!(
         "Generating bindings {:?} {}.",

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -287,12 +287,8 @@ fn cbindgen_bidi(build_dir: &Path) {
 */
 
 fn build(build_dir: &Path, target: BuildTarget) {
-    let mut build = cc::Build::new();
+    let mut build = get_common_cc();
     build.cpp(true).file(target.path());
-
-    for flag in cc_flags(false) {
-        build.flag_if_supported(flag);
-    }
 
     if let Ok(android_api) = env::var("ANDROID_API_LEVEL").as_deref() {
         build.define("__ANDROID_MIN_SDK_VERSION__", android_api);
@@ -331,8 +327,20 @@ fn build_bindings(build_dir: &Path, target: BuildTarget) {
         .derive_partialeq(true)
         .size_t_is_usize(true)
         .enable_cxx_namespaces()
-        .with_codegen_config(config)
-        .clang_args(cc_flags(true));
+        .with_codegen_config(config);
+
+    let mut cc_rs_builder = get_common_cc();
+    cc_rs_builder.define("RUST_BINDGEN", None);
+    if cc_rs_builder.get_compiler().is_like_msvc() {
+        cc_rs_builder.flag("--driver-mode=cl");
+    }
+
+    for arg in cc_rs_builder.get_compiler().args() {
+        builder = builder.clang_arg(
+            arg.to_str()
+                .expect("Non UTF-8 compiler flag in cc::Build args"),
+        );
+    }
 
     if env::var("TARGET").unwrap().contains("wasi") {
         builder = builder
@@ -483,79 +491,68 @@ fn minimum_rust_target() -> RustTarget {
     }
 }
 
-fn cc_flags(bindgen: bool) -> Vec<&'static str> {
-    let mut flags = Vec::new();
+fn get_common_cc() -> cc::Build {
+    let mut builder = cc::Build::new();
 
     let target = env::var("TARGET").unwrap();
 
     if target.contains("windows") {
-        if bindgen {
-            flags.push("--driver-mode=cl");
-        }
-
-        flags.extend(&[
-            "-std:c++17",
-            "-Zi",
-            "-GR-",
-            "-DWIN32",
+        builder
+            .std("c++17")
+            .flag_if_supported("-Zi")
+            .flag_if_supported("-GR-")
+            .define("WIN32", None)
             // Don't use reinterpret_cast() in offsetof(),
             // since it's not a constant expression, so can't
             // be used in static_assert().
-            "-D_CRT_USE_BUILTIN_OFFSETOF",
-        ]);
+            .define("_CRT_USE_BUILTIN_OFFSETOF", None);
     } else {
-        flags.extend(&[
-            "-std=gnu++17",
-            "-std=c++17",
-            "-xc++",
-            "-fPIC",
-            "-fno-rtti",
-            "-fno-sized-deallocation",
-            "-Wno-c++0x-extensions",
-            "-Wno-return-type-c-linkage",
-            "-Wno-unused-parameter",
-            "-Wno-invalid-offsetof",
-            "-Wno-unused-private-field",
-        ]);
+        builder
+            .std("gnu++17")
+            .cpp(true)
+            .pic(true)
+            .flag_if_supported("-fno-rtti")
+            .flag_if_supported("-fno-sized-deallocation")
+            .flag_if_supported("-Wno-c++0x-extensions")
+            .flag_if_supported("-Wno-return-type-c-linkage")
+            .flag_if_supported("-Wno-unused-parameter")
+            .flag_if_supported("-Wno-invalid-offsetof")
+            .flag_if_supported("-Wno-unused-private-field");
 
         if env::var_os("CARGO_FEATURE_PROFILEMOZJS").is_some() {
-            flags.push("-fno-omit-frame-pointer");
+            builder.force_frame_pointer(true);
         }
 
         if target.contains("wasi") {
             // Unconditionally target p1 for now. Even if the application
             // targets p2, an adapter will take care of it.
-            flags.push("--target=wasm32-wasip1");
-            flags.push("-fvisibility=default");
+            builder
+                .target("wasm32-wasip1")
+                .flag_if_supported("-fvisibility=default");
         }
     }
-
-    flags.extend(&["-DSTATIC_JS_API", "-DRUST_BINDGEN"]);
+    builder.define("JS_STATIC_API", None);
     if env::var_os("CARGO_FEATURE_DEBUGMOZJS").is_some() {
-        flags.extend(&["-DJS_GC_ZEAL", "-DDEBUG", "-DJS_DEBUG"]);
-
-        if !bindgen {
-            if target.contains("windows") {
-                flags.push("-Od");
-            } else {
-                flags.extend(&["-g", "-O0"]);
-            }
-        }
+        builder
+            .define("JS_GC_ZEAL", None)
+            .define("DEBUG", None)
+            .define("JS_DEBUG", None);
     }
 
-    let is_apple = target.contains("apple");
-    let is_freebsd = target.contains("freebsd");
-    let is_ohos = target.contains("ohos");
-
-    if is_apple || is_freebsd || is_ohos {
-        flags.push("-stdlib=libc++");
+    if env::var_os("CXXSTDLIB").is_none() {
+        let is_apple = target.contains("apple");
+        let is_freebsd = target.contains("freebsd");
+        let is_ohos = target.contains("ohos");
+        if is_apple || is_freebsd || is_ohos {
+            builder.cpp_set_stdlib("c++");
+        }
     }
 
     if target.contains("wasi") {
-        flags.push("-D_WASI_EMULATED_GETPID");
+        builder.define("_WASI_EMULATED_GETPID", None);
     }
 
-    flags
+    builder
 }
 
 fn include_file_flag(msvc_like: bool) -> &'static str {

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -1210,11 +1210,6 @@ fn join_path(base: &Path, additional: &str) -> PathBuf {
 /// have the values that users of `cc-rs` would expect.
 ///
 /// Adapted from https://github.com/rust-lang/cc-rs/blob/3ba23569a623074748a3030f382afd22483555df/src/lib.rs#L3617
-fn get_cc_rs_env(var_base: &str) -> Option<String> {
-    get_cc_rs_env_os(var_base).map(|val| val.to_str().expect("Not a valid string.").to_string())
-}
-
-/// Like `get_cc_rs_env()` but returns the OsString value.
 fn get_cc_rs_env_os(var_base: &str) -> Option<OsString> {
     fn get_env(var: &str) -> Option<OsString> {
         println!("cargo:rerun-if-env-changed={}", var);

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -287,18 +287,11 @@ fn cbindgen_bidi(build_dir: &Path) {
 */
 
 fn build(build_dir: &Path, target: BuildTarget) {
-    let mut build = get_common_cc();
+    let mut build = get_common_cc(build_dir, target);
     build.cpp(true).file(target.path());
 
     if let Ok(android_api) = env::var("ANDROID_API_LEVEL").as_deref() {
         build.define("__ANDROID_MIN_SDK_VERSION__", android_api);
-    }
-
-    build.flag(include_file_flag(build.get_compiler().is_like_msvc()));
-    build.flag(&js_config_path(build_dir));
-
-    for path in target.include_paths(build_dir) {
-        build.include(path);
     }
 
     build.out_dir(build_dir).compile(target.output());
@@ -329,11 +322,8 @@ fn build_bindings(build_dir: &Path, target: BuildTarget) {
         .enable_cxx_namespaces()
         .with_codegen_config(config);
 
-    let mut cc_rs_builder = get_common_cc();
-    cc_rs_builder
-        .define("RUST_BINDGEN", None)
-        // todo: include via common cc-args?
-        .include(&js_config_path(build_dir));
+    let mut cc_rs_builder = get_common_cc(build_dir, target);
+    cc_rs_builder.define("RUST_BINDGEN", None);
     if cc_rs_builder.get_compiler().is_like_msvc() {
         cc_rs_builder.flag("--driver-mode=cl");
     }
@@ -362,11 +352,6 @@ fn build_bindings(build_dir: &Path, target: BuildTarget) {
             arg.to_str()
                 .expect("Non UTF-8 compiler flag in cc::Build args"),
         );
-    }
-
-    // todo: add target.include_paths via common cc-args?
-    for path in target.include_paths(build_dir) {
-        builder = builder.clang_arg("-I").clang_arg(path);
     }
 
     if env::var("TARGET").unwrap().contains("wasi") {
@@ -502,12 +487,12 @@ fn minimum_rust_target() -> RustTarget {
     }
 }
 
-fn get_common_cc() -> cc::Build {
+fn get_common_cc(build_dir: &Path, target: BuildTarget) -> cc::Build {
     let mut builder = cc::Build::new();
 
-    let target = env::var("TARGET").unwrap();
+    let target_triple = env::var("TARGET").unwrap();
 
-    if target.contains("windows") {
+    if target_triple.contains("windows") {
         builder
             .std("c++17")
             .flag_if_supported("-Zi")
@@ -534,7 +519,7 @@ fn get_common_cc() -> cc::Build {
             builder.force_frame_pointer(true);
         }
 
-        if target.contains("wasi") {
+        if target_triple.contains("wasi") {
             // Unconditionally target p1 for now. Even if the application
             // targets p2, an adapter will take care of it.
             builder
@@ -542,6 +527,16 @@ fn get_common_cc() -> cc::Build {
                 .flag_if_supported("-fvisibility=default");
         }
     }
+
+    // Force-include the JS header with the configure defines.
+    // This is not the same as `builder.include()`!
+    builder.flag(include_file_flag(builder.get_compiler().is_like_msvc()));
+    builder.flag(&js_config_path(build_dir));
+
+    for path in target.include_paths(build_dir) {
+        builder.include(path);
+    }
+
     builder.define("JS_STATIC_API", None);
     if env::var_os("CARGO_FEATURE_DEBUGMOZJS").is_some() {
         builder
@@ -551,15 +546,15 @@ fn get_common_cc() -> cc::Build {
     }
 
     if env::var_os("CXXSTDLIB").is_none() {
-        let is_apple = target.contains("apple");
-        let is_freebsd = target.contains("freebsd");
-        let is_ohos = target.contains("ohos");
+        let is_apple = target_triple.contains("apple");
+        let is_freebsd = target_triple.contains("freebsd");
+        let is_ohos = target_triple.contains("ohos");
         if is_apple || is_freebsd || is_ohos {
             builder.cpp_set_stdlib("c++");
         }
     }
 
-    if target.contains("wasi") {
+    if target_triple.contains("wasi") {
         builder.define("_WASI_EMULATED_GETPID", None);
     }
 

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -317,7 +317,7 @@ fn build_bindings(build_dir: &Path, target: BuildTarget) {
     config &= !CodegenConfig::DESTRUCTORS;
     config &= !CodegenConfig::METHODS;
 
-    let mut builder = bindgen::builder()
+    let builder = bindgen::builder()
         .rust_target(minimum_rust_target())
         .header(target.path())
         // Translate every enum with the "rustified enum" strategy. We should
@@ -335,18 +335,29 @@ fn build_bindings(build_dir: &Path, target: BuildTarget) {
         .include(&js_config_path(build_dir));
     if cc_rs_builder.get_compiler().is_like_msvc() {
         cc_rs_builder.flag("--driver-mode=cl");
+    }
+
+    let compiler = cc_rs_builder.get_compiler();
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+
+    let mut builder = if compiler.is_like_msvc() {
+        builder
     } else {
         // `.cpp(true)` from cc_rs_builder will not propagate to bindgen clang-args,
         // so we need to set it explicitly here. Doesn't work with msvc.
-        builder
-            .clang_args(["-x", "c++"]);
+        builder.clang_args(["-x", "c++"])
+    };
+
+    // Setting CLANG_PATH to the absolute path (when using the default c++ compiler on macos),
+    // allows bindgen to find the c++ headers (not just the system headers).
+    if target_os == "macos" && compiler.path().to_str() == Some("c++") {
+        env::set_var("CLANG_PATH", "/usr/bin/c++");
     }
 
     for path in target.include_paths(build_dir) {
         cc_rs_builder.include(path);
     }
 
-    let compiler = cc_rs_builder.get_compiler();
     // `bindgen` invokes clang via CLANG_PATH to find the system and c++ headers,
     // so if it's not defined, we should set it to the actual path of the compiler.
     if env::var_os("CLANG_PATH").is_none() {

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -335,13 +335,25 @@ fn build_bindings(build_dir: &Path, target: BuildTarget) {
         .include(&js_config_path(build_dir));
     if cc_rs_builder.get_compiler().is_like_msvc() {
         cc_rs_builder.flag("--driver-mode=cl");
+    } else {
+        // `.cpp(true)` from cc_rs_builder will not propagate to bindgen clang-args,
+        // so we need to set it explicitly here. Doesn't work with msvc.
+        builder
+            .clang_args(["-x", "c++"]);
     }
 
     for path in target.include_paths(build_dir) {
         cc_rs_builder.include(path);
     }
 
-    for arg in cc_rs_builder.get_compiler().args() {
+    let compiler = cc_rs_builder.get_compiler();
+    // `bindgen` invokes clang via CLANG_PATH to find the system and c++ headers,
+    // so if it's not defined, we should set it to the actual path of the compiler.
+    if env::var_os("CLANG_PATH").is_none() {
+        env::set_var("CLANG_PATH", "/usr/bin/c++");
+    }
+
+    for arg in compiler.args() {
         builder = builder.clang_arg(
             arg.to_str()
                 .expect("Non UTF-8 compiler flag in cc::Build args"),

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -16,7 +16,6 @@ const ENV_VARS: &'static [&'static str] = &[
     "AS",
     "CC",
     "CFLAGS",
-    "CLANGFLAGS",
     "CPP",
     "CPPFLAGS",
     "CXX",
@@ -39,7 +38,6 @@ const SM_TARGET_ENV_VARS: &'static [&'static str] = &[
     "AS",
     "CC",
     "CFLAGS",
-    "CLANGFLAGS",
     "CPP",
     "CPPFLAGS",
     "CXX",
@@ -354,12 +352,6 @@ fn build_bindings(build_dir: &Path, target: BuildTarget) {
     }
 
     if let Some(flags) = get_cc_rs_env("CXXFLAGS") {
-        for flag in flags.split_whitespace() {
-            builder = builder.clang_arg(flag);
-        }
-    }
-
-    if let Some(flags) = get_cc_rs_env("CLANGFLAGS") {
         for flag in flags.split_whitespace() {
             builder = builder.clang_arg(flag);
         }

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -332,6 +332,7 @@ fn build_bindings(build_dir: &Path, target: BuildTarget) {
     let mut cc_rs_builder = get_common_cc();
     cc_rs_builder
         .define("RUST_BINDGEN", None)
+        // todo: include via common cc-args?
         .include(&js_config_path(build_dir));
     if cc_rs_builder.get_compiler().is_like_msvc() {
         cc_rs_builder.flag("--driver-mode=cl");
@@ -350,18 +351,10 @@ fn build_bindings(build_dir: &Path, target: BuildTarget) {
 
     // Setting CLANG_PATH to the absolute path (when using the default c++ compiler on macos),
     // allows bindgen to find the c++ headers (not just the system headers).
-    if target_os == "macos" && compiler.path().to_str() == Some("c++") {
-        env::set_var("CLANG_PATH", "/usr/bin/c++");
-    }
-
-    for path in target.include_paths(build_dir) {
-        cc_rs_builder.include(path);
-    }
-
-    // `bindgen` invokes clang via CLANG_PATH to find the system and c++ headers,
-    // so if it's not defined, we should set it to the actual path of the compiler.
     if env::var_os("CLANG_PATH").is_none() {
-        env::set_var("CLANG_PATH", "/usr/bin/c++");
+        if target_os == "macos" && compiler.path().to_str() == Some("c++") {
+            env::set_var("CLANG_PATH", "/usr/bin/c++");
+        }
     }
 
     for arg in compiler.args() {
@@ -369,6 +362,11 @@ fn build_bindings(build_dir: &Path, target: BuildTarget) {
             arg.to_str()
                 .expect("Non UTF-8 compiler flag in cc::Build args"),
         );
+    }
+
+    // todo: add target.include_paths via common cc-args?
+    for path in target.include_paths(build_dir) {
+        builder = builder.clang_arg("-I").clang_arg(path);
     }
 
     if env::var("TARGET").unwrap().contains("wasi") {

--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.15.8"
+version = "0.15.9"
 authors = ["The Servo Project Developers"]
 license.workspace = true
 edition.workspace = true
@@ -27,7 +27,7 @@ encoding_rs = "0.8.35"
 libc.workspace = true
 log = "0.4"
 # When doing non-version changes also update ../mozjs-sys/etc/sm-security-bump.py
-mozjs_sys = { version = "=0.140.8-3", path = "../mozjs-sys" }
+mozjs_sys = { version = "=0.140.8-4", path = "../mozjs-sys" }
 num-traits = "0.2"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/ohos-build
+++ b/ohos-build
@@ -57,6 +57,7 @@ def set_toolchain_binaries_in_env(toolchain_dir: str, target_triple: str, env: D
     env["LIBCLANG_PATH"] = os.path.join(toolchain_dir, "lib")
     env["CLANG_PATH"] = cxx
     env[f'CXXSTDLIB_{target_triple_underscore}'] = "c++"
+    env["BINDGEN_EXTRA_CLANG_ARGS"] = f"--sysroot={os.path.join(toolchain_dir, '..', 'sysroot')}"
 
 
 def create_environment_for_build() -> Dict[str, str]:


### PR DESCRIPTION
Follow-up to #732. 

Refactor cc_flags to get_common_cc, which returns a cc builder. Any bindgen specific flags are moved to build_bindings.
Removed the explicit `O0` override, this will be configured by cc-rs based on opt-level (for the glue code, and ignored by bindgen).

Testing: *Describe how this pull request is tested or why it doesn't require tests*
Servo PR: *Link to a companion pull request in the Servo repository. Remove this line if there is no companion PR.*
