### PR TITLE
Expose safe typed array slices.

### DIFF
--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.18.1"
+version = "0.18.2"
 authors = ["The Servo Project Developers"]
 license.workspace = true
 edition.workspace = true

--- a/mozjs/src/typedarray.rs
+++ b/mozjs/src/typedarray.rs
@@ -9,6 +9,7 @@
 use crate::conversions::ConversionResult;
 use crate::conversions::FromJSValConvertible;
 use crate::conversions::ToJSValConvertible;
+use crate::context::NoGC;
 use crate::glue::GetFloat32ArrayLengthAndData;
 use crate::glue::GetFloat64ArrayLengthAndData;
 use crate::glue::GetInt16ArrayLengthAndData;
@@ -213,6 +214,14 @@ impl<T: TypedArrayElement, S: JSObjectStorage> TypedArray<T, S> {
         &*data
     }
 
+    pub fn as_slice_safe<'a>(&self, _no_gc: &'a NoGC) -> &'a [T::Element] {
+        // SAFETY: The slice can only be invalidated by invoking JS engine
+        //         behaviour that detaches the underlying typed array.
+        //         The slice's lifetime is bounded by the provided NoGC token,
+        //         which prevents any JS engine interaction.
+        unsafe { &*self.data() }
+    }
+
     /// # Unsafety
     ///
     /// The returned slice can be invalidated if the underlying typed array
@@ -228,6 +237,14 @@ impl<T: TypedArrayElement, S: JSObjectStorage> TypedArray<T, S> {
         let data = self.data();
         assert!(!data.is_null());
         &mut *self.data()
+    }
+
+    pub fn as_mut_slice_safe<'a>(&mut self, _no_gc: &'a NoGC) -> &'a mut [T::Element] {
+        // SAFETY: The slice can only be invalidated by invoking JS engine
+        //         behaviour that detaches the underlying typed array.
+        //         The slice's lifetime is bounded by the provided NoGC token,
+        //         which prevents any JS engine interaction.
+        unsafe { &mut *self.data() }
     }
 
     /// Return a boolean flag which denotes whether the underlying buffer

--- a/mozjs/src/typedarray.rs
+++ b/mozjs/src/typedarray.rs
@@ -6,10 +6,10 @@
 //! typed arrays or wrapping existing JS reflectors, and prevents reinterpreting
 //! existing buffers as different types except in well-defined cases.
 
+use crate::context::NoGC;
 use crate::conversions::ConversionResult;
 use crate::conversions::FromJSValConvertible;
 use crate::conversions::ToJSValConvertible;
-use crate::context::NoGC;
 use crate::glue::GetFloat32ArrayLengthAndData;
 use crate::glue::GetFloat64ArrayLengthAndData;
 use crate::glue::GetInt16ArrayLengthAndData;

--- a/mozjs/src/typedarray.rs
+++ b/mozjs/src/typedarray.rs
@@ -188,6 +188,7 @@ impl<T: TypedArrayElement, S: JSObjectStorage> TypedArray<T, S> {
     }
 
     /// Retrieves an owned data that's represented by the typed array.
+    #[allow(deprecated)]
     pub fn to_vec(&self) -> Vec<T::Element>
     where
         T::Element: Clone,
@@ -208,6 +209,7 @@ impl<T: TypedArrayElement, S: JSObjectStorage> TypedArray<T, S> {
     /// # Panics
     ///
     /// Panics if the underlying data points to a nullptr.
+    #[deprecated = "use as_slice_safe instead"]
     pub unsafe fn as_slice(&self) -> &[T::Element] {
         let data = self.data();
         assert!(!data.is_null());
@@ -219,7 +221,11 @@ impl<T: TypedArrayElement, S: JSObjectStorage> TypedArray<T, S> {
         //         behaviour that detaches the underlying typed array.
         //         The slice's lifetime is bounded by the provided NoGC token,
         //         which prevents any JS engine interaction.
-        unsafe { &*self.data() }
+        unsafe {
+            let data = self.data();
+            assert!(!data.is_null());
+            &*data
+        }
     }
 
     /// # Unsafety
@@ -233,6 +239,7 @@ impl<T: TypedArrayElement, S: JSObjectStorage> TypedArray<T, S> {
     /// # Panics
     ///
     /// Panics if the underlying data points to a nullptr.
+    #[deprecated = "use as_mut_slice_safe instead"]
     pub unsafe fn as_mut_slice(&mut self) -> &mut [T::Element] {
         let data = self.data();
         assert!(!data.is_null());
@@ -244,7 +251,11 @@ impl<T: TypedArrayElement, S: JSObjectStorage> TypedArray<T, S> {
         //         behaviour that detaches the underlying typed array.
         //         The slice's lifetime is bounded by the provided NoGC token,
         //         which prevents any JS engine interaction.
-        unsafe { &mut *self.data() }
+        unsafe {
+            let data = self.data();
+            assert!(!data.is_null());
+            &mut *self.data()
+        }
     }
 
     /// Return a boolean flag which denotes whether the underlying buffer


### PR DESCRIPTION
We can remove a bunch of unsafe usage related to typed arrays since we can now tie the slice lifetime to a NoGC argument.

Servo PR: https://github.com/servo/servo/pull/46416
