### PR TITLE
build: Workaround make jobserver bug

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.140.8-3"
+version = "0.140.8-4"
 authors = ["Mozilla", "The Servo Project Developers"]
 links = "mozjs"
 license.workspace = true

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -222,8 +222,14 @@ fn build_spidermonkey(build_dir: &Path) {
     cppflags.push(get_cc_rs_env_os("CPPFLAGS").unwrap_or_default());
     cmd.env("CPPFLAGS", cppflags);
 
-    if let Some(makeflags) = env::var_os("CARGO_MAKEFLAGS") {
-        cmd.env("MAKEFLAGS", makeflags);
+    // With make 4.4 a new jobserver style was added, which cargo doesn't support yet.
+    // Unfortunately, the old pipe jobserver that cargo exposes, has a new bug in 4.4,
+    // which is exposed by spidermonkeys makefiles and makes compilation largely
+    // single-threaded.
+    if !is_buggy_make_version() {
+        if let Some(makeflags) = env::var_os("CARGO_MAKEFLAGS") {
+            cmd.env("MAKEFLAGS", makeflags);
+        }
     }
 
     let mut cxxflags = vec![];
@@ -287,6 +293,26 @@ fn cbindgen_bidi(build_dir: &Path) {
       .write_to_file(root_to_bidi(build_dir).join("unicode_bidi_ffi_generated.h"));
 }
 */
+
+fn is_buggy_make_version() -> bool {
+    if let Ok(output) = Command::new("gmake")
+        .arg("--help")
+        .output()
+        .or_else(|_| Command::new("make").arg("--help").output())
+    {
+        let Ok(output) = String::from_utf8(output.stdout) else {
+            println!("cargo:warning=Output from make was not valid utf-8. Can't determine version");
+            return false;
+        };
+        // --jobserver-style was added in Make 4.4, and hence can tell us if we have a version
+        // of make that is incompatible with cargos pipe jobserver (in spidermonkey).
+
+        output.contains("--jobserver-style")
+    } else {
+        println!("cargo:warning=Couldn't invoke make --help to determine make version");
+        false
+    }
+}
 
 fn build(build_dir: &Path, target: BuildTarget) {
     let mut build = cc::Build::new();

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -226,6 +226,8 @@ fn build_spidermonkey(build_dir: &Path) {
     // Unfortunately, the old pipe jobserver that cargo exposes, has a new bug in 4.4,
     // which is exposed by spidermonkeys makefiles and makes compilation largely
     // single-threaded.
+    // The workaround can be removed / adapted once cargo supports the new jobserver:
+    // <https://github.com/rust-lang/cargo/issues/13483>
     if is_buggy_make_version() {
         // worst-case we'll get 2xNUM_JOBS jobs, since we will have two independant job servers
         let num_jobs = env::var("NUM_JOBS").expect("NUM_JOBS should be set by cargo");

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -226,7 +226,12 @@ fn build_spidermonkey(build_dir: &Path) {
     // Unfortunately, the old pipe jobserver that cargo exposes, has a new bug in 4.4,
     // which is exposed by spidermonkeys makefiles and makes compilation largely
     // single-threaded.
-    if !is_buggy_make_version() {
+    if is_buggy_make_version() {
+        // worst-case we'll get 2xNUM_JOBS jobs, since we will have two independant job servers
+        let num_jobs = env::var("NUM_JOBS").expect("NUM_JOBS should be set by cargo");
+        cmd.arg(format!("--jobs={num_jobs}"));
+    } else {
+        // Inherit the jobserver from cargo
         if let Some(makeflags) = env::var_os("CARGO_MAKEFLAGS") {
             cmd.env("MAKEFLAGS", makeflags);
         }
@@ -306,7 +311,6 @@ fn is_buggy_make_version() -> bool {
         };
         // --jobserver-style was added in Make 4.4, and hence can tell us if we have a version
         // of make that is incompatible with cargos pipe jobserver (in spidermonkey).
-
         output.contains("--jobserver-style")
     } else {
         println!("cargo:warning=Couldn't invoke make --help to determine make version");

--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.15.8"
+version = "0.15.9"
 authors = ["The Servo Project Developers"]
 license.workspace = true
 edition.workspace = true
@@ -27,7 +27,7 @@ encoding_rs = "0.8.35"
 libc.workspace = true
 log = "0.4"
 # When doing non-version changes also update ../mozjs-sys/etc/sm-security-bump.py
-mozjs_sys = { version = "=0.140.8-3", path = "../mozjs-sys" }
+mozjs_sys = { version = "=0.140.8-4", path = "../mozjs-sys" }
 num-traits = "0.2"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]


### PR DESCRIPTION
This works around the following bug, where the invocation below fails with the pipe style and works fine with the new fifo jobserver. Since there is no sign of cargo going to support fifo jobservers, and single threaded compilation is horribly slow, we don't pass makeflags on, when using make 4.4. We use a crude version check, which checks the presence of the flag - since new make versions are rare, this should be fine for a while.
If we detect the flag (i.e. make 4.4 or newer), we pass `-j <NUM_JOBS>` to make instead of inheriting MAKEFLAGS and the jobserver from cargo. This means we get an upper bound of 2x NUM_JOBS jobs, since the cargo jobserver  and makes jobserver coexist.
We can remove this workaround once cargo [supports fifo style jobservers](https://github.com/rust-lang/cargo/issues/13483).

Minimum reproducer:

`gmake -j2 --jobserver-style=pipe -f Makefile`

Makefile:
```make
define RECURSE
+$(MAKE) -f sub.mk
endef

all:
	$(RECURSE)
```

sub.mk:

```
all:
	@:
```

Output: `gmake[1]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.`

Testing: This is specific to make 4.4, and hence not covered by automated tests
Fixes: #375 
Servo PR: https://github.com/servo/servo/pull/44346
