### PR TITLE
Allow extracting the box out of a RootedTraceableBox.

### DIFF
--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.15.12"
+version = "0.15.13"
 authors = ["The Servo Project Developers"]
 license.workspace = true
 edition.workspace = true

--- a/mozjs/src/gc/collections.rs
+++ b/mozjs/src/gc/collections.rs
@@ -6,6 +6,7 @@ use mozjs_sys::jsgc::GCMethods;
 use mozjs_sys::jsval::JSVal;
 use mozjs_sys::trace::Traceable;
 use std::ops::{Deref, DerefMut};
+use std::ptr;
 
 /// A vector of items to be rooted with `RootedVec`.
 /// Guaranteed to be empty when not rooted.
@@ -131,6 +132,18 @@ impl<T: Traceable + 'static> RootedTraceableBox<T> {
     pub unsafe fn ptr(&self) -> *mut T {
         self.ptr
     }
+
+    pub fn into_box(mut self) -> Box<T> {
+        self.cleanup()
+    }
+
+    fn cleanup(&mut self) -> Box<T> {
+        unsafe {
+            let ptr = std::mem::replace(&mut self.ptr, ptr::null_mut());
+            RootedTraceableSet::remove(ptr);
+            Box::from_raw(ptr)
+        }
+    }
 }
 
 impl<T> RootedTraceableBox<Heap<T>>
@@ -164,9 +177,8 @@ impl<T: Traceable> DerefMut for RootedTraceableBox<T> {
 
 impl<T: Traceable + 'static> Drop for RootedTraceableBox<T> {
     fn drop(&mut self) {
-        unsafe {
-            RootedTraceableSet::remove(self.ptr);
-            let _ = Box::from_raw(self.ptr);
+        if !self.ptr.is_null() {
+            self.cleanup();
         }
     }
 }

--- a/mozjs/src/gc/collections.rs
+++ b/mozjs/src/gc/collections.rs
@@ -133,6 +133,9 @@ impl<T: Traceable + 'static> RootedTraceableBox<T> {
         self.ptr
     }
 
+    /// Destroys this root and returns the boxed value.
+    /// This value is no longer rooted, but is still safe to stored
+    /// in some other rooted or traceable location.
     pub fn into_box(mut self) -> Box<T> {
         self.cleanup()
     }

--- a/mozjs/src/gc/root.rs
+++ b/mozjs/src/gc/root.rs
@@ -167,6 +167,11 @@ where
         // Safety: Values within this rooted vector are traced.
         unsafe { MutableHandle::from_marked_location(self.as_mut().as_mut_ptr().add(index)) }
     }
+
+    pub fn take(&'_ mut self) -> Vec<T> {
+        // Safety: No GC can run during this call.
+        std::mem::take(unsafe { self.as_mut() })
+    }
 }
 
 impl<'a, T: 'a + RootKind> Deref for RootedGuard<'a, T> {

--- a/mozjs/tests/rooted_traceable_box.rs
+++ b/mozjs/tests/rooted_traceable_box.rs
@@ -1,0 +1,70 @@
+#![cfg(feature = "debugmozjs")]
+
+use std::ptr;
+
+use mozjs::gc::RootedTraceableBox;
+use mozjs::jsapi::SetGCZeal;
+use mozjs::jsapi::{GCReason, Heap, JSTracer, OnNewGlobalHookOption, Value};
+use mozjs::jsval::ObjectValue;
+use mozjs::realm::AutoRealm;
+use mozjs::rooted;
+use mozjs::rust::wrappers2::{JS_NewGlobalObject, JS_NewPlainObject, JS_GC};
+use mozjs::rust::{JSEngine, RealmOptions, Runtime, SIMPLE_GLOBAL_CLASS};
+
+#[test]
+fn rooted_traceable_box() {
+    let engine = JSEngine::init().unwrap();
+    let mut runtime = Runtime::new(engine.handle());
+    let context = runtime.cx();
+    let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
+    let c_option = RealmOptions::default();
+
+    unsafe {
+        SetGCZeal(context.raw_cx(), 2, 1);
+        rooted!(&in(context) let global = JS_NewGlobalObject(
+            context,
+            &SIMPLE_GLOBAL_CLASS,
+            ptr::null_mut(),
+            h_option,
+            &*c_option,
+        ));
+        let mut realm = AutoRealm::new_from_handle(context, global.handle());
+        let context = &mut realm;
+
+        let something = RootedTraceableBox::new(Something {
+            object: Heap::default(),
+        });
+        something
+            .object
+            .set(ObjectValue(JS_NewPlainObject(context)));
+        JS_GC(context, GCReason::API);
+
+        rooted!(&in(context) let _container = Container {
+            something: something.into_box(),
+        });
+
+        JS_GC(context, GCReason::API);
+    }
+}
+
+struct Something {
+    object: Heap<Value>,
+}
+
+unsafe impl mozjs::rust::Trace for Something {
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        self.object.trace(trc);
+    }
+}
+
+struct Container {
+    something: Box<Something>,
+}
+
+unsafe impl mozjs::rust::Trace for Container {
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        self.something.trace(trc);
+    }
+}
+
+impl mozjs::gc::Rootable for Container {}


### PR DESCRIPTION
This method is important for making it easier to use typed arrays more safely in Servo. We can pass around RootedTraceableBox values into functions that return heap-allocated objects that need to store the inner `Heap` instead of the RootedTraceableBox.

Testing: Added unit test.
Servo PR: https://github.com/servo/servo/pull/44464
