### PR TITLE
Implement trace for PhantomData

### DIFF
--- a/mozjs-sys/src/trace.rs
+++ b/mozjs-sys/src/trace.rs
@@ -21,6 +21,7 @@ use std::collections::btree_set::BTreeSet;
 use std::collections::vec_deque::VecDeque;
 use std::collections::{HashMap, HashSet};
 use std::hash::{BuildHasher, Hash};
+use std::marker::PhantomData;
 use std::num::{
     NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroIsize, NonZeroU128,
     NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize,
@@ -42,6 +43,10 @@ use std::time::{Duration, Instant, SystemTime};
 pub unsafe trait Traceable {
     /// Trace `self`.
     unsafe fn trace(&self, trc: *mut JSTracer);
+}
+
+unsafe impl<D> Traceable for PhantomData<D> {
+    unsafe fn trace(&self, _trc: *mut JSTracer) {}
 }
 
 unsafe impl Traceable for Heap<*mut JSFunction> {


### PR DESCRIPTION
PhantomData will be used in splitting the script crate in servo but this needs PhantomData to be traceable.
Currently the #[no_trace] part of the macro breaks a generic parameter, so 
```
struct Foo<D> {
    #[no_trace]
    PhantomData<D>
}
```
does not recognize the type parameter D.


Testing: This does not need testing as phantomdata does not exist, so tracing it with an empty trace is fine.
Servo PR: *Link to a companion pull request in the Servo repository. Remove this line if there is no companion PR.*
