### PR TITLE
Usa safe wrappers in `RootedObjectVectorWrapper`, `IdVector`, `EnvironmentChain` and `CapturedJSStack`

### DIFF
--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.21.6"
+version = "0.22.0"
 authors = ["The Servo Project Developers"]
 license.workspace = true
 edition.workspace = true

--- a/mozjs/src/gc/root.rs
+++ b/mozjs/src/gc/root.rs
@@ -429,10 +429,6 @@ impl<'a, T> MutableHandle<'a, T> {
             anchor: PhantomData,
         }
     }
-
-    pub(crate) fn raw(&mut self) -> RawMutableHandle<T> {
-        unsafe { RawMutableHandle::from_marked_location(self.ptr.as_ptr()) }
-    }
 }
 
 impl<'a, T> MutableHandle<'a, Option<T>> {

--- a/mozjs/src/rust.rs
+++ b/mozjs/src/rust.rs
@@ -19,8 +19,9 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
 use self::wrappers2::{
-    CreateRootedIdVector, CreateRootedObjectVector, StackGCVectorStringAtIndex,
-    StackGCVectorStringLength, StackGCVectorValueAtIndex, StackGCVectorValueLength, ToStringSlow,
+    BuildStackString, CaptureCurrentStack, CreateRootedIdVector, CreateRootedObjectVector,
+    StackGCVectorStringAtIndex, StackGCVectorStringLength, StackGCVectorValueAtIndex,
+    StackGCVectorValueLength, ToStringSlow,
 };
 use crate::consts::{JSCLASS_GLOBAL_SLOT_COUNT, JSCLASS_RESERVED_SLOTS_MASK};
 use crate::consts::{JSCLASS_IS_DOMJSCLASS, JSCLASS_IS_GLOBAL};
@@ -46,8 +47,8 @@ use crate::jsapi::HandleValue as RawHandleValue;
 use crate::jsapi::JS_AddExtraGCRootsTracer;
 use crate::jsapi::MutableHandleIdVector as RawMutableHandleIdVector;
 use crate::jsapi::MutableHandleValue as RawMutableHandleValue;
+use crate::jsapi::StackFormat;
 use crate::jsapi::{already_AddRefed, jsid};
-use crate::jsapi::{BuildStackString, CaptureCurrentStack, StackFormat};
 use crate::jsapi::{HandleValueArray, StencilRelease};
 use crate::jsapi::{InitSelfHostedCode, IsWindowSlow};
 use crate::jsapi::{JSAutoStructuredCloneBuffer, JSStructuredCloneCallbacks, StructuredCloneScope};
@@ -1165,13 +1166,13 @@ pub unsafe fn error_info_from_exception_stack(
 }
 
 pub struct CapturedJSStack<'a> {
-    cx: *mut JSContext,
+    cx: &'a mut crate::context::JSContext,
     stack: RootedGuard<'a, *mut JSObject>,
 }
 
 impl<'a> CapturedJSStack<'a> {
     pub unsafe fn new(
-        cx: *mut JSContext,
+        cx: &'a mut crate::context::JSContext,
         mut guard: RootedGuard<'a, *mut JSObject>,
         max_frame_count: Option<u32>,
     ) -> Option<Self> {
@@ -1182,60 +1183,53 @@ impl<'a> CapturedJSStack<'a> {
         };
         let ref mut stack_capture = stack_capture.assume_init();
 
-        if !CaptureCurrentStack(
-            cx,
-            guard.handle_mut().raw(),
-            stack_capture,
-            HandleObject::null().into(),
-        ) {
+        if !CaptureCurrentStack(cx, guard.handle_mut(), stack_capture, HandleObject::null()) {
             None
         } else {
             Some(CapturedJSStack { cx, stack: guard })
         }
     }
 
-    pub fn as_string(&self, indent: Option<usize>, format: StackFormat) -> Option<String> {
-        unsafe {
-            let stack_handle = self.stack.handle();
-            rooted!(in(self.cx) let mut js_string = ptr::null_mut::<JSString>());
-            let mut string_handle = js_string.handle_mut();
+    pub fn as_string(&mut self, indent: Option<usize>, format: StackFormat) -> Option<String> {
+        let stack_handle = self.stack.handle();
+        rooted!(&in(self.cx) let mut js_string = ptr::null_mut::<JSString>());
 
+        unsafe {
             if !BuildStackString(
                 self.cx,
                 ptr::null_mut(),
-                stack_handle.into(),
-                string_handle.raw(),
+                stack_handle,
+                js_string.handle_mut(),
                 indent.unwrap_or(0),
                 format,
             ) {
                 return None;
             }
 
-            #[expect(deprecated)]
-            Some(crate::conversions::unsafe_jsstr_to_string(
+            Some(crate::conversions::jsstr_to_string(
                 self.cx,
-                NonNull::new(string_handle.get())?,
+                NonNull::new(js_string.get())?,
             ))
         }
     }
 
     /// Executes the provided closure for each frame on the js stack
-    pub fn for_each_stack_frame<F>(&self, mut f: F)
+    pub fn for_each_stack_frame<F>(&mut self, mut f: F)
     where
-        F: FnMut(Handle<*mut JSObject>),
+        F: FnMut(&mut crate::context::JSContext, Handle<*mut JSObject>),
     {
-        rooted!(in(self.cx) let mut current_element = self.stack.clone());
-        rooted!(in(self.cx) let mut next_element = ptr::null_mut::<JSObject>());
+        rooted!(&in(self.cx) let mut current_element = self.stack.clone());
+        rooted!(&in(self.cx) let mut next_element = ptr::null_mut::<JSObject>());
 
         loop {
-            f(current_element.handle());
+            f(self.cx, current_element.handle());
 
             unsafe {
-                let result = jsapi::GetSavedFrameParent(
+                let result = wrappers2::GetSavedFrameParent(
                     self.cx,
                     ptr::null_mut(),
-                    current_element.handle().into_handle(),
-                    next_element.handle_mut().into_handle_mut(),
+                    current_element.handle(),
+                    next_element.handle_mut(),
                     jsapi::SavedFrameSelfHosted::Include,
                 );
 
@@ -1250,15 +1244,12 @@ impl<'a> CapturedJSStack<'a> {
 
 #[macro_export]
 macro_rules! capture_stack {
-    (&in($cx:expr) $($t:tt)*) => {
-        capture_stack!(in(unsafe {$cx.raw_cx()}) $($t)*);
-    };
-    (in($cx:expr) let $name:ident = with max depth($max_frame_count:expr)) => {
-        rooted!(in($cx) let mut __obj = ::std::ptr::null_mut());
+    (&in($cx:expr) let $name:ident = with max depth($max_frame_count:expr)) => {
+        rooted!(&in($cx) let mut __obj = ::std::ptr::null_mut());
         let $name = $crate::rust::CapturedJSStack::new($cx, __obj, Some($max_frame_count));
     };
-    (in($cx:expr) let $name:ident ) => {
-        rooted!(in($cx) let mut __obj = ::std::ptr::null_mut());
+    (&in($cx:expr) let $name:ident ) => {
+        rooted!(&in($cx) let mut __obj = ::std::ptr::null_mut());
         let $name = $crate::rust::CapturedJSStack::new($cx, __obj, None);
     }
 }

--- a/mozjs/src/rust.rs
+++ b/mozjs/src/rust.rs
@@ -19,15 +19,14 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
 use self::wrappers2::{
-    StackGCVectorStringAtIndex, StackGCVectorStringLength, StackGCVectorValueAtIndex,
-    StackGCVectorValueLength, ToStringSlow,
+    CreateRootedIdVector, CreateRootedObjectVector, StackGCVectorStringAtIndex,
+    StackGCVectorStringLength, StackGCVectorValueAtIndex, StackGCVectorValueLength, ToStringSlow,
 };
 use crate::consts::{JSCLASS_GLOBAL_SLOT_COUNT, JSCLASS_RESERVED_SLOTS_MASK};
 use crate::consts::{JSCLASS_IS_DOMJSCLASS, JSCLASS_IS_GLOBAL};
 use crate::default_heapsize;
 pub use crate::gc::*;
 use crate::glue::AppendToRootedObjectVector;
-use crate::glue::{CreateRootedIdVector, CreateRootedObjectVector};
 use crate::glue::{
     DeleteCompileOptions, DeleteRootedObjectVector, DescribeScriptedCaller, DestroyRootedIdVector,
     PendingExceptionStackInfo,
@@ -508,7 +507,7 @@ pub struct RootedObjectVectorWrapper {
 }
 
 impl RootedObjectVectorWrapper {
-    pub fn new(cx: *mut JSContext) -> RootedObjectVectorWrapper {
+    pub fn new(cx: &mut crate::context::JSContext) -> RootedObjectVectorWrapper {
         RootedObjectVectorWrapper {
             ptr: unsafe { CreateRootedObjectVector(cx) },
         }
@@ -790,8 +789,8 @@ pub unsafe extern "C" fn report_warning(_cx: *mut JSContext, report: *mut JSErro
 pub struct IdVector(*mut PersistentRootedIdVector);
 
 impl IdVector {
-    pub unsafe fn new(cx: *mut JSContext) -> IdVector {
-        let vector = CreateRootedIdVector(cx);
+    pub fn new(cx: &mut crate::context::JSContext) -> IdVector {
+        let vector = unsafe { CreateRootedIdVector(cx) };
         assert!(!vector.is_null());
         IdVector(vector)
     }
@@ -1270,13 +1269,11 @@ pub struct EnvironmentChain {
 
 impl EnvironmentChain {
     pub fn new(
-        cx: *mut JSContext,
+        cx: &mut crate::context::JSContext,
         support_unscopeables: crate::jsapi::JS::SupportUnscopables,
     ) -> Self {
-        unsafe {
-            Self {
-                chain: crate::jsapi::glue::NewEnvironmentChain(cx, support_unscopeables),
-            }
+        Self {
+            chain: unsafe { wrappers2::NewEnvironmentChain(cx, support_unscopeables) },
         }
     }
 

--- a/mozjs/tests/capture_stack.rs
+++ b/mozjs/tests/capture_stack.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::ptr;
+use std::ptr::{self, NonNull};
 
 use mozjs::capture_stack;
 use mozjs::jsapi::{CallArgs, JSContext, OnNewGlobalHookOption, StackFormat, Value};
@@ -17,9 +17,11 @@ use mozjs::rust::{
 #[test]
 fn capture_stack() {
     unsafe extern "C" fn print_stack(context: *mut JSContext, argc: u32, vp: *mut Value) -> bool {
+        let mut context = mozjs::context::JSContext::from_ptr(NonNull::new(context).unwrap());
+        let cx = &mut context;
         let args = CallArgs::from_vp(vp, argc);
 
-        capture_stack!(in(context) let stack);
+        capture_stack!(&in(cx) let stack);
         let str_stack = stack
             .unwrap()
             .as_string(None, StackFormat::SpiderMonkey)

--- a/mozjs/tests/enumerate.rs
+++ b/mozjs/tests/enumerate.rs
@@ -45,7 +45,7 @@ fn enumerate() {
         assert!(rval.is_object());
 
         rooted!(&in(context) let object = rval.to_object());
-        let mut ids = IdVector::new(context.raw_cx());
+        let mut ids = IdVector::new(context);
         assert!(GetPropertyKeys(
             context,
             object.handle().into(),

--- a/mozjs/tests/iterate_stack.rs
+++ b/mozjs/tests/iterate_stack.rs
@@ -20,15 +20,17 @@ fn iterate_stack_frames() {
         _vp: *mut Value,
     ) -> bool {
         let mut context = mozjs::context::JSContext::from_ptr(NonNull::new(context).unwrap());
+        let cx = &mut context;
+
         let mut function_names = vec![];
-        capture_stack!(&in(context) let stack);
-        stack.unwrap().for_each_stack_frame(|frame| {
-            rooted!(&in(context) let mut result: *mut jsapi::JSString = ptr::null_mut());
+        capture_stack!(&in(cx) let stack);
+        stack.unwrap().for_each_stack_frame(|cx, frame| {
+            rooted!(&in(cx) let mut result: *mut jsapi::JSString = ptr::null_mut());
 
             // Get function name
             unsafe {
                 wrappers2::GetSavedFrameFunctionDisplayName(
-                    &mut context,
+                    cx,
                     ptr::null_mut(),
                     frame.into(),
                     result.handle_mut().into(),
@@ -37,7 +39,7 @@ fn iterate_stack_frames() {
             }
             let buffer = if !result.is_null() {
                 let mut buffer = vec![0; 3];
-                wrappers2::JS_EncodeStringToBuffer(&mut context, *result, buffer.as_mut_ptr(), 3);
+                wrappers2::JS_EncodeStringToBuffer(cx, *result, buffer.as_mut_ptr(), 3);
                 Some(buffer.into_iter().map(|c| c as u8).collect())
             } else {
                 None


### PR DESCRIPTION


Testing: It compiles
Servo PR: https://github.com/servo/servo/pull/47398
