### PR TITLE
CI: Validate `-lts` version suffix on the LTS branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,11 +28,37 @@ jobs:
       rust_version: 'beta'
     secrets: inherit
 
+  # The goal is to have an LTS branch of mozjs, where the rust API (mozjs and mozjs_sys glue code)
+  # is stable, and only spidermonkey is updated.
+  # We still keep the regular versioning, but add an `-lts` suffix, so we can have "duplicate" releases
+  # of the same ESR (to crates.io and github releases).
+  verify_lts_version:
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'pull_request' && startsWith(github.base_ref, 'servo-lts-v')
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        # Check if we added the `-lts` suffix to the version, so we can create an independent crates.io release for
+        # the LTS.
+      - name: Verify LTS version suffix
+        run: |
+          MOZJS_SYS_VERSION=$(cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | select(.name == "mozjs_sys") | .version')
+          # A new LTS servo version is expected to have an updated SM ESR, hence the major version would differ,
+          # and we don't need to version the lts suffix itself to achieve distinct tags for the period of time
+          # when the old LTS branch overlaps with the new one.
+          if [[ "${MOZJS_SYS_VERSION}" == *-lts ]]; then
+            echo "Version ${MOZJS_SYS_VERSION} is okay and has the expected suffix"
+          else
+            echo "You forgot to add the `-lts` suffix to the mozjs_sys version number. This is required on the lts branch"
+            exit 1
+          fi
+
 
   build_result:
     name: Result
     runs-on: ubuntu-latest
-    needs: ["build"]
+    needs: ["build", "verify_lts_version"]
     if: ${{ always() }}
     steps:
       - name: Mark the job as successful

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,10 +4,9 @@ name: Publish
 
 # Workflow triggers should be strictly controlled,
 # as this will trigger publishing to crates.io.
-# We only want to publish on the main branch.
 on:
   push:
-    branches: [main]
+    branches: ["main", "servo-lts-v*"]
 
 # dispatches build workflow with different permissions
 jobs:

--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "140.10.1-0"
+version = "140.10.1-0-lts"
 authors = ["Mozilla", "The Servo Project Developers"]
 links = "mozjs"
 license.workspace = true

--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -27,7 +27,7 @@ encoding_rs = "0.8.35"
 libc.workspace = true
 log = "0.4"
 # When doing non-version changes also update ../mozjs-sys/etc/sm-security-bump.py
-mozjs_sys = { version = "=140.10.1-0", path = "../mozjs-sys" }
+mozjs_sys = { version = "=140.10.1-0-lts", path = "../mozjs-sys" }
 num-traits = "0.2"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]


### PR DESCRIPTION
To keep the servo LTS version using a recent SM ESR version, without needing to backport `mozjs` API changes, we add a new branch `servo-lts-v0.1`, for use in the servo v0.1 LTS release based on mozjs 0.15.4. 
To allow duplicate releases (so that publishing to crates.io. / github releases to work), we require an `-lts` suffix to mozjs_sys versions. For `mozjs` itself this isn't necessary, since we already upgrade the `minor` version, so we can continue bumping x in `0.15.X`.
The `build.rs` doesn't require any changes, since it consumes the `version` via `CARGO_PKG_VERSION` and hence will download the lts branch prebuilt release.

ESR updates on this branch would be run by editing `COMMIT` and running `update.py`, since `main` should have received the ESR update first.

Testing: This does not change the mozjs API, and should be invisible for servo (LTS), which just consumes mozjs 0.15.X releases.
