### PR TITLE
scripts: Build mozjs.tar.xz from source instead of searching taskcluster

### DIFF
--- a/mozjs-sys/etc/get_git_mozjs.py
+++ b/mozjs-sys/etc/get_git_mozjs.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Build mozjs.tar.xz locally from upstream.
+Since not all upstream ESR releases build mozjs.tar.xz in CI,
+this script checks out the firefox source code from upstream at the relevant tag
+and builds the archive using the upstream script.
+"""
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+from urllib.request import urlretrieve
+
+REPO = "mozilla-firefox/firefox"
+
+
+def download_source_tarball(tag: str, dest: Path) -> None:
+    url = f"https://codeload.github.com/{REPO}/tar.gz/refs/tags/{tag}"
+    print(f"Downloading: {url}")
+    urlretrieve(url, dest)
+
+
+def extract_tarball(tarball: Path, dest_dir: Path) -> Path:
+    print(f"Extracting {tarball.name} into {dest_dir}")
+    with tarfile.open(tarball, "r:gz") as tar:
+        tar.extractall(dest_dir, filter="data")
+    entries = [p for p in dest_dir.iterdir() if p.is_dir()]
+    if len(entries) != 1:
+        raise RuntimeError(
+            f"Expected a single top-level directory in {tarball}, found {entries}"
+        )
+    return entries[0]
+
+
+def run_make_source_package(source_root: Path, dist_dir: Path) -> Path:
+    script = source_root / "js" / "src" / "make-source-package.py"
+    if not script.is_file():
+        raise RuntimeError(f"{script} not found in extracted source tree")
+    env = os.environ.copy()
+    env["DIST"] = str(dist_dir)
+    print(f"Running {script.relative_to(source_root)}")
+    subprocess.check_call([sys.executable, str(script)], env=env, cwd=str(source_root))
+    matches = sorted(dist_dir.glob("mozjs-*.tar.xz"))
+    if len(matches) != 1:
+        raise RuntimeError(
+            f"Expected a single mozjs-*.tar.xz in {dist_dir}, found {matches}"
+        )
+    return matches[0]
+
+
+def build_sm_package_from_git(tag: str, output: Path) -> None:
+    """Produce a SpiderMonkey source tarball at `output` from the upstream git
+    tag `tag` (e.g. "FIREFOX_140_11_0esr_RELEASE")."""
+    with tempfile.TemporaryDirectory(prefix="mozjs-git-") as tmp_str:
+        tmp = Path(tmp_str)
+        tarball = tmp / "firefox.tar.gz"
+        download_source_tarball(tag, tarball)
+        extract_dir = tmp / "src"
+        extract_dir.mkdir()
+        source_root = extract_tarball(tarball, extract_dir)
+        tarball.unlink()
+        dist_dir = tmp / "dist"
+        dist_dir.mkdir()
+        pkg = run_make_source_package(source_root, dist_dir)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(pkg), str(output))
+        print(f"Wrote {output}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build a SpiderMonkey source tarball from the mozilla-firefox/firefox "
+            "git repository at a given Firefox release tag."
+        ),
+    )
+    parser.add_argument(
+        "tag",
+        help='Firefox release tag, e.g. "FIREFOX_140_11_0esr_RELEASE"',
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        default="mozjs.tar.xz",
+        help="Output path (default: %(default)s)",
+    )
+    args = parser.parse_args()
+    build_sm_package_from_git(args.tag, Path(args.output))
+
+
+if __name__ == "__main__":
+    main()

--- a/mozjs-sys/etc/get_latest_mozjs.py
+++ b/mozjs-sys/etc/get_latest_mozjs.py
@@ -3,10 +3,13 @@
 import os
 import sys
 import re
+from pathlib import Path
+
 import requests
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from get_taskcluster_mozjs import download_from_taskcluster, ESR, REPO
+from get_taskcluster_mozjs import ESR, REPO, download_hazard_artifacts_from_taskcluster
+from get_git_mozjs import build_sm_package_from_git
 
 
 # Returns minor, patch, tag, changeset.
@@ -53,4 +56,5 @@ if __name__ == "__main__":
     minor, patch, tag, changeset = get_latest_mozjs_tag_changeset()
     print(f"Latest tag: {tag}, changeset: {changeset}")
 
-    download_from_taskcluster(changeset)
+    build_sm_package_from_git(tag, Path("mozjs.tar.xz"))
+    download_hazard_artifacts_from_taskcluster(changeset)

--- a/mozjs-sys/etc/get_taskcluster_mozjs.py
+++ b/mozjs-sys/etc/get_taskcluster_mozjs.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python3
 
 import sys
-import os
 import tarfile
 
 import requests
-from urllib.parse import quote
 from urllib.request import urlretrieve
 
 ESR = 140
@@ -13,85 +11,45 @@ REPO = f"mozilla-esr{ESR}"
 HEADERS = {"User-Agent": "mozjs-sys/1.0 (https://github.com/servo/mozjs)"}
 
 
-def download_artifact(task_id: str, artifact_name: str, dl_name: str, i=0):
-    response = requests.get(
-        f"https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/{task_id}/runs/{i}/artifacts",
+def download_artifact(task_id: str, artifact_name: str, dl_name: str) -> None:
+    """Download `artifact_name` from `task_id`, scanning runs newest-first.
+
+    A task can have multiple runs (presumably due to failures) - We must walk runs
+    and look for the requested artifact.
+    Scanning newest-first since presumably the latest run is a successfull one.
+    """
+    base = f"https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/{task_id}"
+    status_response = requests.get(f"{base}/status")
+    status_response.raise_for_status()
+    runs = status_response.json()["status"]["runs"]
+    for run in reversed(runs):
+        i = run["runId"]
+        response = requests.get(f"{base}/runs/{i}/artifacts")
+        response.raise_for_status()
+        for artifact in response.json()["artifacts"]:
+            if artifact_name in artifact["name"]:
+                url = f"{base}/runs/{i}/artifacts/{artifact['name']}"
+                print(f"Downloading: {url}")
+                urlretrieve(url, dl_name)
+                return
+    print(
+        f"Error: Could not find {artifact_name} in any of {len(runs)} run(s) "
+        f"of task {task_id}"
     )
-    response.raise_for_status()
-    artifacts = response.json()["artifacts"]
-    if not artifacts:
-        if i < 5:
-            download_artifact(task_id, artifact_name, dl_name, i + 1)
-            return
-        else:
-            print(f"Error: No artifacts found for task {task_id} after {i} attempts")
-            sys.exit(1)
-    file = None
-    for artifact in artifacts:
-        if artifact_name in artifact["name"]:
-            file = artifact["name"]
-            break
-
-    if file is None:
-        print(f"Error: Could not find {artifact_name} artifact")
-        sys.exit(1)
-
-    url = f"https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/{task_id}/runs/{i}/artifacts/{file}"
-    print(f"Downloading: {url}")
-
-    urlretrieve(url, dl_name)
+    sys.exit(1)
 
 
-def find_sm_pkg_and_hazard_task_in_push(push_id: int) -> tuple[str | None, str | None]:
+def find_hazard_task_in_push(push_id: int) -> str | None:
     response = requests.get(
         f"https://treeherder.mozilla.org/api/jobs/?push_id={push_id}",
         headers=HEADERS,
     )
     response.raise_for_status()
-    sm_pkg_task_id = None
-    hazard_task_id = None
     for result in response.json()["results"]:
-        if "spidermonkey-sm-package-linux64/opt" in result:
-            sm_pkg_task_id = result[14]
-        elif "hazard-linux64-haz/debug" in result:
-            hazard_task_id = result[14]
-    return sm_pkg_task_id, hazard_task_id
+        if "hazard-linux64-haz/debug" in result:
+            return result[14]
+    return None
 
-
-def get_ancestor_revisions(commit: str, limit: int) -> set[str]:
-    revset = quote(f"ancestors({commit})")
-    response = requests.get(
-        f"https://hg.mozilla.org/releases/{REPO}/json-log"
-        f"?rev={revset}&limit={limit}",
-        headers=HEADERS,
-    )
-    response.raise_for_status()
-    return {entry["node"] for entry in response.json().get("entries", [])}
-
-
-def get_previous_pushes(commit: str, count: int):
-    # Multiple changesets can map to the same push, so we fetch more.
-    ancestors = get_ancestor_revisions(commit, limit=count * 20)
-
-    response = requests.get(
-        f"https://treeherder.mozilla.org/api/project/{REPO}/push/?revision={commit}",
-        headers=HEADERS,
-    )
-    response.raise_for_status()
-    initial_push = response.json()["results"][0]
-    push_timestamp = initial_push["push_timestamp"]
-
-    response = requests.get(
-        f"https://treeherder.mozilla.org/api/project/{REPO}/push/"
-        f"?push_timestamp__lte={push_timestamp}&count={count * 4}",
-        headers=HEADERS,
-    )
-    response.raise_for_status()
-    all_pushes = response.json()["results"]
-
-    # Keep only pushes whose tip changeset is an ancestor of `commit`.
-    on_branch = [p for p in all_pushes if p["revision"] in ancestors]
-    return on_branch[:count]
 
 def read_milestone_from_tarball(tarball_path: str) -> str:
     """Extract `config/milestone.txt` from the SM source tarball and return
@@ -133,52 +91,26 @@ def verify_tarball_version(tarball_path: str, expected_version: str) -> None:
     print(f"Milestone verified: tarball is SpiderMonkey {milestone}")
 
 
-def download_from_taskcluster(commit: str, look_back_for_artifacts: int = 50):
-    pushes = get_previous_pushes(commit, look_back_for_artifacts + 1)
+def download_hazard_artifacts_from_taskcluster(commit: str) -> None:
+    response = requests.get(
+        f"https://treeherder.mozilla.org/api/project/{REPO}/push/?revision={commit}",
+        headers=HEADERS,
+    )
+    response.raise_for_status()
+    results = response.json()["results"]
+    if not results:
+        print(f"Error: No push found on {REPO} for commit {commit}")
+        sys.exit(1)
+    push_id = results[0]["id"]
+    print(f"Looking for hazard task in push {push_id} ({commit[:12]})...")
 
-    sm_pkg_task_id = None
-    hazard_task_id = None
-
-    # SM tasks are only run for pushes that modify SM related files:
-    # https://searchfox.org/firefox-main/rev/98bf4b92d3f5d7a9855281df4bf333210bcfbbc4/taskcluster/kinds/spidermonkey/kind.yml#30-60
-    # so we need to find last commit that had such task
-    for i, push in enumerate(pushes):
-        push_id = push["id"]
-        push_revision = push["revision"][:12]
-        if i == 0:
-            print(f"Checking initial push {push_id} ({push_revision})...")
-        else:
-            print(
-                f"No SpiderMonkey tasks found, checking previous push {push_id} ({push_revision})..."
-            )
-
-        sm_pkg_task_id, hazard_task_id = find_sm_pkg_and_hazard_task_in_push(push_id)
-
-        if sm_pkg_task_id is not None and hazard_task_id is not None:
-            print(f"Found tasks in push {push_id} ({push_revision})")
-            break
-
-    if sm_pkg_task_id is None:
+    hazard_task_id = find_hazard_task_in_push(push_id)
+    if hazard_task_id is None:
         print(
-            f"Error: Could not find spidermonkey-sm-package-linux64/opt task after checking {len(pushes)} pushes"
+            f"Error: Could not find hazard-linux64-haz/debug task in push "
+            f"{push_id} ({commit[:12]})"
         )
         sys.exit(1)
-    else:
-        print(f"Spidermonkey package task id {sm_pkg_task_id}")
-        download_artifact(sm_pkg_task_id, "tar.xz", "mozjs.tar.xz")
-    if hazard_task_id is None:
-        print("Error: Could not find hazard-linux64-haz/debug task")
-        sys.exit(1)
-    else:
-        print(f"Hazard task id {hazard_task_id}")
-        download_artifact(hazard_task_id, "allFunctions.txt.gz", "allFunctions.txt.gz")
-        download_artifact(hazard_task_id, "gcFunctions.txt.gz", "gcFunctions.txt.gz")
-
-
-if __name__ == "__main__":
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-    commit_file = os.path.join(script_dir, "COMMIT")
-    with open(commit_file, "r") as f:
-        commit = f.read().strip()
-    print(f"Commit: {commit}")
-    download_from_taskcluster(commit)
+    print(f"Hazard task id {hazard_task_id}")
+    download_artifact(hazard_task_id, "allFunctions.txt.gz", "allFunctions.txt.gz")
+    download_artifact(hazard_task_id, "gcFunctions.txt.gz", "gcFunctions.txt.gz")

--- a/mozjs-sys/etc/sm-security-bump.py
+++ b/mozjs-sys/etc/sm-security-bump.py
@@ -3,10 +3,17 @@
 import os
 import sys
 import subprocess
+from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from get_latest_mozjs import get_latest_mozjs_tag_changeset
-from get_taskcluster_mozjs import download_from_taskcluster, ESR, REPO, verify_tarball_version
+from get_taskcluster_mozjs import (
+    ESR,
+    REPO,
+    download_hazard_artifacts_from_taskcluster,
+    verify_tarball_version,
+)
+from get_git_mozjs import build_sm_package_from_git
 from get_mozjs import download_gh_artifact
 from update import main
 
@@ -32,9 +39,13 @@ if GITHUB_OUTPUT := os.getenv("GITHUB_OUTPUT"):
         print(f"esr={ESR}", file=github_output_file)
 
 
-download_from_taskcluster(changeset)
+# Build the SpiderMonkey source tarball locally from the upstream git mirror.
+# The Taskcluster artifact is not reliably available for ESR releases (see #747).
+build_sm_package_from_git(tag, Path("mozjs.tar.xz"))
 
 verify_tarball_version("mozjs.tar.xz", f"{ESR}.{minor}.{patch}")
+
+download_hazard_artifacts_from_taskcluster(changeset)
 
 subprocess.check_call(
     [


### PR DESCRIPTION
ESR 140.11 is not available on the taskcluster, since CI was skipped. The simplest solutions seems to be to just build the archive ourselves, from source, by checking out the firefox source and running the script ourselves. This allows us to simplify the taskcluster script, which now only needs to download the hazard artifacts, which apparently are always there.

This change got a lot bigger than I initially hoped - a large part is reducing the complexity again in the hazard task download script, by removing the part checking multiple pushes. Instead, we do check multiple runs of one push, since the first one doesn't always have the hazard tasks (probably since CI can fail). Maybe reverse order first would have already been sufficient, but at that point i had already written the code and it's probably safer to iterate through all runs anyway until we find the hazard tasks.

We can let CI create the release after this PR is merged.

Testing: Manual testing only - `get_latest_mozjs.py` and `sm-security-bump.py` tested locally (the latter by commenting out the parts with permanent side-effects, like creating a github release)
Addresses #747 (in a way). 
