### PR TITLE
Fix warnings

### DIFF
--- a/mozjs-sys/src/jsval.rs
+++ b/mozjs-sys/src/jsval.rs
@@ -16,7 +16,6 @@ use crate::jsapi::JS::Value;
 
 use libc::c_void;
 use std::default::Default;
-use std::mem;
 
 pub type JSVal = Value;
 
@@ -113,7 +112,7 @@ pub fn Int32Value(i: i32) -> JSVal {
 #[cfg(target_pointer_width = "64")]
 #[inline(always)]
 pub fn DoubleValue(f: f64) -> JSVal {
-    let bits: u64 = unsafe { mem::transmute(f) };
+    let bits: u64 = f64::to_bits(f);
     assert!(bits <= ValueShiftedTag::MAX_DOUBLE as u64);
     AsJSVal(bits)
 }
@@ -121,7 +120,7 @@ pub fn DoubleValue(f: f64) -> JSVal {
 #[cfg(target_pointer_width = "32")]
 #[inline(always)]
 pub fn DoubleValue(f: f64) -> JSVal {
-    let bits: u64 = unsafe { mem::transmute(f) };
+    let bits: u64 = f64::to_bits(f);
     let val = AsJSVal(bits);
     assert!(val.is_double());
     val
@@ -430,7 +429,7 @@ impl JSVal {
     #[inline(always)]
     pub fn to_double(&self) -> f64 {
         assert!(self.is_double());
-        unsafe { mem::transmute(self.asBits()) }
+        f64::from_bits(self.asBits())
     }
 
     #[inline(always)]

--- a/mozjs/tests/typedarray.rs
+++ b/mozjs/tests/typedarray.rs
@@ -50,7 +50,7 @@ fn typedarray() {
         assert!(rval.is_object());
 
         typedarray!(&in(context) let array: Uint8Array = rval.to_object());
-        assert_eq!(array.unwrap().as_slice(), &[0, 2, 4][..]);
+        assert_eq!(array.unwrap().as_slice_safe(context), &[0, 2, 4][..]);
 
         typedarray!(&in(context) let array: Uint8Array = rval.to_object());
         assert_eq!(array.unwrap().len(), 3);
@@ -73,11 +73,11 @@ fn typedarray() {
         .is_ok());
 
         typedarray!(&in(context) let array: Uint32Array = rval.get());
-        assert_eq!(array.unwrap().as_slice(), &[1, 3, 5][..]);
+        assert_eq!(array.unwrap().as_slice_safe(context), &[1, 3, 5][..]);
 
         typedarray!(&in(context) let mut array: Uint32Array = rval.get());
         array.as_mut().unwrap().update(&[2, 4, 6]);
-        assert_eq!(array.unwrap().as_slice(), &[2, 4, 6][..]);
+        assert_eq!(array.unwrap().as_slice_safe(context), &[2, 4, 6][..]);
 
         rooted!(&in(context) let rval = ptr::null_mut::<JSObject>());
         typedarray!(&in(context) let array: Uint8Array = rval.get());
@@ -89,11 +89,11 @@ fn typedarray() {
         );
 
         typedarray!(&in(context) let array: Uint32Array = rval.get());
-        assert_eq!(array.unwrap().as_slice(), &[0, 0, 0, 0, 0]);
+        assert_eq!(array.unwrap().as_slice_safe(context), &[0, 0, 0, 0, 0]);
 
         typedarray!(&in(context) let mut array: Uint32Array = rval.get());
         array.as_mut().unwrap().update(&[0, 1, 2, 3]);
-        assert_eq!(array.unwrap().as_slice(), &[0, 1, 2, 3, 0]);
+        assert_eq!(array.unwrap().as_slice_safe(context), &[0, 1, 2, 3, 0]);
 
         typedarray!(&in(context) let view: ArrayBufferView = rval.get());
         assert_eq!(view.unwrap().get_array_type(), Type::Uint32);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,9 +2,6 @@
 # Keep this in sync with the Minimum-supported Rust version (MSRV) of servo!
 # When updating also search the github worflows .yml files for the old version
 # and update all occurences.
-channel = "1.85.0"
+channel = "1.88.0"
 
-components = [
-    "clippy",
-    "rustfmt"
-]
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Some warnings are from #777.

We need to bump rust version used by CI to make some warnings go away. Servo MSRV is 1.88: https://github.com/servo/servo/blob/4bf6354dd27620ceaaf5a18181bb60cabffe231c/Cargo.toml#L29

Testing: In rust we trust
