### PR TITLE
Mark VecDeque as rootable.

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "140.12.0-1"
+version = "140.12.0-2"
 authors = ["Mozilla", "The Servo Project Developers"]
 links = "mozjs"
 license.workspace = true

--- a/mozjs-sys/src/jsgc.rs
+++ b/mozjs-sys/src/jsgc.rs
@@ -6,6 +6,7 @@ use crate::jsapi::{js, JS};
 use crate::jsapi::{jsid, JSFunction, JSObject, JSScript, JSString, JSTracer};
 use crate::jsid::VoidId;
 use std::cell::UnsafeCell;
+use std::collections::VecDeque;
 use std::ffi::{c_char, c_void};
 use std::marker::PhantomData;
 use std::mem;
@@ -111,6 +112,7 @@ pub trait Rootable: crate::trace::Traceable + Sized {
 
 impl<T: Rootable> Rootable for Option<T> {}
 impl<T: crate::trace::Traceable> Rootable for Vec<T> {}
+impl<T: crate::trace::Traceable> Rootable for VecDeque<T> {}
 
 // The C++ representation of Rooted<T> inherits from StackRootedBase, which
 // contains the actual pointers that get manipulated. The Rust representation

--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.18.0"
+version = "0.18.1"
 authors = ["The Servo Project Developers"]
 license.workspace = true
 edition.workspace = true
@@ -27,7 +27,7 @@ encoding_rs = "0.8.35"
 libc.workspace = true
 log = "0.4"
 # When doing non-version changes also update ../mozjs-sys/etc/sm-security-bump.py
-mozjs_sys = { version = "=140.12.0-1", path = "../mozjs-sys" }
+mozjs_sys = { version = "=140.12.0-2", path = "../mozjs-sys" }
 num-traits = "0.2"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]


### PR DESCRIPTION
This allows using VecDeque values with the root! macro.