### PR TITLE
Allow configuring SM optimization level for debugmozjs builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,8 +63,8 @@ jobs:
         env:
           DEBUGMOZJS_OPT: ${{ matrix.features == 'debugmozjs' && '--config profile.dev.package.mozjs_sys.opt-level=3' || '' }}
         run: |
-          cargo +${{ steps.toolchain.outputs.name }} build --verbose --features "${{ matrix.features }}" ${DEBUGMOZJS_OPT}
-          cargo +${{ steps.toolchain.outputs.name }} test --tests --examples --verbose --features "${{ matrix.features }}" ${DEBUGMOZJS_OPT}
+          cargo +${{ steps.toolchain.outputs.name }} build --verbose --features "${{ matrix.features }}" ${{ env.DEBUGMOZJS_OPT }}
+          cargo +${{ steps.toolchain.outputs.name }} test --tests --examples --verbose --features "${{ matrix.features }}" ${{ env.DEBUGMOZJS_OPT }}
       - name: Upload artifact
         if: ${{ env.NEW_RUST_CHECK == 'false' }}
         uses: actions/upload-artifact@v7
@@ -109,9 +109,9 @@ jobs:
         env:
           DEBUGMOZJS_OPT: ${{ matrix.features == 'debugmozjs' && '--config profile.dev.package.mozjs_sys.opt-level=3' || '' }}
         run: |
-          cargo +${{ steps.toolchain.outputs.name }} build --verbose --features "${{ matrix.features }}" ${DEBUGMOZJS_OPT}
-          cargo +${{ steps.toolchain.outputs.name }} test --tests --examples --verbose --features "${{ matrix.features }}" ${DEBUGMOZJS_OPT}
-          cargo +${{ steps.toolchain.outputs.name }} test --doc -p mozjs --verbose --features "${{ matrix.features }}" ${DEBUGMOZJS_OPT}
+          cargo +${{ steps.toolchain.outputs.name }} build --verbose --features "${{ matrix.features }}" ${{ env.DEBUGMOZJS_OPT }}
+          cargo +${{ steps.toolchain.outputs.name }} test --tests --examples --verbose --features "${{ matrix.features }}" ${{ env.DEBUGMOZJS_OPT }}
+          cargo +${{ steps.toolchain.outputs.name }} test --doc -p mozjs --verbose --features "${{ matrix.features }}" ${{ env.DEBUGMOZJS_OPT }}
       - name: Check wrappers integrity
         # we generate wrappers only without debugmozjs
         if: ${{ matrix.features != 'debugmozjs' }}
@@ -166,13 +166,13 @@ jobs:
         env:
           DEBUGMOZJS_OPT: ${{ matrix.features == 'debugmozjs' && '--config profile.dev.package.mozjs_sys.opt-level=3' || '' }}
         run: |
-          cargo +${{ steps.toolchain.outputs.name }} build --verbose --target ${{ matrix.platform.target }} --features "${{ matrix.features }}" %DEBUGMOZJS_OPT%
+          cargo +${{ steps.toolchain.outputs.name }} build --verbose --target ${{ matrix.platform.target }} --features "${{ matrix.features }}" ${{ env.DEBUGMOZJS_OPT }}
       - name: Test Windows
         shell: cmd
         env:
           DEBUGMOZJS_OPT: ${{ matrix.features == 'debugmozjs' && '--config profile.dev.package.mozjs_sys.opt-level=3' || '' }}
         run: |
-          cargo +${{ steps.toolchain.outputs.name }} test --tests --examples --verbose --target ${{ matrix.platform.target }} --features "${{ matrix.features }}" %DEBUGMOZJS_OPT%
+          cargo +${{ steps.toolchain.outputs.name }} test --tests --examples --verbose --target ${{ matrix.platform.target }} --features "${{ matrix.features }}" ${{ env.DEBUGMOZJS_OPT }}
 
       - name: Upload artifact
         if: ${{ env.NEW_RUST_CHECK == 'false' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,15 +57,20 @@ jobs:
         with:
           version: "v0.12.0"
       - name: Build
+        # Build the debug-mozjs prebuilt artifact with -O3 (matching the
+        # `checked-release` profile in servo) so that we have a fast prebuilt version with
+        # debug assertions for running WPT in servo with debug-mozjs.
+        env:
+          DEBUGMOZJS_OPT: ${{ matrix.features == 'debugmozjs' && '--config profile.dev.package.mozjs_sys.opt-level=3' || '' }}
         run: |
-          cargo +${{ steps.toolchain.outputs.name }} build --verbose --features "${{ matrix.features }}"
-          cargo +${{ steps.toolchain.outputs.name }} test --tests --examples --verbose --features "${{ matrix.features }}"
+          cargo +${{ steps.toolchain.outputs.name }} build --verbose --features "${{ matrix.features }}" ${DEBUGMOZJS_OPT}
+          cargo +${{ steps.toolchain.outputs.name }} test --tests --examples --verbose --features "${{ matrix.features }}" ${DEBUGMOZJS_OPT}
       - name: Upload artifact
         if: ${{ env.NEW_RUST_CHECK == 'false' }}
         uses: actions/upload-artifact@v7
         with:
-          path: ./target/libmozjs-${{ matrix.platform.target }}${{ matrix.features && '-debugmozjs' || '' }}.tar.gz
-          name: libmozjs-${{ matrix.platform.target }}${{ matrix.features && '-debugmozjs' || '' }}.tar.gz
+          path: ./target/libmozjs-${{ matrix.platform.target }}${{ matrix.features && '-debugmozjs-O3' || '' }}.tar.gz
+          name: libmozjs-${{ matrix.platform.target }}${{ matrix.features && '-debugmozjs-O3' || '' }}.tar.gz
 
   linux:
     env:
@@ -101,10 +106,12 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.9
       - name: Build
         # doc tests on mozjs_sys fail because they include stuff from SpiderMonkey
+        env:
+          DEBUGMOZJS_OPT: ${{ matrix.features == 'debugmozjs' && '--config profile.dev.package.mozjs_sys.opt-level=3' || '' }}
         run: |
-          cargo +${{ steps.toolchain.outputs.name }} build --verbose --features "${{ matrix.features }}"
-          cargo +${{ steps.toolchain.outputs.name }} test --tests --examples --verbose --features "${{ matrix.features }}"
-          cargo +${{ steps.toolchain.outputs.name }} test --doc -p mozjs --verbose --features "${{ matrix.features }}"
+          cargo +${{ steps.toolchain.outputs.name }} build --verbose --features "${{ matrix.features }}" ${DEBUGMOZJS_OPT}
+          cargo +${{ steps.toolchain.outputs.name }} test --tests --examples --verbose --features "${{ matrix.features }}" ${DEBUGMOZJS_OPT}
+          cargo +${{ steps.toolchain.outputs.name }} test --doc -p mozjs --verbose --features "${{ matrix.features }}" ${DEBUGMOZJS_OPT}
       - name: Check wrappers integrity
         # we generate wrappers only without debugmozjs
         if: ${{ matrix.features != 'debugmozjs' }}
@@ -118,8 +125,8 @@ jobs:
         if: ${{ env.NEW_RUST_CHECK == 'false' }}
         uses: actions/upload-artifact@v7
         with:
-          path: ./target/libmozjs-${{matrix.platform.target }}${{ matrix.features && '-debugmozjs' || '' }}.tar.gz
-          name: libmozjs-${{matrix.platform.target }}${{ matrix.features && '-debugmozjs' || '' }}.tar.gz
+          path: ./target/libmozjs-${{matrix.platform.target }}${{ matrix.features && '-debugmozjs-O3' || '' }}.tar.gz
+          name: libmozjs-${{matrix.platform.target }}${{ matrix.features && '-debugmozjs-O3' || '' }}.tar.gz
 
   windows:
     runs-on: ${{ matrix.platform.os }}
@@ -156,19 +163,23 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.9
       - name: Build Windows
         shell: cmd
+        env:
+          DEBUGMOZJS_OPT: ${{ matrix.features == 'debugmozjs' && '--config profile.dev.package.mozjs_sys.opt-level=3' || '' }}
         run: |
-          cargo +${{ steps.toolchain.outputs.name }} build --verbose --target ${{ matrix.platform.target }} --features "${{ matrix.features }}"
+          cargo +${{ steps.toolchain.outputs.name }} build --verbose --target ${{ matrix.platform.target }} --features "${{ matrix.features }}" %DEBUGMOZJS_OPT%
       - name: Test Windows
         shell: cmd
+        env:
+          DEBUGMOZJS_OPT: ${{ matrix.features == 'debugmozjs' && '--config profile.dev.package.mozjs_sys.opt-level=3' || '' }}
         run: |
-          cargo +${{ steps.toolchain.outputs.name }} test --tests --examples --verbose --target ${{ matrix.platform.target }} --features "${{ matrix.features }}"
+          cargo +${{ steps.toolchain.outputs.name }} test --tests --examples --verbose --target ${{ matrix.platform.target }} --features "${{ matrix.features }}" %DEBUGMOZJS_OPT%
 
       - name: Upload artifact
         if: ${{ env.NEW_RUST_CHECK == 'false' }}
         uses: actions/upload-artifact@v7
         with:
-          path: ./target/${{ matrix.platform.target }}/libmozjs-${{ matrix.platform.target }}${{ matrix.features && '-debugmozjs' || '' }}.tar.gz
-          name: libmozjs-${{ matrix.platform.target }}${{ matrix.features && '-debugmozjs' || '' }}.tar.gz
+          path: ./target/${{ matrix.platform.target }}/libmozjs-${{ matrix.platform.target }}${{ matrix.features && '-debugmozjs-O3' || '' }}.tar.gz
+          name: libmozjs-${{ matrix.platform.target }}${{ matrix.features && '-debugmozjs-O3' || '' }}.tar.gz
 
   android:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -46,11 +46,11 @@ jobs:
         if: ${{ env.RELEASE_TAG == '' }}
         uses: actions/download-artifact@v4
         with:
-          name: libmozjs-${{ matrix.platform.target }}${{ matrix.features && '-debugmozjs' || '' }}.tar.gz
+          name: libmozjs-${{ matrix.platform.target }}${{ matrix.features && '-debugmozjs-O3' || '' }}.tar.gz
       - name: Build from archive
         if: ${{ env.RELEASE_TAG == '' }}
         env:
-          MOZJS_ARCHIVE: libmozjs-${{ matrix.platform.target }}${{ matrix.features && '-debugmozjs' || '' }}.tar.gz
+          MOZJS_ARCHIVE: libmozjs-${{ matrix.platform.target }}${{ matrix.features && '-debugmozjs-O3' || '' }}.tar.gz
         run: |
           cargo +${{ steps.toolchain.outputs.name }} build --verbose  --features "${{ matrix.features }}"
           cargo +${{ steps.toolchain.outputs.name }} test --tests --examples --verbose  --features "${{ matrix.features }}"
@@ -58,9 +58,11 @@ jobs:
         if: ${{ env.RELEASE_TAG != '' }}
         env:
           MOZJS_ATTESTATION: strict
+          # The debugmozjs prebuilt archive is only published for OPT_LEVEL=3.
+          DEBUGMOZJS_OPT: ${{ matrix.features == 'debugmozjs' && '--config profile.dev.package.mozjs_sys.opt-level=3' || '' }}
         run: |
-          cargo +${{ steps.toolchain.outputs.name }} build --verbose  --features "${{ matrix.features }}"
-          cargo +${{ steps.toolchain.outputs.name }} test --tests --examples --verbose  --features "${{ matrix.features }}"
+          cargo +${{ steps.toolchain.outputs.name }} build --verbose  --features "${{ matrix.features }}" ${DEBUGMOZJS_OPT}
+          cargo +${{ steps.toolchain.outputs.name }} test --tests --examples --verbose  --features "${{ matrix.features }}" ${DEBUGMOZJS_OPT}
 
   verify-archive-android:
     name: "Verify archive Android"

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -61,8 +61,8 @@ jobs:
           # The debugmozjs prebuilt archive is only published for OPT_LEVEL=3.
           DEBUGMOZJS_OPT: ${{ matrix.features == 'debugmozjs' && '--config profile.dev.package.mozjs_sys.opt-level=3' || '' }}
         run: |
-          cargo +${{ steps.toolchain.outputs.name }} build --verbose  --features "${{ matrix.features }}" ${DEBUGMOZJS_OPT}
-          cargo +${{ steps.toolchain.outputs.name }} test --tests --examples --verbose  --features "${{ matrix.features }}" ${DEBUGMOZJS_OPT}
+          cargo +${{ steps.toolchain.outputs.name }} build --verbose  --features "${{ matrix.features }}" ${{ env.DEBUGMOZJS_OPT }}
+          cargo +${{ steps.toolchain.outputs.name }} test --tests --examples --verbose  --features "${{ matrix.features }}" ${{ env.DEBUGMOZJS_OPT }}
 
   verify-archive-android:
     name: "Verify archive Android"

--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ cargo test --features debugmozjs
 ### The `debugmozjs` feature and prebuilt archives
 
 The `debugmozjs` feature enables SpiderMonkey assertions and GC zeal (to help find GC issues).
-When building from source (`MOZJS_FROM_SOURCE=1`) the optimization level is taken
-from cargo's `OPT_LEVEL` (i.e. the active profile), so a default `dev`-profile
-build is unoptimized (`-O0`), while `--release` produces an optimized build with assertions still enabled.
+If `debugmozjs` is enabled, the optimization level is taken from cargo's `OPT_LEVEL` (i.e. the active profile), 
+so a default `dev`-profile build is unoptimized (`-O0`), while `--release` produces an optimized build with assertions 
+still enabled. If `debugmozjs` is disabled, the prebuilt archive is **always optimized**.
 The pre-built `debugmozjs` archive published by CI is built with `-O3` (default for the release profile).
 If you specify any other opt-level (e.g. by building the `dev` profile), this will be honored, and 
 a build from source will be triggered. You can edit the opt-level for spidermonkey specifically by 
@@ -124,6 +124,8 @@ editing you workspace Cargo.toml to contain:
 
 ```toml
 # replace `dev` with the profile name you are targeting
+# Note: This will only affect Spidermonkey code if `debugmozjs` is enabled, otherwise
+# optimisations will always be enabled.
 [profile.dev.package.mozjs_sys]
 opt-level = 3 # or any other opt-level
 ```

--- a/README.md
+++ b/README.md
@@ -111,6 +111,23 @@ cargo build --features debugmozjs
 cargo test --features debugmozjs
 ```
 
+### The `debugmozjs` feature and prebuilt archives
+
+The `debugmozjs` feature enables SpiderMonkey assertions and GC zeal (to help find GC issues).
+When building from source (`MOZJS_FROM_SOURCE=1`) the optimization level is taken
+from cargo's `OPT_LEVEL` (i.e. the active profile), so a default `dev`-profile
+build is unoptimized (`-O0`), while `--release` produces an optimized build with assertions still enabled.
+The pre-built `debugmozjs` archive published by CI is built with `-O3` (default for the release profile).
+If you specify any other opt-level (e.g. by building the `dev` profile), this will be honored, and 
+a build from source will be triggered. You can edit the opt-level for spidermonkey specifically by 
+editing you workspace Cargo.toml to contain:
+
+```toml
+# replace `dev` with the profile name you are targeting
+[profile.dev.package.mozjs_sys]
+opt-level = 3 # or any other opt-level
+```
+
 ### Usage for downstream consumers
 
 Both [`mozjs`](https://crates.io/crates/mozjs) and [`mozjs_sys`](https://crates.io/crates/mozjs_sys) crates are published on crates.io.

--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "140.12.0-0"
+version = "140.12.0-1"
 authors = ["Mozilla", "The Servo Project Developers"]
 links = "mozjs"
 license.workspace = true

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -574,12 +574,8 @@ fn cc_flags(bindgen: bool) -> Vec<&'static str> {
     if env::var_os("CARGO_FEATURE_DEBUGMOZJS").is_some() {
         flags.extend(&["-DJS_GC_ZEAL", "-DDEBUG", "-DJS_DEBUG"]);
 
-        if !bindgen {
-            if target.contains("windows") {
-                flags.push("-Od");
-            } else {
-                flags.extend(&["-g", "-O0"]);
-            }
+        if !bindgen && !target.contains("windows") {
+            flags.push("-g");
         }
     }
 
@@ -1080,9 +1076,10 @@ mod archive {
     pub(crate) fn archive() -> String {
         let target = env::var("TARGET").unwrap();
         let features = if env::var_os("CARGO_FEATURE_DEBUGMOZJS").is_some() {
-            "-debugmozjs"
+            let opt_level = env::var("OPT_LEVEL").expect("OPT_LEVEL not set by cargo?");
+            format!("-debugmozjs-O{opt_level}")
         } else {
-            ""
+            "".to_string()
         };
         format!("libmozjs-{target}{features}.tar.gz")
     }

--- a/mozjs-sys/makefile.cargo
+++ b/mozjs-sys/makefile.cargo
@@ -25,11 +25,19 @@ endif
 
 ifneq (,$(CARGO_FEATURE_DEBUGMOZJS))
 	CONFIGURE_FLAGS += --enable-debug --enable-gczeal
-	ifneq (,$(findstring -wasi,$(TARGET)))
-		# wasm-opt chokes on -O0 builds.
-		CONFIGURE_FLAGS += --enable-optimize=-O1
+
+	# Respect cargo's OPT_LEVEL instead of unconditionally forcing -O0.
+	# This allows building SM with debug assertions and optimisations
+	DEBUGMOZJS_OPT_LEVEL := $(or $(OPT_LEVEL),0)
+	ifeq (0,$(DEBUGMOZJS_OPT_LEVEL))
+		ifneq (,$(findstring -wasi,$(TARGET)))
+			# wasm-opt chokes on -O0 builds, so floor wasi to -O1.
+			CONFIGURE_FLAGS += --enable-optimize=-O1
+		else
+			CONFIGURE_FLAGS += --disable-optimize
+		endif
 	else
-		CONFIGURE_FLAGS += --disable-optimize
+		CONFIGURE_FLAGS += --enable-optimize=-O$(DEBUGMOZJS_OPT_LEVEL)
 	endif
 endif
 

--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.17.0"
+version = "0.17.1"
 authors = ["The Servo Project Developers"]
 license.workspace = true
 edition.workspace = true
@@ -27,7 +27,7 @@ encoding_rs = "0.8.35"
 libc.workspace = true
 log = "0.4"
 # When doing non-version changes also update ../mozjs-sys/etc/sm-security-bump.py
-mozjs_sys = { version = "=140.12.0-0", path = "../mozjs-sys" }
+mozjs_sys = { version = "=140.12.0-1", path = "../mozjs-sys" }
 num-traits = "0.2"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]


### PR DESCRIPTION
This PR allows configuring the optimisation level of spidermonkey by honoring `OPT_LEVEL` (which is set by cargo).
For the prebuilt CI artifact, we default to `O3` (i.e. the default for the `--release` profile), which allows us to have a somewhat performant SM version with debug assertions, which hopefully would allow us to run `wpt` tests with this debug-mozjs version (once existing assertion failures in wpt are fixed).
This does mean that when debugging issues in SM, one might need to build mozjs from source more often, but since the fallback to from source build is automatic, this shouldn't be too bad. 
We could consider adding a `O0` debugmozjs build for Linux + arm mac, since those are probably the only two platforms actively used by developers working on mozjs, but that could be done in a follow-up if necessary.

Testing: We don't test optimisation levels
Servo PR: TODO
Closes: #733
