### PR TITLE
Implement JSContext::get_from_thread

### DIFF
--- a/mozjs/src/context.rs
+++ b/mozjs/src/context.rs
@@ -101,7 +101,7 @@ impl JSContext {
     /// SAFETY:
     /// - only one [JSContext] can be alive and it should not outlive [Runtime].
     pub unsafe fn get_from_thread() -> Option<JSContext> {
-        unsafe { crate::rust::Runtime::get().map(JSContext::from_ptr) }
+        unsafe { crate::rust::Runtime::get().map(|raw_cx| unsafe { JSContext::from_ptr(raw_cx) }) }
     }
 
     /// Returns [NoGC] token bounded to this [JSContext].

--- a/mozjs/src/context.rs
+++ b/mozjs/src/context.rs
@@ -101,7 +101,7 @@ impl JSContext {
     /// SAFETY:
     /// - only one [JSContext] can be alive and it should not outlive [Runtime].
     pub unsafe fn get_from_thread() -> Option<JSContext> {
-        unsafe { mozjs::rust::Runtime::get().map(JSContext::from_ptr) }
+        unsafe { crate::rust::Runtime::get().map(JSContext::from_ptr) }
     }
 
     /// Returns [NoGC] token bounded to this [JSContext].

--- a/mozjs/src/context.rs
+++ b/mozjs/src/context.rs
@@ -96,6 +96,14 @@ impl JSContext {
         JSContext { ptr: cx }
     }
 
+    /// Get the `JSContext` for this thread (thin air). This should be rarely used.
+    ///
+    /// SAFETY:
+    /// - only one [JSContext] can be alive and it should not outlive [Runtime].
+    pub unsafe fn get_from_thread() -> Option<JSContext> {
+        unsafe { mozjs::rust::Runtime::get().map(JSContext::from_ptr) }
+    }
+
     /// Returns [NoGC] token bounded to this [JSContext].
     /// No function that accepts `&mut JSContext` (read: triggers GC)
     /// can be called while this is alive.


### PR DESCRIPTION
This is unofficially perma cx. Sometimes it is needed: https://github.com/servo/servo/pull/45040#discussion_r3278839426 and https://doc.servo.org/mozjs/rust/struct.Runtime.html#method.get is planned to be removed.
