### PR TITLE
Add `AsMut<JSContext>` implementation

### DIFF
--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.16.2"
+version = "0.16.3"
 authors = ["The Servo Project Developers"]
 license.workspace = true
 edition.workspace = true

--- a/mozjs/src/context.rs
+++ b/mozjs/src/context.rs
@@ -101,7 +101,7 @@ impl JSContext {
     /// SAFETY:
     /// - only one [JSContext] can be alive and it should not outlive [Runtime].
     pub unsafe fn get_from_thread() -> Option<JSContext> {
-        unsafe { crate::rust::Runtime::get().map(|raw_cx| unsafe { JSContext::from_ptr(raw_cx) }) }
+        crate::rust::Runtime::get().map(|raw_cx| unsafe { JSContext::from_ptr(raw_cx) })
     }
 
     /// Returns [NoGC] token bounded to this [JSContext].
@@ -156,6 +156,12 @@ impl JSContext {
     /// ```
     pub unsafe fn raw_cx_no_gc(&self) -> *mut RawJSContext {
         self.ptr.as_ptr()
+    }
+}
+
+impl AsMut<JSContext> for JSContext {
+    fn as_mut(&mut self) -> &mut JSContext {
+        self
     }
 }
 

--- a/mozjs/src/realm.rs
+++ b/mozjs/src/realm.rs
@@ -171,6 +171,12 @@ impl<'cx> AutoRealm<'cx> {
     }
 }
 
+impl<'cx> AsMut<JSContext> for AutoRealm<'cx> {
+    fn as_mut(&mut self) -> &mut JSContext {
+        &mut self.cx
+    }
+}
+
 impl<'cx> Deref for AutoRealm<'cx> {
     type Target = JSContext;
 
@@ -275,6 +281,12 @@ impl<'cx> CurrentRealm<'cx> {
 
     pub fn realm(&self) -> &NonNull<Realm> {
         &self.realm
+    }
+}
+
+impl<'cx> AsMut<JSContext> for CurrentRealm<'cx> {
+    fn as_mut(&mut self) -> &mut JSContext {
+        &mut self.cx
     }
 }
 


### PR DESCRIPTION
This can be useful for making functions generic over &mut JSContext in case they need JSContext and pass more powerful version down in closure. For motivation specific motivation see https://github.com/servo/servo/pull/45684#discussion_r3416246697.
While we could theoretically do any other versions too, I do not think they would be useful in practice. 

Servo PR: https://github.com/servo/servo/pull/45684 will be
