### PR TITLE
Fix build with crown feature enabled.

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.140.10-1"
+version = "0.140.10-2"
 authors = ["Mozilla", "The Servo Project Developers"]
 links = "mozjs"
 license.workspace = true

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -846,6 +846,7 @@ impl BuildTarget {
                 "JS::dbg::Builder_Object",
                 "JS::dbg::Builder_Object_Base",
                 "JS::dbg::BuilderOrigin",
+                "JS::ExpandoAndGeneration",
                 "JS::RootedTuple",
                 "mozilla::external::AtomicRefCounted",
                 "mozilla::ProfilerStringView",

--- a/mozjs-sys/src/jsgc.rs
+++ b/mozjs-sys/src/jsgc.rs
@@ -341,6 +341,7 @@ impl<T: GCMethods + Copy> Heap<T> {
     ///
     /// Using boxed Heap value guarantees that the underlying Heap value will
     /// not be moved when constructed.
+    #[cfg_attr(feature = "crown", expect(crown::unrooted_must_root))]
     pub fn boxed(v: T) -> Box<Heap<T>>
     where
         Heap<T>: Default,

--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -27,7 +27,7 @@ encoding_rs = "0.8.35"
 libc.workspace = true
 log = "0.4"
 # When doing non-version changes also update ../mozjs-sys/etc/sm-security-bump.py
-mozjs_sys = { version = "=0.140.10-1", path = "../mozjs-sys" }
+mozjs_sys = { version = "=0.140.10-2", path = "../mozjs-sys" }
 num-traits = "0.2"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.15.11"
+version = "0.15.12"
 authors = ["The Servo Project Developers"]
 license.workspace = true
 edition.workspace = true

--- a/mozjs/src/typedarray.rs
+++ b/mozjs/src/typedarray.rs
@@ -88,6 +88,7 @@ impl JSObjectStorage for Box<Heap<*mut JSObject>> {
     fn as_raw(&self) -> *mut JSObject {
         self.get()
     }
+    #[cfg_attr(feature = "crown", expect(crown::unrooted_must_root))]
     fn from_raw(raw: *mut JSObject) -> Self {
         let boxed = Box::new(Heap::default());
         boxed.set(raw);


### PR DESCRIPTION
Per #737 this doesn't get detected in either this repository's CI or Servo's CI. `Heap<T>` is marked `must_root`, and method that return a `Heap<T>` need to suppress that warning. 

Testing: Servo build succeeded with MOZJS_FROM_SOURCE=1, `--use-crown`, and a local Cargo override.