### PR TITLE
ci: Restrict security bump to servo/mozjs.

### DIFF
--- a/.github/workflows/security-bump.yml
+++ b/.github/workflows/security-bump.yml
@@ -9,6 +9,8 @@ on:
 jobs:
     bump:
         runs-on: ubuntu-latest
+        # We don't want to run the security bump in forks.
+        if: github.repository == 'servo/mozjs'
         permissions:
             contents: write
             pull-requests: write


### PR DESCRIPTION
The action shouldn't run in forks, and will fail there.

Testing: Not tested, but trivial. We already do the same checks in servo/servo for many workflows.
Fixes #792 

