### PR TITLE
backport: Fix mozjs_sys prebuilt library (#756)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,10 @@ jobs:
       matrix:
         features: ["debugmozjs", ""]
         platform:
-          - { target: x86_64-pc-windows-msvc, os: windows-latest }
+          # Note: the image should be kept in sync with the servo image,
+          # otherwise there might be ABI issues with the prebuilt mozjs
+          # if the VS major changes.
+          - { target: x86_64-pc-windows-msvc, os: windows-2022 }
           - { target: aarch64-pc-windows-msvc, os: windows-11-arm }
     env:
       LINKER: "lld-link.exe"

--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "140.12.0-0-lts"
+version = "140.12.0-1-lts"
 authors = ["Mozilla", "The Servo Project Developers"]
 links = "mozjs"
 license.workspace = true

--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.15.15"
+version = "0.15.16"
 authors = ["The Servo Project Developers"]
 license.workspace = true
 edition.workspace = true
@@ -27,7 +27,7 @@ encoding_rs = "0.8.35"
 libc.workspace = true
 log = "0.4"
 # When doing non-version changes also update ../mozjs-sys/etc/sm-security-bump.py
-mozjs_sys = { version = "=140.12.0-0-lts", path = "../mozjs-sys" }
+mozjs_sys = { version = "=140.12.0-1-lts", path = "../mozjs-sys" }
 num-traits = "0.2"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]


### PR DESCRIPTION
This PR applies #756 to the lts branch.

------

The windows-latest image was upgraded to VS 2026 in June, which seems to cause linking errors when attempting to link the VS 2026 prebuilt library into servo (built in CI with VS 2022). Pin the old image instead, to stay in sync with servo.

Testing: This will need a prebuilt library first, before we can test this in servo, since build from source doesn't reproduce the problem.


(cherry picked from commit cebfc2aa9fb1aa1ff5f25c94ed4c98c967d19944)
