### PR TITLE
Add safer cell types

### DIFF
--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.18.3"
+version = "0.19.0"
 authors = ["The Servo Project Developers"]
 license.workspace = true
 edition.workspace = true

--- a/mozjs/src/cell.rs
+++ b/mozjs/src/cell.rs
@@ -30,6 +30,16 @@ impl<T> JSRefCell<T> {
         }
     }
 
+    /// Returns a reference to the underlying [`RefCell`].
+    ///
+    /// This is not strictly unsafe, but it is not recommended to use this method unless you know what you are doing.
+    ///
+    /// Mutable borrows from it can cause panics if a GC happens while the borrow is active,
+    /// which is why [`JSRefCell::borrow_mut`] should be used instead.
+    pub fn as_refcell(&self) -> &RefCell<T> {
+        &self.value
+    }
+
     /// Immutably borrows the wrapped value.
     ///
     /// The borrow lasts until the returned `Ref` exits scope. Multiple

--- a/mozjs/src/cell.rs
+++ b/mozjs/src/cell.rs
@@ -1,0 +1,168 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+//! A shareable mutable container.
+
+pub use std::cell::{Ref, RefMut};
+use std::cell::{RefCell, UnsafeCell};
+
+use mozjs_sys::trace::Traceable;
+
+use crate::context::{JSContext, NoGC};
+use crate::jsapi::JSTracer;
+
+/// [`std::cell::RefCell`] that statically prevents borrow_mut panics
+/// from occurring by borrowing due to GC using the [`NoGC`] marker.
+///
+/// If dynamic borrow checking is not needed, one should use [`JSCell`] instead.
+#[derive(Clone, Debug, Default)]
+pub struct JSRefCell<T> {
+    value: RefCell<T>,
+}
+
+impl<T> JSRefCell<T> {
+    /// Create a new `JSRefCell` containing `value`.
+    pub fn new(value: T) -> JSRefCell<T> {
+        JSRefCell {
+            value: RefCell::new(value),
+        }
+    }
+
+    /// Immutably borrows the wrapped value.
+    ///
+    /// The borrow lasts until the returned `Ref` exits scope. Multiple
+    /// immutable borrows can be taken out at the same time.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is currently mutably borrowed.
+    #[track_caller]
+    pub fn borrow(&self) -> Ref<'_, T> {
+        self.value.borrow()
+    }
+
+    /// Mutably borrows the wrapped value.
+    ///
+    /// The borrow lasts until the returned `RefMut` exits scope. The value
+    /// cannot be borrowed while this borrow is active.
+    ///
+    /// By passing a `&NoGC` we statically prevent GC from being run while the borrow is active,
+    /// to prevent panic when tracing (which calls `borrow`).
+    ///
+    /// # Example
+    ///
+    /// In simple cases one can use `NoGC` to statically ensure no GC can happen in the whole DOM method:
+    ///
+    /// ```
+    /// use mozjs::context::{JSContext, NoGC};
+    /// use mozjs::cell::JSRefCell;
+    /// fn DomMethod(no_gc: &NoGC, cell: &JSRefCell<usize>) {
+    ///     let mut mutably_borrowed = cell.borrow_mut(no_gc);
+    /// }
+    /// ```
+    ///
+    /// But in more complex cases, method might trigger a GC, and thus require a `&mut JSContext`.
+    /// In that case `&JSContext` can be used in place of `NoGC`,
+    /// which will make `RefMut` bounded to the lifetime of the `&JSContext`
+    /// and thus prevent any GC from happening while it is alive.
+    ///
+    /// ```
+    /// use mozjs::context::{JSContext, NoGC};
+    /// use mozjs::cell::JSRefCell;
+    /// fn GC(cx: &mut JSContext) {}
+    ///
+    /// fn DomMethod(cell: &JSRefCell<usize>, cx: &mut JSContext) {
+    ///     {
+    ///         let mut mutably_borrowed = cell.borrow_mut(cx);
+    ///         // do something with mutably_borrowed
+    ///
+    ///         // only &JSContext is available here
+    ///     } // mutably_borrowed goes out of scope here
+    ///     // so one can now use &mut JSContext
+    ///     GC(cx);
+    /// }
+    /// ```
+    ///
+    /// ```compile_fail
+    /// use mozjs::context::{JSContext, NoGC};
+    /// use mozjs::cell::JSRefCell;
+    /// fn GC(cx: &mut JSContext) {}
+    ///
+    /// fn DomMethod(cell: &JSRefCell<usize>, cx: &mut JSContext) {
+    ///     {
+    ///         let mut mutably_borrowed = cell.borrow_mut(cx);
+    ///         // do something with mutably_borrowed
+    ///
+    ///         // here one cannot use anything that might trigger a GC
+    ///         // as that would require &mut JSContext
+    ///         // but there is already existing &JSContext bounded at RefMut
+    ///         GC(cx);
+    ///     } // mutably_borrowed goes out of scope here
+    /// }
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is currently borrowed.
+    #[track_caller]
+    pub fn borrow_mut<'a: 'r, 'no_cx: 'r, 'r>(&'a self, _no_gc: &'no_cx NoGC) -> RefMut<'r, T> {
+        self.value.borrow_mut()
+    }
+}
+
+impl<T: Default> JSRefCell<T> {
+    /// Takes the wrapped value, leaving `Default::default()` in its place.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is currently borrowed.
+    pub fn take(&self, _no_gc: &NoGC) -> T {
+        self.value.take()
+    }
+}
+
+unsafe impl<T: Traceable> Traceable for JSRefCell<T> {
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        unsafe { (*self).borrow().trace(trc) };
+    }
+}
+
+/// A cell for interior mutability, that (ab)uses [JSContext]
+/// as affinity token for ensuring safety.
+///
+/// If inner type is `Copy` one should prefer using normal [`std::cell::Cell`] instead.
+#[derive(Debug)]
+pub struct JSCell<T> {
+    inner: UnsafeCell<T>,
+}
+
+impl<T> JSCell<T> {
+    pub fn new(val: T) -> Self {
+        JSCell {
+            inner: UnsafeCell::new(val),
+        }
+    }
+
+    pub fn set<'a, 'cx>(&'a self, _exclusive: &'cx mut JSContext, val: T) {
+        // SAFETY: `&mut JSContext` is used as an affinity token to ensure that no other borrows are alive at the same time.
+        unsafe { *self.inner.get() = val }
+    }
+
+    pub fn borrow_mut<'a: 'r, 'cx: 'r, 'r>(&'a self, _exclusive: &'cx mut JSContext) -> &'r mut T {
+        // SAFETY: `&mut JSContext` is used as an affinity token to ensure that no other borrows are alive at the same time.
+        unsafe { &mut *self.inner.get() }
+    }
+
+    pub fn borrow<'a: 'r, 'no_cx: 'r, 'r>(&'a self, _no_gc: &'no_cx NoGC) -> &'r T {
+        // SAFETY: `&NoGC` is used as an affinity token to ensure that no other mutable borrows are alive at the same time.
+        unsafe { &*self.inner.get() }
+    }
+}
+
+unsafe impl<T: Traceable> Traceable for JSCell<T> {
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        // SAFETY: Tracing happens as part of GC, which requires &mut JSContext, so there cannot be any borrow alive at the same time.
+        unsafe { (&*self.inner.get()).trace(trc) };
+    }
+}

--- a/mozjs/src/cell.rs
+++ b/mozjs/src/cell.rs
@@ -16,6 +16,7 @@ use crate::jsapi::JSTracer;
 /// from occurring by borrowing due to GC using the [`NoGC`] marker.
 ///
 /// If dynamic borrow checking is not needed, one should use [`JSCell`] instead.
+/// If inner type is [`Copy`] one should use [`std::cell::Cell`] instead.
 #[derive(Clone, Debug, Default)]
 pub struct JSRefCell<T> {
     value: RefCell<T>,
@@ -34,6 +35,8 @@ impl<T> JSRefCell<T> {
     /// The borrow lasts until the returned `Ref` exits scope. Multiple
     /// immutable borrows can be taken out at the same time.
     ///
+    /// This is exactly the same as [`std::cell::RefCell::borrow`].
+    ///
     /// # Panics
     ///
     /// Panics if the value is currently mutably borrowed.
@@ -47,24 +50,25 @@ impl<T> JSRefCell<T> {
     /// The borrow lasts until the returned `RefMut` exits scope. The value
     /// cannot be borrowed while this borrow is active.
     ///
-    /// By passing a `&NoGC` we statically prevent GC from being run while the borrow is active,
-    /// to prevent panic when tracing (which calls `borrow`).
+    /// This is similar to [`std::cell::RefCell::borrow_mut`],
+    /// but it requires a [`&NoGC`][NoGC] token to ensure that no GC can happen while the borrow is active,
+    /// which would otherwise cause a panic when tracing (which calls `borrow`).
     ///
-    /// # Example
+    /// ## Examples
     ///
-    /// In simple cases one can use `NoGC` to statically ensure no GC can happen in the whole DOM method:
+    /// In simple cases one can use [`&NoGC`][NoGC] to statically ensure no GC can happen in the whole function:
     ///
     /// ```
     /// use mozjs::context::{JSContext, NoGC};
     /// use mozjs::cell::JSRefCell;
-    /// fn DomMethod(no_gc: &NoGC, cell: &JSRefCell<usize>) {
+    /// fn f(no_gc: &NoGC, cell: &JSRefCell<String>) {
     ///     let mut mutably_borrowed = cell.borrow_mut(no_gc);
     /// }
     /// ```
     ///
-    /// But in more complex cases, method might trigger a GC, and thus require a `&mut JSContext`.
-    /// In that case `&JSContext` can be used in place of `NoGC`,
-    /// which will make `RefMut` bounded to the lifetime of the `&JSContext`
+    /// But in more complex cases, method might trigger a GC, and thus require a [`&mut JSContext`][crate::context::JSContext].
+    /// In that case [`&JSContext`][crate::context::JSContext] can be used in place of [`&NoGC`][NoGC],
+    /// which will make [`RefMut`] bounded to the lifetime of the [`&JSContext`][crate::context::JSContext]
     /// and thus prevent any GC from happening while it is alive.
     ///
     /// ```
@@ -72,7 +76,7 @@ impl<T> JSRefCell<T> {
     /// use mozjs::cell::JSRefCell;
     /// fn GC(cx: &mut JSContext) {}
     ///
-    /// fn DomMethod(cell: &JSRefCell<usize>, cx: &mut JSContext) {
+    /// fn f(cx: &mut JSContext, cell: &JSRefCell<String>) {
     ///     {
     ///         let mut mutably_borrowed = cell.borrow_mut(cx);
     ///         // do something with mutably_borrowed
@@ -84,12 +88,14 @@ impl<T> JSRefCell<T> {
     /// }
     /// ```
     ///
+    /// ## Non-Example
+    ///
     /// ```compile_fail
     /// use mozjs::context::{JSContext, NoGC};
     /// use mozjs::cell::JSRefCell;
     /// fn GC(cx: &mut JSContext) {}
     ///
-    /// fn DomMethod(cell: &JSRefCell<usize>, cx: &mut JSContext) {
+    /// fn f(cx: &mut JSContext, cell: &JSRefCell<String>) {
     ///     {
     ///         let mut mutably_borrowed = cell.borrow_mut(cx);
     ///         // do something with mutably_borrowed
@@ -128,10 +134,60 @@ unsafe impl<T: Traceable> Traceable for JSRefCell<T> {
     }
 }
 
-/// A cell for interior mutability, that (ab)uses [JSContext]
-/// as affinity token for ensuring safety.
+/// A cell for interior mutability, that (ab)uses [NoGC]
+/// as a borrow token for ensuring safety.
 ///
-/// If inner type is `Copy` one should prefer using normal [`std::cell::Cell`] instead.
+/// If inner type is [`Copy`] one should use [`std::cell::Cell`] instead.
+///
+/// ## Examples
+///
+/// ```rust
+/// use mozjs::context::NoGC;
+/// use mozjs::cell::JSCell;
+/// fn f(no_gc: &mut NoGC, cell: &JSCell<String>) {
+///     {
+///         let borrow = cell.borrow(no_gc);
+///     } // borrow goes out of scope here
+///     cell.set(no_gc, "Hello".to_string());
+///     {
+///        let borrow_mut = cell.borrow_mut(no_gc);
+///     } // borrow_mut goes out of scope here
+/// }
+/// ```
+///
+/// ## Non-Examples
+///
+/// These fail to compile:
+///
+/// ```compile_fail
+/// use mozjs::context::NoGC;
+/// use mozjs::cell::JSCell;
+/// fn mut_borrow_after_borrow(no_gc: &mut NoGC, cell: &JSCell<String>) {
+///     let borrow = cell.borrow(no_gc);
+///     cell.set(no_gc, "Hello".to_string());
+///     drop(borrow); // otherwise compiler can shorten borrow's lifetime
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use mozjs::context::NoGC;
+/// use mozjs::cell::JSCell;
+/// fn mut_borrow_after_mut_borrow(no_gc: &mut NoGC, cell: &JSCell<String>) {
+///     let borrow_mut = cell.borrow_mut(no_gc);
+///     cell.set(no_gc, "Hello".to_string());
+///     drop(borrow_mut); // otherwise compiler can shorten borrow_mut's lifetime
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use mozjs::context::NoGC;
+/// use mozjs::cell::JSCell;
+/// fn borrow_after_mut_borrow(no_gc: &mut NoGC, cell: &JSCell<String>) {
+///     let borrow_mut = cell.borrow_mut(no_gc);
+///     let borrow = cell.borrow(no_gc);
+///     drop(borrow_mut); // otherwise compiler can shorten borrow_mut's lifetime
+/// }
+/// ```
 #[derive(Debug)]
 pub struct JSCell<T> {
     inner: UnsafeCell<T>,
@@ -144,18 +200,33 @@ impl<T> JSCell<T> {
         }
     }
 
+    /// Sets the wrapped value.
+    ///
+    /// By passing a [`&mut NoGC`][NoGC] we statically ensure no other borrows are alive at the same time.
+    ///
+    /// For more information see [JSCell] documentation.
     pub fn set<'a, 'cx>(&'a self, _exclusive: &'cx mut NoGC, val: T) {
-        // SAFETY: `&mut NoGC` is used as an affinity token to ensure that no other borrows are alive at the same time.
+        // SAFETY: `&mut NoGC` is used as a borrow token to ensure that no other borrows are alive at the same time.
         unsafe { *self.inner.get() = val }
     }
 
+    /// Mutably borrows the wrapped value.
+    ///
+    /// By passing a [`&mut NoGC`][NoGC] we statically ensure no other borrows are alive at the same time.
+    ///
+    /// For more information see [JSCell] documentation.
     pub fn borrow_mut<'a: 'r, 'cx: 'r, 'r>(&'a self, _exclusive: &'cx mut NoGC) -> &'r mut T {
-        // SAFETY: `&mut NoGC` is used as an affinity token to ensure that no other borrows are alive at the same time.
+        // SAFETY: `&mut NoGC` is used as a borrow token to ensure that no other borrows are alive at the same time.
         unsafe { &mut *self.inner.get() }
     }
 
+    /// Immutably borrows the wrapped value.
+    ///
+    /// By passing a [`&NoGC`][NoGC] we statically ensure no mutable borrows are alive at the same time.
+    ///
+    /// For more information see [JSCell] documentation.
     pub fn borrow<'a: 'r, 'no_cx: 'r, 'r>(&'a self, _no_gc: &'no_cx NoGC) -> &'r T {
-        // SAFETY: `&NoGC` is used as an affinity token to ensure that no other mutable borrows are alive at the same time.
+        // SAFETY: `&NoGC` is used as a borrow token to ensure that no other mutable borrows are alive at the same time.
         unsafe { &*self.inner.get() }
     }
 }

--- a/mozjs/src/cell.rs
+++ b/mozjs/src/cell.rs
@@ -76,7 +76,7 @@ impl<T> JSRefCell<T> {
     /// }
     /// ```
     ///
-    /// But in more complex cases, method might trigger a GC, and thus require a [`&mut JSContext`][crate::context::JSContext].
+    /// But in more complex cases, a method might trigger a GC, and thus require a [`&mut JSContext`][crate::context::JSContext].
     /// In that case [`&JSContext`][crate::context::JSContext] can be used in place of [`&NoGC`][NoGC],
     /// which will make [`RefMut`] bounded to the lifetime of the [`&JSContext`][crate::context::JSContext]
     /// and thus prevent any GC from happening while it is alive.
@@ -133,7 +133,7 @@ impl<T: Default> JSRefCell<T> {
     /// # Panics
     ///
     /// Panics if the value is currently borrowed.
-    pub fn take(&self, _no_gc: &NoGC) -> T {
+    pub fn take(&self) -> T {
         self.value.take()
     }
 }

--- a/mozjs/src/cell.rs
+++ b/mozjs/src/cell.rs
@@ -237,3 +237,140 @@ unsafe impl<T: Traceable> Traceable for JSCell<T> {
         unsafe { (&*self.inner.get()).trace(trc) };
     }
 }
+
+/// Mutably borrows two different [`JSCell`]s at the same time.
+///
+/// This is impossible to do with normal [`JSCell::borrow_mut`],
+/// because it would require two mutable borrows of the same [`NoGC`] token at the same time:
+///
+/// ```compile_fail
+/// use mozjs::context::NoGC;
+/// use mozjs::cell::JSCell;
+/// fn f(no_gc: &mut NoGC, cell1: &JSCell<String>, cell2: &JSCell<String>) {
+///     let borrow1 = cell1.borrow_mut(no_gc);
+///     let borrow2 = cell2.borrow_mut(no_gc); // cannot borrow `no_gc` as mutable more than once at a time
+///     std::mem::swap(borrow1, borrow2);
+/// }
+/// ```
+///
+/// instead one should do it like this:
+/// ```
+/// use mozjs::context::NoGC;
+/// use mozjs::cell::JSCell;
+/// fn f(no_gc: &mut NoGC, cell1: &JSCell<String>, cell2: &JSCell<String>) {
+///     let (borrow1, borrow2) = mozjs::cell::two_cells_borrow_mut(cell1, cell2, no_gc);
+///     std::mem::swap(borrow1, borrow2);
+/// }
+/// ```
+///
+/// # Panics
+///
+/// Panics if `cell1` and `cell2` are the same cell.
+pub fn two_cells_borrow_mut<'c1, 'c2, 'cx, 'r1, 'r2, T1, T2>(
+    cell1: &'c1 JSCell<T1>,
+    cell2: &'c2 JSCell<T2>,
+    _exclusive: &'cx mut NoGC,
+) -> (&'r1 mut T1, &'r2 mut T2)
+where
+    'c1: 'r1,
+    'c2: 'r2,
+    'cx: 'r1,
+    'cx: 'r2,
+{
+    let c1 = cell1.inner.get();
+    let c2 = cell2.inner.get();
+    assert_ne!(
+        c1 as *const _, c2 as *const _,
+        "Cannot mutably borrow the same cell multiple times at the same time"
+    );
+    // SAFETY: `&mut NoGC` is used as a borrow token to ensure that no other borrows are alive at the same time.
+    unsafe { (&mut *cell1.inner.get(), &mut *cell2.inner.get()) }
+}
+
+/// Mutably borrows three different [`JSCell`]s at the same time.
+///
+/// This is impossible to do with normal [`JSCell::borrow_mut`],
+/// because it would require three mutable borrows of the same [`NoGC`] token at the same time:
+/// ```compile_fail
+/// use mozjs::context::NoGC;
+/// use mozjs::cell::JSCell;
+/// fn f(no_gc: &mut NoGC, cell1: &JSCell<String>, cell2: &JSCell<String>, cell3: &JSCell<String>) {
+///     let borrow1 = cell1.borrow_mut(no_gc);
+///     let borrow2 = cell2.borrow_mut(no_gc);
+///     let borrow3 = cell3.borrow_mut(no_gc); // cannot borrow `no_gc` as mutable more than once at a time
+///     std::mem::swap(borrow1, borrow2);
+///     std::mem::swap(borrow2, borrow3);
+/// }
+/// ```
+///
+/// instead one should do it like this:
+/// ```
+/// use mozjs::context::NoGC;
+/// use mozjs::cell::JSCell;
+/// fn f(no_gc: &mut NoGC, cell1: &JSCell<String>, cell2: &JSCell<String>, cell3: &JSCell<String>) {
+///     let (borrow1, borrow2, borrow3) = mozjs::cell::three_cells_borrow_mut(cell1, cell2, cell3, no_gc);
+///     std::mem::swap(borrow1, borrow2);
+///     std::mem::swap(borrow2, borrow3);
+/// }
+/// ```
+///
+/// # Panics
+/// Panics if any two of `cell1`, `cell2` and `cell3` are the same cell.
+pub fn three_cells_borrow_mut<'c1, 'c2, 'c3, 'cx, 'r1, 'r2, 'r3, T1, T2, T3>(
+    cell1: &'c1 JSCell<T1>,
+    cell2: &'c2 JSCell<T2>,
+    cell3: &'c3 JSCell<T3>,
+    _exclusive: &'cx mut NoGC,
+) -> (&'r1 mut T1, &'r2 mut T2, &'r3 mut T3)
+where
+    'c1: 'r1,
+    'c2: 'r2,
+    'c3: 'r3,
+    'cx: 'r1,
+    'cx: 'r2,
+    'cx: 'r3,
+{
+    let c1 = cell1.inner.get();
+    let c2 = cell2.inner.get();
+    let c3 = cell3.inner.get();
+    assert_ne!(
+        c1 as *const _, c2 as *const _,
+        "Cannot mutably borrow the same cell multiple times at the same time"
+    );
+    assert_ne!(
+        c1 as *const _, c3 as *const _,
+        "Cannot mutably borrow the same cell multiple times at the same time"
+    );
+    assert_ne!(
+        c2 as *const _, c3 as *const _,
+        "Cannot mutably borrow the same cell multiple times at the same time"
+    );
+    // SAFETY: `&mut NoGC` is used as a borrow token to ensure that no other borrows are alive at the same time.
+    unsafe {
+        (
+            &mut *cell1.inner.get(),
+            &mut *cell2.inner.get(),
+            &mut *cell3.inner.get(),
+        )
+    }
+}
+
+#[test]
+fn test_two_cells_borrow_mut() {
+    let cell1 = JSCell::new(1);
+    let cell2 = JSCell::new(2);
+    let mut no_gc = unsafe { NoGC::new() };
+    let (borrow1, borrow2) = two_cells_borrow_mut(&cell1, &cell2, &mut no_gc);
+    *borrow1 += 1;
+    *borrow2 += 1;
+    assert_eq!(*cell1.borrow(&no_gc), 2);
+    assert_eq!(*cell2.borrow(&no_gc), 3);
+}
+
+#[should_panic(expected = "Cannot mutably borrow the same cell multiple times at the same time")]
+#[test]
+fn test_two_same_cells_borrow_mut() {
+    let cell1 = JSCell::new(1);
+    let mut no_gc = unsafe { NoGC::new() };
+    let _ = two_cells_borrow_mut(&cell1, &cell1, &mut no_gc);
+}

--- a/mozjs/src/cell.rs
+++ b/mozjs/src/cell.rs
@@ -9,7 +9,7 @@ use std::cell::{RefCell, UnsafeCell};
 
 use mozjs_sys::trace::Traceable;
 
-use crate::context::{JSContext, NoGC};
+use crate::context::NoGC;
 use crate::jsapi::JSTracer;
 
 /// [`std::cell::RefCell`] that statically prevents borrow_mut panics
@@ -144,13 +144,13 @@ impl<T> JSCell<T> {
         }
     }
 
-    pub fn set<'a, 'cx>(&'a self, _exclusive: &'cx mut JSContext, val: T) {
-        // SAFETY: `&mut JSContext` is used as an affinity token to ensure that no other borrows are alive at the same time.
+    pub fn set<'a, 'cx>(&'a self, _exclusive: &'cx mut NoGC, val: T) {
+        // SAFETY: `&mut NoGC` is used as an affinity token to ensure that no other borrows are alive at the same time.
         unsafe { *self.inner.get() = val }
     }
 
-    pub fn borrow_mut<'a: 'r, 'cx: 'r, 'r>(&'a self, _exclusive: &'cx mut JSContext) -> &'r mut T {
-        // SAFETY: `&mut JSContext` is used as an affinity token to ensure that no other borrows are alive at the same time.
+    pub fn borrow_mut<'a: 'r, 'cx: 'r, 'r>(&'a self, _exclusive: &'cx mut NoGC) -> &'r mut T {
+        // SAFETY: `&mut NoGC` is used as an affinity token to ensure that no other borrows are alive at the same time.
         unsafe { &mut *self.inner.get() }
     }
 

--- a/mozjs/src/context.rs
+++ b/mozjs/src/context.rs
@@ -199,7 +199,7 @@ impl DerefMut for JSContext {
 
 /// Token that ensures that no GC can happen while it is alive.
 ///
-/// This type is similar to `&JSContext`,
+/// This type is similar to [`&JSContext`][JSContext],
 /// but it is used in cases where no actual context is needed.
 ///
 /// For more info and examples see [JSContext].
@@ -217,8 +217,8 @@ pub struct NoGC(()); // zero-sized type that cannot be constructed from outside
 impl NoGC {
     /// Creates new NoGC token from thin air.
     ///
-    /// This is more safe than constructing [JSContext] from thin air as the promise here (of no GC) is weaker,
-    /// but one should still prefer passing [NoGC] down as an argument.
+    /// This is more safe than constructing [`JSContext`] from thin air as the promise here (of no GC) is weaker,
+    /// but one should still prefer passing [`NoGC`] down as an argument.
     ///
     /// # Safety
     ///

--- a/mozjs/src/context.rs
+++ b/mozjs/src/context.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 use std::ptr::NonNull;
 
 pub use crate::jsapi::JSContext as RawJSContext;
@@ -82,6 +82,8 @@ pub use crate::jsapi::JSContext as RawJSContext;
 /// This model is still being incrementally introduced, so there are currently some escape hatches.
 pub struct JSContext {
     pub(crate) ptr: NonNull<RawJSContext>,
+    // this is ZST, but we need it to get &mut NoGC safely
+    no_gc: NoGC,
 }
 
 impl JSContext {
@@ -93,7 +95,10 @@ impl JSContext {
     /// This in turn means that [JSContext] always needs to be passed down as an argument,
     /// but for the SpiderMonkey callbacks which provide [RawJSContext] it's safe to construct **one** from provided [RawJSContext].
     pub unsafe fn from_ptr(cx: NonNull<RawJSContext>) -> JSContext {
-        JSContext { ptr: cx }
+        JSContext {
+            ptr: cx,
+            no_gc: NoGC(()),
+        }
     }
 
     /// Get the `JSContext` for this thread (thin air). This should be rarely used.
@@ -111,6 +116,15 @@ impl JSContext {
     #[must_use]
     pub fn no_gc<'cx>(&'cx self) -> &'cx NoGC {
         &NoGC(())
+    }
+
+    /// Returns [NoGC] token bounded to this [JSContext].
+    /// No function that accepts `&mut JSContext` (read: triggers GC)
+    /// can be called while this is alive.
+    #[inline]
+    #[must_use]
+    pub fn no_gc_mut<'cx>(&'cx mut self) -> &'cx mut NoGC {
+        &mut self.no_gc
     }
 
     /// Obtain [RawJSContext] mutable pointer.
@@ -175,6 +189,14 @@ impl Deref for JSContext {
     }
 }
 
+impl DerefMut for JSContext {
+    /// Deref [`&mut JSContext`](JSContext) into [`&mut NoGC`](NoGC) so that
+    /// one can pass [`&mut JSContext`](JSContext) to functions that require [`&mut NoGC`](NoGC).
+    fn deref_mut<'cx>(&'cx mut self) -> &'cx mut Self::Target {
+        self.no_gc_mut()
+    }
+}
+
 /// Token that ensures that no GC can happen while it is alive.
 ///
 /// This type is similar to `&JSContext`,
@@ -200,9 +222,8 @@ impl NoGC {
     ///
     /// # Safety
     ///
-    /// One must ensure that no `&mut JSContext` is alive while [NoGC] is alive.
-    /// (having `&JSContext` is technically OK, but one should rather derive [NoGC] from it).
-    pub unsafe fn new() -> &'static Self {
-        &NoGC(())
+    /// One must ensure that no [`JSContext`] or existing [`NoGC`] is alive while this [`NoGC`] is alive.
+    pub unsafe fn new() -> Self {
+        NoGC(())
     }
 }

--- a/mozjs/src/lib.rs
+++ b/mozjs/src/lib.rs
@@ -47,6 +47,7 @@ pub mod jsapi {
 #[macro_use]
 pub mod rust;
 
+pub mod cell;
 mod consts;
 pub mod context;
 pub mod conversions;


### PR DESCRIPTION
`JSRefCell` is based on work done in https://github.com/servo/servo/pull/46050 and `JSCell` is based on https://github.com/servo/mozjs/issues/569#issuecomment-2764639269, but we do not offer special handling for Copy types as they should be stored in normal Cell instead and instead of requiring &mut JSContext we require &mut NoGC when we need exclusivity.

Testing: Many doctests and also some regular unit tests.
Servo PR: https://github.com/servo/servo/pull/46447
