### PR TITLE
build: Consider cc-rs CXXFLAGS variants

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "140.13.0-3"
+version = "140.13.0-4"
 authors = ["Mozilla", "The Servo Project Developers"]
 links = "mozjs"
 license.workspace = true

--- a/mozjs-sys/build.rs
+++ b/mozjs-sys/build.rs
@@ -243,9 +243,11 @@ fn build_spidermonkey(build_dir: &Path) {
         cxxflags.push(String::from("-stdlib=libc++"));
     }
 
-    let base_cxxflags = env::var("CXXFLAGS").unwrap_or_default();
-    let mut cxxflags = cxxflags.join(" ");
-    cxxflags.push_str(&base_cxxflags);
+    if let Some(user_cxxflags) = get_cc_rs_env("CXXFLAGS").filter(|s| !s.is_empty()) {
+        // We want the user-provided CXXFLAGS after ours, since that allows overriding.
+        cxxflags.push(user_cxxflags);
+    };
+    let cxxflags = cxxflags.join(" ");
     cmd.env("CXXFLAGS", cxxflags);
 
     let cargo_manifest_dir = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
@@ -1267,6 +1269,13 @@ fn join_path(base: &Path, additional: &str) -> PathBuf {
         base.push(component);
     }
     base
+}
+
+/// Returns the value `cc-rs` would use for `var_base`.
+///
+/// See also [get_cc_rs_env_os].
+fn get_cc_rs_env(var_base: &str) -> Option<String> {
+    get_cc_rs_env_os(var_base).map(|val| val.to_str().expect("Not a valid string.").to_string())
 }
 
 /// Returns the value `cc-rs` would use for `var_base`

--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.21.3"
+version = "0.21.4"
 authors = ["The Servo Project Developers"]
 license.workspace = true
 edition.workspace = true
@@ -27,7 +27,7 @@ encoding_rs = "0.8.35"
 libc.workspace = true
 log = "0.4"
 # When doing non-version changes also update ../mozjs-sys/etc/sm-security-bump.py
-mozjs_sys = { version = "=140.13.0-3", path = "../mozjs-sys" }
+mozjs_sys = { version = "=140.13.0-4", path = "../mozjs-sys" }
 num-traits = "0.2"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]


### PR DESCRIPTION
Previously we would just consider CXXFLAGS, but not the cc-rs variants, which is unexpected (and inconsistent with bindgen and the glue code). Additionally, we also fix joining user-provided CXXFLAGS with our default flags, (we didn't space seperate them before). 

Testing: Not tested, the problematic OS + `CXXFLAGS` are set scenario does not occur in servos CI. PR is trivial though.

