### PR TITLE
Fix alignment mismatch warning

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "140.11.0-0"
+version = "140.11.0-1"
 authors = ["Mozilla", "The Servo Project Developers"]
 links = "mozjs"
 license.workspace = true

--- a/mozjs-sys/etc/patches/0024-bindgen-fixes.patch
+++ b/mozjs-sys/etc/patches/0024-bindgen-fixes.patch
@@ -69,16 +69,3 @@ index 9d1df4664..86646e13d 100644
    const char* data_;
  
   public:
-diff --git a/js/public/ColumnNumber.h b/js/public/ColumnNumber.h
-index 9fd007f4b..adfce9dd2 100644
---- a/js/public/ColumnNumber.h
-+++ b/js/public/ColumnNumber.h
-@@ -304,7 +304,7 @@ struct LimitedColumnNumberOneOrigin : public detail::MaybeLimitedColumnNumber<
- };
- 
- // Column number in 1-origin.
--struct ColumnNumberOneOrigin : public detail::MaybeLimitedColumnNumber<0> {
-+struct __attribute__((__packed__)) ColumnNumberOneOrigin : public detail::MaybeLimitedColumnNumber<0> {
-  private:
-   using Base = detail::MaybeLimitedColumnNumber<0>;
- 

--- a/mozjs-sys/mozjs/js/public/ColumnNumber.h
+++ b/mozjs-sys/mozjs/js/public/ColumnNumber.h
@@ -304,7 +304,7 @@ struct LimitedColumnNumberOneOrigin : public detail::MaybeLimitedColumnNumber<
 };
 
 // Column number in 1-origin.
-struct __attribute__((__packed__)) ColumnNumberOneOrigin : public detail::MaybeLimitedColumnNumber<0> {
+struct ColumnNumberOneOrigin : public detail::MaybeLimitedColumnNumber<0> {
  private:
   using Base = detail::MaybeLimitedColumnNumber<0>;
 

--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.16.1"
+version = "0.16.2"
 authors = ["The Servo Project Developers"]
 license.workspace = true
 edition.workspace = true
@@ -27,7 +27,7 @@ encoding_rs = "0.8.35"
 libc.workspace = true
 log = "0.4"
 # When doing non-version changes also update ../mozjs-sys/etc/sm-security-bump.py
-mozjs_sys = { version = "=140.11.0-0", path = "../mozjs-sys" }
+mozjs_sys = { version = "=140.11.0-1", path = "../mozjs-sys" }
 num-traits = "0.2"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]


### PR DESCRIPTION
During the ESR 128 upgrade this patch was added to fix an issue with the generated bindings.
The problem doesn't seem to exist anymore and removing the patch seems to work just fine and fixes a clang warning about mismatching alignment.

```
warning: mozjs_sys@140.11.0-0: /Users/runner/work/mozjs/mozjs/target/debug/build/mozjs_sys-ef4f07daefa91c0c/out/build/dist/include/js/ColumnNumber.h:325:12: warning: passing 1-byte aligned argument to 4-byte aligned parameter 'this' of 'MaybeLimitedColumnNumber' may result in an unaligned pointer access [-Walign-mismatch]
warning: mozjs_sys@140.11.0-0:   325 |     return ColumnNumberOneOrigin(value + 1);
warning: mozjs_sys@140.11.0-0:       |            ^
warning: mozjs_sys@140.11.0-0: ./src/jsapi.cpp:321:7: warning: passing 1-byte aligned argument to 4-byte aligned parameter 'this' of 'MaybeLimitedColumnNumber' may result in an unaligned pointer access [-Walign-mismatch]
warning: mozjs_sys@140.11.0-0:   321 |       JS::ColumnNumberOneOrigin(columnNumber), report, message,
warning: mozjs_sys@140.11.0-0:       |       ^
```

Testing: Should be covered by a full servo try run
Servo PR: pending
