### PR TITLE
typedarray: Added safety to as_slice and as_mut_slice

### DIFF
--- a/mozjs/src/typedarray.rs
+++ b/mozjs/src/typedarray.rs
@@ -203,14 +203,11 @@ impl<T: TypedArrayElement, S: JSObjectStorage> TypedArray<T, S> {
     ///
     /// The returned slice can be invalidated if the underlying typed array
     /// is neutered.
-    /// Returns an empty array if the data ptr is null (for example if the buffer was detached).
+    /// Panics if the underlying data points to a nullptr.
     pub unsafe fn as_slice(&self) -> &[T::Element] {
         let data = self.data();
-        if data.is_null() {
-            &[]
-        } else {
-            &*data
-        }
+        assert!(!data.is_null());
+        &*data
     }
 
     /// # Unsafety
@@ -220,11 +217,10 @@ impl<T: TypedArrayElement, S: JSObjectStorage> TypedArray<T, S> {
     ///
     /// The underlying `JSObject` can be aliased, which can lead to
     /// Undefined Behavior due to mutable aliasing.
+    /// Panics if the underlying data points to a nullptr.
     pub unsafe fn as_mut_slice(&mut self) -> &mut [T::Element] {
         let data = self.data();
-        if data.is_null() {
-            panic!("Data PTR is null. Cannot give mutable reference.")
-        }
+        assert!(!data.is_null());
         &mut *self.data()
     }
 

--- a/mozjs/src/typedarray.rs
+++ b/mozjs/src/typedarray.rs
@@ -203,6 +203,9 @@ impl<T: TypedArrayElement, S: JSObjectStorage> TypedArray<T, S> {
     ///
     /// The returned slice can be invalidated if the underlying typed array
     /// is neutered.
+    ///
+    /// # Panics
+    ///
     /// Panics if the underlying data points to a nullptr.
     pub unsafe fn as_slice(&self) -> &[T::Element] {
         let data = self.data();
@@ -217,6 +220,9 @@ impl<T: TypedArrayElement, S: JSObjectStorage> TypedArray<T, S> {
     ///
     /// The underlying `JSObject` can be aliased, which can lead to
     /// Undefined Behavior due to mutable aliasing.
+    ///
+    /// # Panics
+    ///
     /// Panics if the underlying data points to a nullptr.
     pub unsafe fn as_mut_slice(&mut self) -> &mut [T::Element] {
         let data = self.data();

--- a/mozjs/src/typedarray.rs
+++ b/mozjs/src/typedarray.rs
@@ -203,8 +203,14 @@ impl<T: TypedArrayElement, S: JSObjectStorage> TypedArray<T, S> {
     ///
     /// The returned slice can be invalidated if the underlying typed array
     /// is neutered.
+    /// Returns an empty array if the data ptr is null (for example if the buffer was detached).
     pub unsafe fn as_slice(&self) -> &[T::Element] {
-        &*self.data()
+        let data = self.data();
+        if data.is_null() {
+            &[]
+        } else {
+            &*data
+        }
     }
 
     /// # Unsafety
@@ -215,6 +221,10 @@ impl<T: TypedArrayElement, S: JSObjectStorage> TypedArray<T, S> {
     /// The underlying `JSObject` can be aliased, which can lead to
     /// Undefined Behavior due to mutable aliasing.
     pub unsafe fn as_mut_slice(&mut self) -> &mut [T::Element] {
+        let data = self.data();
+        if data.is_null() {
+            panic!("Data PTR is null. Cannot give mutable reference.")
+        }
         &mut *self.data()
     }
 


### PR DESCRIPTION
Currently if there is any reason the ptr is null, we run into undefined behavior. This can happen when the array is detached.
WPT test /FileAPI/blob/Blob-constructor-detached-buffer.any.worker.html is hitting this behavior.
As it is unclear to me when and how to fix the underlying cause, we should at least not run into undefined behavior (dereferencing a null ptr) in mozjs.

Alternatively we can return Option for both cases but I am not sure what is the  expected result.