### PR TITLE
security bump: Fix script, and verify version

### DIFF
--- a/mozjs-sys/etc/get_latest_mozjs.py
+++ b/mozjs-sys/etc/get_latest_mozjs.py
@@ -9,7 +9,8 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from get_taskcluster_mozjs import download_from_taskcluster, ESR, REPO
 
 
-def get_latest_mozjs_tag_changeset() -> tuple[str, str, str]:
+# Returns minor, patch, tag, changeset.
+def get_latest_mozjs_tag_changeset() -> tuple[str, str, str, str]:
     # Obtain latest released tag
     response = requests.get(f"https://hg.mozilla.org/releases/{REPO}/json-tags")
     response.raise_for_status()
@@ -18,15 +19,20 @@ def get_latest_mozjs_tag_changeset() -> tuple[str, str, str]:
 
     matching = []
     for tag_info in tags:
-        tag = tag_info["tag"]
+        tag: str = tag_info["tag"]
         if re.match(rf"^FIREFOX_{ESR}_.*esr_RELEASE$", tag):
+            minor_patch = tag.removeprefix(f"FIREFOX_{ESR}_").removesuffix("esr_RELEASE").split("_", 1)
+            minor = minor_patch[0]
+            if len(minor_patch) == 2:
+                patch = minor_patch[1]
+            elif len(minor_patch) == 1:
+                patch = "0"
+            else:
+                raise ValueError(f"Invalid tag format: {tag}")
             matching.append(
                 (
-                    float(
-                        tag.removeprefix(f"FIREFOX_{ESR}_")
-                        .removesuffix("esr_RELEASE")
-                        .replace("_", ".")
-                    ),
+                    minor,
+                    patch,
                     tag,
                     tag_info["node"],
                 )
@@ -36,15 +42,15 @@ def get_latest_mozjs_tag_changeset() -> tuple[str, str, str]:
         print("Error: No matching FIREFOX_*_RELEASE tags found")
         sys.exit(1)
 
-    # Sort by version and get the latest
-    matching.sort(key=lambda x: x[0])
-    minor_patch, tag, changeset = matching[-1]
+    # Sort by version (first minor, then patch) and get the latest
+    matching.sort(key=lambda x: (int(x[0]), int(x[1])))
+    minor, patch, tag, changeset = matching[-1]
 
-    return minor_patch, tag, changeset
+    return minor, patch, tag, changeset
 
 
 if __name__ == "__main__":
-    minor_patch, tag, changeset = get_latest_mozjs_tag_changeset()
+    minor, patch, tag, changeset = get_latest_mozjs_tag_changeset()
     print(f"Latest tag: {tag}, changeset: {changeset}")
 
     download_from_taskcluster(changeset)

--- a/mozjs-sys/etc/get_taskcluster_mozjs.py
+++ b/mozjs-sys/etc/get_taskcluster_mozjs.py
@@ -2,12 +2,15 @@
 
 import sys
 import os
+import tarfile
+
 import requests
+from urllib.parse import quote
 from urllib.request import urlretrieve
 
 ESR = 140
 REPO = f"mozilla-esr{ESR}"
-HEADERS = {"User-Agent": "Mozilla/5.0 (X11; Linux x86_64) mozjs-sys/1.0"}
+HEADERS = {"User-Agent": "mozjs-sys/1.0 (https://github.com/servo/mozjs)"}
 
 
 def download_artifact(task_id: str, artifact_name: str, dl_name: str, i=0):
@@ -55,7 +58,21 @@ def find_sm_pkg_and_hazard_task_in_push(push_id: int) -> tuple[str | None, str |
     return sm_pkg_task_id, hazard_task_id
 
 
+def get_ancestor_revisions(commit: str, limit: int) -> set[str]:
+    revset = quote(f"ancestors({commit})")
+    response = requests.get(
+        f"https://hg.mozilla.org/releases/{REPO}/json-log"
+        f"?rev={revset}&limit={limit}",
+        headers=HEADERS,
+    )
+    response.raise_for_status()
+    return {entry["node"] for entry in response.json().get("entries", [])}
+
+
 def get_previous_pushes(commit: str, count: int):
+    # Multiple changesets can map to the same push, so we fetch more.
+    ancestors = get_ancestor_revisions(commit, limit=count * 20)
+
     response = requests.get(
         f"https://treeherder.mozilla.org/api/project/{REPO}/push/?revision={commit}",
         headers=HEADERS,
@@ -64,13 +81,56 @@ def get_previous_pushes(commit: str, count: int):
     initial_push = response.json()["results"][0]
     push_timestamp = initial_push["push_timestamp"]
 
-    # this is how treeherders get n more pushes works
     response = requests.get(
-        f"https://treeherder.mozilla.org/api/project/{REPO}/push/?push_timestamp__lte={push_timestamp}&count={count}",
+        f"https://treeherder.mozilla.org/api/project/{REPO}/push/"
+        f"?push_timestamp__lte={push_timestamp}&count={count * 4}",
         headers=HEADERS,
     )
     response.raise_for_status()
-    return response.json()["results"]
+    all_pushes = response.json()["results"]
+
+    # Keep only pushes whose tip changeset is an ancestor of `commit`.
+    on_branch = [p for p in all_pushes if p["revision"] in ancestors]
+    return on_branch[:count]
+
+def read_milestone_from_tarball(tarball_path: str) -> str:
+    """Extract `config/milestone.txt` from the SM source tarball and return
+    the milestone version string (e.g. '140.9.0')."""
+    with tarfile.open(tarball_path, "r:*") as tar:
+        milestone_member = None
+        for member in tar:
+            if member.isfile() and member.name.endswith("/config/milestone.txt"):
+                milestone_member = member
+                break
+        if milestone_member is None:
+            raise RuntimeError(
+                f"config/milestone.txt not found in {tarball_path}"
+            )
+        f = tar.extractfile(milestone_member)
+        if f is None:
+            raise RuntimeError(
+                f"Could not read {milestone_member.name} from {tarball_path}"
+            )
+        content = f.read().decode("utf-8")
+
+    for line in content.splitlines():
+        line = line.strip()
+        if line and not line.startswith("#"):
+            return line
+    raise RuntimeError(
+        f"Could not parse milestone version from {milestone_member.name}"
+    )
+
+
+def verify_tarball_version(tarball_path: str, expected_version: str) -> None:
+    """Verify the tarball's milestone matches the expected tag version."""
+    milestone = read_milestone_from_tarball(tarball_path)
+    if milestone != expected_version:
+        raise RuntimeError(
+            f"SpiderMonkey version mismatch: tarball milestone is {milestone} "
+            f"but the resolved tag implies {expected_version}."
+        )
+    print(f"Milestone verified: tarball is SpiderMonkey {milestone}")
 
 
 def download_from_taskcluster(commit: str, look_back_for_artifacts: int = 50):

--- a/mozjs-sys/etc/sm-security-bump.py
+++ b/mozjs-sys/etc/sm-security-bump.py
@@ -6,7 +6,7 @@ import subprocess
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from get_latest_mozjs import get_latest_mozjs_tag_changeset
-from get_taskcluster_mozjs import download_from_taskcluster, ESR, REPO
+from get_taskcluster_mozjs import download_from_taskcluster, ESR, REPO, verify_tarball_version
 from get_mozjs import download_gh_artifact
 from update import main
 
@@ -33,6 +33,8 @@ if GITHUB_OUTPUT := os.getenv("GITHUB_OUTPUT"):
 
 
 download_from_taskcluster(changeset)
+
+verify_tarball_version("mozjs.tar.xz", f"{ESR}.{minor_patch}")
 
 subprocess.check_call(
     [

--- a/mozjs-sys/etc/sm-security-bump.py
+++ b/mozjs-sys/etc/sm-security-bump.py
@@ -12,7 +12,7 @@ from update import main
 
 script_dir = os.path.dirname(os.path.abspath(__file__))
 
-minor_patch, tag, changeset = get_latest_mozjs_tag_changeset()
+minor, patch, tag, changeset = get_latest_mozjs_tag_changeset()
 print(f"Latest tag: {tag}, changeset: {changeset}")
 
 try:
@@ -28,13 +28,13 @@ if GITHUB_OUTPUT := os.getenv("GITHUB_OUTPUT"):
     with open(GITHUB_OUTPUT, "a") as github_output_file:
         print(f"tag={tag}", file=github_output_file)
         print(f"changeset={changeset}", file=github_output_file)
-        print(f"version={ESR}.{int(minor_patch)}", file=github_output_file)
+        print(f"version={ESR}.{minor}.{patch}", file=github_output_file)
         print(f"esr={ESR}", file=github_output_file)
 
 
 download_from_taskcluster(changeset)
 
-verify_tarball_version("mozjs.tar.xz", f"{ESR}.{minor_patch}")
+verify_tarball_version("mozjs.tar.xz", f"{ESR}.{minor}.{patch}")
 
 subprocess.check_call(
     [
@@ -75,7 +75,7 @@ os.remove("mozjs.tar.xz")
 subprocess.check_call(["git", "add", "--all"])
 subprocess.check_call(["git", "commit", "-m", "Apply patches", "--signoff"])
 
-version = f"0.{ESR}.{int(minor_patch)}-0"
+version = f"{ESR}.{minor}.{patch}-0"
 print(f"Updating to version {version}")
 
 cargo_toml_file = os.path.join(script_dir, "..", "Cargo.toml")


### PR DESCRIPTION
This PR attempts to fix the issue identified in https://github.com/servo/mozjs/pull/729#discussion_r3050185183.
We add a function to verify that the milestone version matches our expected version, so that failures are visible.
To fix `get_previous_pushes` we also check ancestors on `hg.mozilla.org` and use that to filter the time-based pushes from treeherder.
I'm pretty confident in the "verification" part of the PR, less so for the treeherder part, since I'm not familiar.

Also change the version to `<ESR>.<minor>.<patch>-0`, since otherwise there is no room for the patch version. 
For sorting use a tuple of minor, patch. In practice `float` should be fine, but in theory if we actually had 10 patch releases, then the sorting would be wrong. Changed it anyway, to be on the correct side.

The sm-security-bump script already pushed 140.10.0 to servo releases, so it's required to comment out the unneeded parts for testing.

Testing: Not part of any automated testing.

