### PR TITLE
More raw `JSContext` deprecations

### DIFF
--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.18.2"
+version = "0.18.3"
 authors = ["The Servo Project Developers"]
 license.workspace = true
 edition.workspace = true

--- a/mozjs/src/generate_wrappers.py
+++ b/mozjs/src/generate_wrappers.py
@@ -128,7 +128,7 @@ def grep_heur2(file_path: Path) -> list[str]:
             .replace("*mut JSContext", "&mut JSContext")
             .replace("*const JSContext", "&JSContext")
         )
-        if link_name in no_gc or "NewCompileOptions" in sig or "CurrentGlobal" in sig:
+        if link_name in no_gc or "NewCompileOptions" in sig or "CurrentGlobal" in sig or "DescribeScriptedCaller" in sig:
             sig = sig.replace("&mut JSContext", "&JSContext")
         return sig
 

--- a/mozjs/src/glue2_wrappers.in.rs
+++ b/mozjs/src/glue2_wrappers.in.rs
@@ -36,7 +36,7 @@ wrap!(glue: pub fn JS_GetRegExpFlags(cx: &mut JSContext, obj: HandleObject, flag
 wrap!(glue: pub fn EncodeStringToUTF8(cx: &mut JSContext, str_: HandleString, cb: EncodedStringCallback));
 wrap!(glue: pub fn SetUpEventLoopDispatch(cx: &mut JSContext, callback: RustDispatchToEventLoopCallback, closure: *mut ::std::os::raw::c_void));
 wrap!(glue: pub fn DispatchableRun(cx: &mut JSContext, ptr: *mut DispatchablePointer, mb: Dispatchable_MaybeShuttingDown));
-wrap!(glue: pub fn DescribeScriptedCaller(cx: &mut JSContext, buffer: *mut ::std::os::raw::c_char, buflen: usize, line: *mut u32, col: *mut u32) -> bool);
+wrap!(glue: pub fn DescribeScriptedCaller(cx: &JSContext, buffer: *mut ::std::os::raw::c_char, buflen: usize, line: *mut u32, col: *mut u32) -> bool);
 wrap!(glue: pub fn PendingExceptionStackInfo(cx: &mut JSContext, callback: StringCallback, message_target: *mut ::std::os::raw::c_void, filename_target: *mut ::std::os::raw::c_void, line: *mut u32, col: *mut u32, dest: MutableHandleValue) -> bool);
 wrap!(glue: pub fn SetDataPropertyDescriptor(desc: MutableHandle<PropertyDescriptor>, value: HandleValue, attrs: u32));
 wrap!(glue: pub fn SetAccessorPropertyDescriptor(desc: MutableHandle<PropertyDescriptor>, getter: HandleObject, setter: HandleObject, attrs: u32));

--- a/mozjs/src/rust.rs
+++ b/mozjs/src/rust.rs
@@ -1062,20 +1062,12 @@ pub unsafe fn describe_scripted_caller(cx: *mut JSContext) -> Result<ScriptedCal
     })
 }
 
-pub fn describe_scripted_caller_safe(
-    cx: &mut crate::context::JSContext,
-) -> Result<ScriptedCaller, ()> {
+pub fn describe_scripted_caller_safe(cx: &crate::context::JSContext) -> Result<ScriptedCaller, ()> {
     let mut buf = [0; 1024];
     let mut line = 0;
     let mut col = 0;
     if unsafe {
-        !DescribeScriptedCaller(
-            cx.raw_cx(),
-            buf.as_mut_ptr(),
-            buf.len(),
-            &mut line,
-            &mut col,
-        )
+        !wrappers2::DescribeScriptedCaller(cx, buf.as_mut_ptr(), buf.len(), &mut line, &mut col)
     } {
         return Err(());
     }
@@ -1115,14 +1107,14 @@ pub fn error_info_from_exception_stack_safe(
     let mut col = 0;
 
     unsafe {
-        if !PendingExceptionStackInfo(
-            cx.raw_cx(),
+        if !wrappers2::PendingExceptionStackInfo(
+            cx,
             Some(fill_string_callback),
             &raw mut message as *mut c_void,
             &raw mut filename as *mut c_void,
             &mut line,
             &mut col,
-            rval.into(),
+            rval,
         ) {
             return None;
         }

--- a/mozjs/src/rust.rs
+++ b/mozjs/src/rust.rs
@@ -18,11 +18,10 @@ use std::str;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
-use self::wrappers::{
+use self::wrappers2::{
     StackGCVectorStringAtIndex, StackGCVectorStringLength, StackGCVectorValueAtIndex,
-    StackGCVectorValueLength,
+    StackGCVectorValueLength, ToStringSlow,
 };
-use self::wrappers2::ToStringSlow;
 use crate::consts::{JSCLASS_GLOBAL_SLOT_COUNT, JSCLASS_RESERVED_SLOTS_MASK};
 use crate::consts::{JSCLASS_IS_DOMJSCLASS, JSCLASS_IS_GLOBAL};
 use crate::default_heapsize;
@@ -1374,6 +1373,7 @@ where
 }
 
 /// Wrappers for JSAPI methods that accept lifetimed Handle and MutableHandle arguments
+#[deprecated(note = "Use wrappers2 instead")]
 pub mod wrappers {
     macro_rules! wrap {
         // The invocation of @inner has the following form:

--- a/mozjs/src/rust.rs
+++ b/mozjs/src/rust.rs
@@ -545,6 +545,7 @@ impl CompileOptionsWrapper {
     /// # Safety
     /// `cx` must point to a non-null, valid [`JSContext`].
     /// To create an instance from safe code, use [`Runtime::new_compile_options`].
+    #[deprecated(note = "Use CompileOptionsWrapper::new instead")]
     pub unsafe fn new_raw(cx: *mut JSContext, filename: CString, line: u32) -> Self {
         let ptr = NewCompileOptions(cx, filename.as_ptr(), line);
         assert!(!ptr.is_null());
@@ -1045,6 +1046,7 @@ pub struct ScriptedCaller {
     pub col: u32,
 }
 
+#[deprecated(note = "Use describe_scripted_caller_safe instead")]
 pub unsafe fn describe_scripted_caller(cx: *mut JSContext) -> Result<ScriptedCaller, ()> {
     let mut buf = [0; 1024];
     let mut line = 0;
@@ -1053,6 +1055,31 @@ pub unsafe fn describe_scripted_caller(cx: *mut JSContext) -> Result<ScriptedCal
         return Err(());
     }
     let filename = CStr::from_ptr((&buf) as *const _ as *const _);
+    Ok(ScriptedCaller {
+        filename: String::from_utf8_lossy(filename.to_bytes()).into_owned(),
+        line,
+        col,
+    })
+}
+
+pub fn describe_scripted_caller_safe(
+    cx: &mut crate::context::JSContext,
+) -> Result<ScriptedCaller, ()> {
+    let mut buf = [0; 1024];
+    let mut line = 0;
+    let mut col = 0;
+    if unsafe {
+        !DescribeScriptedCaller(
+            cx.raw_cx(),
+            buf.as_mut_ptr(),
+            buf.len(),
+            &mut line,
+            &mut col,
+        )
+    } {
+        return Err(());
+    }
+    let filename = unsafe { CStr::from_ptr(buf.as_ptr()) };
     Ok(ScriptedCaller {
         filename: String::from_utf8_lossy(filename.to_bytes()).into_owned(),
         line,
@@ -1077,6 +1104,39 @@ unsafe extern "C" fn fill_string_callback(ptr: *const c_char, len: usize, target
 
 /// Retrieve error info from the pending exception stack, by clearing it.
 /// Return None if there isn't one or if it is a warning.
+pub fn error_info_from_exception_stack_safe(
+    cx: &mut crate::context::JSContext,
+    rval: MutableHandleValue,
+) -> Option<ErrorInfo> {
+    let mut message = String::new();
+    let mut filename = String::new();
+
+    let mut line = 0;
+    let mut col = 0;
+
+    unsafe {
+        if !PendingExceptionStackInfo(
+            cx.raw_cx(),
+            Some(fill_string_callback),
+            &raw mut message as *mut c_void,
+            &raw mut filename as *mut c_void,
+            &mut line,
+            &mut col,
+            rval.into(),
+        ) {
+            return None;
+        }
+    }
+
+    Some(ErrorInfo {
+        message,
+        filename,
+        line,
+        col,
+    })
+}
+
+#[deprecated(note = "Use error_info_from_exception_stack_safe instead")]
 pub unsafe fn error_info_from_exception_stack(
     cx: *mut JSContext,
     rval: RawMutableHandleValue,


### PR DESCRIPTION
To fully remove unsafe bindings we need to introduce safe variants of some existing mozjs APIs, starting with `describe_scripted_caller` and `error_info_from_exception_stack`.
Deprecate `wrappers` module too.

Testing: It compiles
Servo PR: https://github.com/servo/servo/pull/46461
