### PR TITLE
Deprecate `FromJSValConvertible::from_jsval`

### DIFF
--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.17.0"
+version = "0.17.1"
 authors = ["The Servo Project Developers"]
 license.workspace = true
 edition.workspace = true

--- a/mozjs/src/conversions.rs
+++ b/mozjs/src/conversions.rs
@@ -169,6 +169,7 @@ pub trait FromJSValConvertible: Sized {
     /// argument.
     /// If it returns `Err(())`, a JSAPI exception is pending.
     /// If it returns `Ok(Failure(reason))`, there is no pending JSAPI exception.
+    #[deprecated(note = "Use safe_from_jsval instead")]
     unsafe fn from_jsval(
         cx: *mut JSContext,
         val: HandleValue,
@@ -185,7 +186,10 @@ pub trait FromJSValConvertible: Sized {
         val: HandleValue,
         option: Self::Config,
     ) -> Result<ConversionResult<Self>, ()> {
-        unsafe { Self::from_jsval(cx.raw_cx(), val, option) }
+        #[expect(deprecated)]
+        unsafe {
+            Self::from_jsval(cx.raw_cx(), val, option)
+        }
     }
 }
 
@@ -329,6 +333,14 @@ impl FromJSValConvertible for JSVal {
     ) -> Result<ConversionResult<JSVal>, ()> {
         Ok(ConversionResult::Success(value.get()))
     }
+
+    fn safe_from_jsval(
+        _cx: &mut crate::context::JSContext,
+        value: HandleValue,
+        _option: (),
+    ) -> Result<ConversionResult<JSVal>, ()> {
+        Ok(ConversionResult::Success(value.get()))
+    }
 }
 
 impl ToJSValConvertible for JSVal {
@@ -392,6 +404,14 @@ impl FromJSValConvertible for bool {
     ) -> Result<ConversionResult<bool>, ()> {
         Ok(ToBoolean(val)).map(ConversionResult::Success)
     }
+
+    fn safe_from_jsval(
+        _cx: &mut crate::context::JSContext,
+        val: HandleValue,
+        _option: (),
+    ) -> Result<ConversionResult<bool>, ()> {
+        unsafe { Ok(ToBoolean(val)).map(ConversionResult::Success) }
+    }
 }
 
 // https://heycam.github.io/webidl/#es-byte
@@ -411,6 +431,14 @@ impl FromJSValConvertible for i8 {
         option: ConversionBehavior,
     ) -> Result<ConversionResult<i8>, ()> {
         convert_int_from_jsval(cx, val, option, ToInt32)
+    }
+
+    fn safe_from_jsval(
+        cx: &mut crate::context::JSContext,
+        val: HandleValue,
+        option: ConversionBehavior,
+    ) -> Result<ConversionResult<i8>, ()> {
+        unsafe { convert_int_from_jsval(cx.raw_cx(), val, option, ToInt32) }
     }
 }
 
@@ -432,6 +460,14 @@ impl FromJSValConvertible for u8 {
     ) -> Result<ConversionResult<u8>, ()> {
         convert_int_from_jsval(cx, val, option, ToInt32)
     }
+
+    fn safe_from_jsval(
+        cx: &mut crate::context::JSContext,
+        val: HandleValue,
+        option: ConversionBehavior,
+    ) -> Result<ConversionResult<u8>, ()> {
+        unsafe { convert_int_from_jsval(cx.raw_cx(), val, option, ToInt32) }
+    }
 }
 
 // https://heycam.github.io/webidl/#es-short
@@ -451,6 +487,14 @@ impl FromJSValConvertible for i16 {
         option: ConversionBehavior,
     ) -> Result<ConversionResult<i16>, ()> {
         convert_int_from_jsval(cx, val, option, ToInt32)
+    }
+
+    fn safe_from_jsval(
+        cx: &mut crate::context::JSContext,
+        val: HandleValue,
+        option: ConversionBehavior,
+    ) -> Result<ConversionResult<i16>, ()> {
+        unsafe { convert_int_from_jsval(cx.raw_cx(), val, option, ToInt32) }
     }
 }
 
@@ -472,6 +516,14 @@ impl FromJSValConvertible for u16 {
     ) -> Result<ConversionResult<u16>, ()> {
         convert_int_from_jsval(cx, val, option, ToUint16)
     }
+
+    fn safe_from_jsval(
+        cx: &mut crate::context::JSContext,
+        val: HandleValue,
+        option: ConversionBehavior,
+    ) -> Result<ConversionResult<u16>, ()> {
+        unsafe { convert_int_from_jsval(cx.raw_cx(), val, option, ToUint16) }
+    }
 }
 
 // https://heycam.github.io/webidl/#es-long
@@ -491,6 +543,14 @@ impl FromJSValConvertible for i32 {
         option: ConversionBehavior,
     ) -> Result<ConversionResult<i32>, ()> {
         convert_int_from_jsval(cx, val, option, ToInt32)
+    }
+
+    fn safe_from_jsval(
+        cx: &mut crate::context::JSContext,
+        val: HandleValue,
+        option: ConversionBehavior,
+    ) -> Result<ConversionResult<i32>, ()> {
+        unsafe { convert_int_from_jsval(cx.raw_cx(), val, option, ToInt32) }
     }
 }
 
@@ -512,6 +572,14 @@ impl FromJSValConvertible for u32 {
     ) -> Result<ConversionResult<u32>, ()> {
         convert_int_from_jsval(cx, val, option, ToUint32)
     }
+
+    fn safe_from_jsval(
+        cx: &mut crate::context::JSContext,
+        val: HandleValue,
+        option: ConversionBehavior,
+    ) -> Result<ConversionResult<u32>, ()> {
+        unsafe { convert_int_from_jsval(cx.raw_cx(), val, option, ToUint32) }
+    }
 }
 
 // https://heycam.github.io/webidl/#es-long-long
@@ -532,6 +600,14 @@ impl FromJSValConvertible for i64 {
     ) -> Result<ConversionResult<i64>, ()> {
         convert_int_from_jsval(cx, val, option, ToInt64)
     }
+
+    fn safe_from_jsval(
+        cx: &mut crate::context::JSContext,
+        val: HandleValue,
+        option: ConversionBehavior,
+    ) -> Result<ConversionResult<i64>, ()> {
+        unsafe { convert_int_from_jsval(cx.raw_cx(), val, option, ToInt64) }
+    }
 }
 
 // https://heycam.github.io/webidl/#es-unsigned-long-long
@@ -551,6 +627,14 @@ impl FromJSValConvertible for u64 {
         option: ConversionBehavior,
     ) -> Result<ConversionResult<u64>, ()> {
         convert_int_from_jsval(cx, val, option, ToUint64)
+    }
+
+    fn safe_from_jsval(
+        cx: &mut crate::context::JSContext,
+        val: HandleValue,
+        option: ConversionBehavior,
+    ) -> Result<ConversionResult<u64>, ()> {
+        unsafe { convert_int_from_jsval(cx.raw_cx(), val, option, ToUint64) }
     }
 }
 
@@ -573,6 +657,15 @@ impl FromJSValConvertible for f32 {
         let result = ToNumber(cx, val);
         result.map(|f| f as f32).map(ConversionResult::Success)
     }
+
+    fn safe_from_jsval(
+        cx: &mut crate::context::JSContext,
+        val: HandleValue,
+        _option: (),
+    ) -> Result<ConversionResult<f32>, ()> {
+        let result = unsafe { ToNumber(cx.raw_cx(), val) };
+        result.map(|f| f as f32).map(ConversionResult::Success)
+    }
 }
 
 // https://heycam.github.io/webidl/#es-double
@@ -592,6 +685,14 @@ impl FromJSValConvertible for f64 {
         _option: (),
     ) -> Result<ConversionResult<f64>, ()> {
         ToNumber(cx, val).map(ConversionResult::Success)
+    }
+
+    fn safe_from_jsval(
+        cx: &mut crate::context::JSContext,
+        val: HandleValue,
+        _option: (),
+    ) -> Result<ConversionResult<f64>, ()> {
+        unsafe { ToNumber(cx.raw_cx(), val).map(ConversionResult::Success) }
     }
 }
 
@@ -736,10 +837,28 @@ impl<T: FromJSValConvertible> FromJSValConvertible for Option<T> {
         if value.get().is_null_or_undefined() {
             Ok(ConversionResult::Success(None))
         } else {
+            #[expect(deprecated)]
             Ok(match FromJSValConvertible::from_jsval(cx, value, option)? {
                 ConversionResult::Success(v) => ConversionResult::Success(Some(v)),
                 ConversionResult::Failure(v) => ConversionResult::Failure(v),
             })
+        }
+    }
+
+    fn safe_from_jsval(
+        cx: &mut crate::context::JSContext,
+        value: HandleValue,
+        option: T::Config,
+    ) -> Result<ConversionResult<Option<T>>, ()> {
+        if value.get().is_null_or_undefined() {
+            Ok(ConversionResult::Success(None))
+        } else {
+            Ok(
+                match FromJSValConvertible::safe_from_jsval(cx, value, option)? {
+                    ConversionResult::Success(v) => ConversionResult::Success(Some(v)),
+                    ConversionResult::Failure(v) => ConversionResult::Failure(v),
+                },
+            )
         }
     }
 }
@@ -811,6 +930,7 @@ impl<C: Clone, T: FromJSValConvertible<Config = C>> FromJSValConvertible for Vec
 
         let mut return_value = vec![];
         let result = for_of(cx, value, |iterator_element| {
+            #[expect(deprecated)]
             let conversion_result = T::from_jsval(cx, iterator_element, option.clone())
                 .map_err(|_| ForOfIterationFailure::JSFailed)?;
             return_value.push(match conversion_result {
@@ -831,6 +951,42 @@ impl<C: Clone, T: FromJSValConvertible<Config = C>> FromJSValConvertible for Vec
             Err(ForOfIterationFailure::JSFailed) => Err(()),
             Err(ForOfIterationFailure::Other(error)) => {
                 throw_type_error(cx, error.as_ref());
+                Err(())
+            }
+        }
+    }
+
+    fn safe_from_jsval(
+        cx: &mut crate::context::JSContext,
+        value: HandleValue,
+        option: C,
+    ) -> Result<ConversionResult<Vec<T>>, ()> {
+        if !value.is_object() {
+            return Ok(ConversionResult::Failure(c"Value is not an object".into()));
+        }
+
+        let mut return_value = vec![];
+        let result = for_of(unsafe { cx.raw_cx() }, value, |iterator_element| {
+            let conversion_result = T::safe_from_jsval(cx, iterator_element, option.clone())
+                .map_err(|_| ForOfIterationFailure::JSFailed)?;
+            return_value.push(match conversion_result {
+                ConversionResult::Success(value) => value,
+                ConversionResult::Failure(error) => {
+                    return Err(ForOfIterationFailure::Other(error));
+                }
+            });
+
+            Ok(ControlFlow::Continue(()))
+        });
+
+        match result {
+            Ok(_) => Ok(ConversionResult::Success(return_value)),
+            Err(ForOfIterationFailure::ValueIsNotIterable) => {
+                Ok(ConversionResult::Failure(c"Value is not iterable".into()))
+            }
+            Err(ForOfIterationFailure::JSFailed) => Err(()),
+            Err(ForOfIterationFailure::Other(error)) => {
+                unsafe { throw_type_error(cx.raw_cx(), error.as_ref()) };
                 Err(())
             }
         }
@@ -882,6 +1038,26 @@ impl FromJSValConvertible for *mut JSObject {
 
         Ok(ConversionResult::Success(value.to_object()))
     }
+
+    #[inline]
+    fn safe_from_jsval(
+        cx: &mut crate::context::JSContext,
+        value: HandleValue,
+        _option: (),
+    ) -> Result<ConversionResult<*mut JSObject>, ()> {
+        if !value.is_object() {
+            unsafe {
+                throw_type_error(cx.raw_cx(), c"value is not an object");
+            }
+            return Err(());
+        }
+
+        unsafe {
+            AssertSameCompartment(cx.raw_cx(), value.to_object());
+        }
+
+        Ok(ConversionResult::Success(value.to_object()))
+    }
 }
 
 impl ToJSValConvertible for *mut JS::Symbol {
@@ -901,6 +1077,22 @@ impl FromJSValConvertible for *mut JS::Symbol {
     ) -> Result<ConversionResult<*mut JS::Symbol>, ()> {
         if !value.is_symbol() {
             throw_type_error(cx, c"value is not a symbol");
+            return Err(());
+        }
+
+        Ok(ConversionResult::Success(value.to_symbol()))
+    }
+
+    #[inline]
+    fn safe_from_jsval(
+        cx: &mut crate::context::JSContext,
+        value: HandleValue,
+        _option: (),
+    ) -> Result<ConversionResult<*mut JS::Symbol>, ()> {
+        if !value.is_symbol() {
+            unsafe {
+                throw_type_error(cx.raw_cx(), c"value is not a symbol");
+            }
             return Err(());
         }
 

--- a/mozjs/src/typedarray.rs
+++ b/mozjs/src/typedarray.rs
@@ -108,6 +108,18 @@ impl<T: TypedArrayElement, S: JSObjectStorage> FromJSValConvertible for TypedArr
             Err(())
         }
     }
+
+    fn safe_from_jsval(
+        _cx: &mut crate::context::JSContext,
+        value: HandleValue,
+        _option: (),
+    ) -> Result<ConversionResult<Self>, ()> {
+        if value.get().is_object() {
+            Self::from(value.get().to_object()).map(ConversionResult::Success)
+        } else {
+            Err(())
+        }
+    }
 }
 
 impl<T: TypedArrayElement, S: JSObjectStorage> ToJSValConvertible for TypedArray<T, S> {


### PR DESCRIPTION
Deprecate `FromJSValConvertible::from_jsval`, which will be removed in a subsequent release.
Implement `safe_from_jsval` for the existing types.

Testing: It compiles
Part of #749 
