### PR TITLE
Port the remaining public APIs to `&mut JSContext`

### DIFF
--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.22.0"
+version = "0.23.0"
 authors = ["The Servo Project Developers"]
 license.workspace = true
 edition.workspace = true

--- a/mozjs/src/conversions.rs
+++ b/mozjs/src/conversions.rs
@@ -791,7 +791,7 @@ impl<C: Clone, T: FromJSValConvertible<Config = C>> FromJSValConvertible for Vec
         }
 
         let mut return_value = vec![];
-        let result = for_of(unsafe { cx.raw_cx() }, value, |iterator_element| {
+        let result = for_of(cx, value, |cx, iterator_element| {
             let conversion_result = T::safe_from_jsval(cx, iterator_element, option.clone())
                 .map_err(|_| ForOfIterationFailure::JSFailed)?;
             return_value.push(match conversion_result {

--- a/mozjs/src/conversions.rs
+++ b/mozjs/src/conversions.rs
@@ -327,7 +327,7 @@ fn convert_int_from_jsval<T, M>(
     cx: &mut crate::context::JSContext,
     value: HandleValue,
     option: ConversionBehavior,
-    convert_fn: unsafe fn(*mut JSContext, HandleValue) -> Result<M, ()>,
+    convert_fn: unsafe fn(&mut crate::context::JSContext, HandleValue) -> Result<M, ()>,
 ) -> Result<ConversionResult<T>, ()>
 where
     T: Number + As<f64> + PrimInt,
@@ -336,14 +336,14 @@ where
 {
     match option {
         ConversionBehavior::Default => Ok(ConversionResult::Success(unsafe {
-            convert_fn(cx.raw_cx(), value)?.cast()
+            convert_fn(cx, value)?.cast()
         })),
         ConversionBehavior::EnforceRange => {
-            let number = unsafe { ToNumber(cx.raw_cx(), value) }?;
+            let number = unsafe { ToNumber(cx, value) }?;
             enforce_range(cx, number)
         }
         ConversionBehavior::Clamp => Ok(ConversionResult::Success(clamp_to(unsafe {
-            ToNumber(cx.raw_cx(), value)
+            ToNumber(cx, value)
         }?))),
     }
 }
@@ -554,7 +554,7 @@ impl FromJSValConvertible for f32 {
         val: HandleValue,
         _option: (),
     ) -> Result<ConversionResult<f32>, ()> {
-        let result = unsafe { ToNumber(cx.raw_cx(), val) };
+        let result = unsafe { ToNumber(cx, val) };
         result.map(|f| f as f32).map(ConversionResult::Success)
     }
 }
@@ -576,7 +576,7 @@ impl FromJSValConvertible for f64 {
         val: HandleValue,
         _option: (),
     ) -> Result<ConversionResult<f64>, ()> {
-        unsafe { ToNumber(cx.raw_cx(), val).map(ConversionResult::Success) }
+        unsafe { ToNumber(cx, val).map(ConversionResult::Success) }
     }
 }
 

--- a/mozjs/src/rust.rs
+++ b/mozjs/src/rust.rs
@@ -20,9 +20,9 @@ use std::sync::{Arc, Mutex, RwLock};
 
 use self::wrappers2::{
     BuildStackString, CaptureCurrentStack, CreateRootedIdVector, CreateRootedObjectVector,
-    StackGCVectorStringAtIndex, StackGCVectorStringLength, StackGCVectorValueAtIndex,
-    StackGCVectorValueLength, ToInt32Slow, ToInt64Slow, ToNumberSlow, ToStringSlow, ToUint16Slow,
-    ToUint32Slow, ToUint64Slow,
+    JS_DefineFunctions, JS_DefineProperties, StackGCVectorStringAtIndex, StackGCVectorStringLength,
+    StackGCVectorValueAtIndex, StackGCVectorValueLength, ToInt32Slow, ToInt64Slow, ToNumberSlow,
+    ToStringSlow, ToUint16Slow, ToUint32Slow, ToUint64Slow,
 };
 use crate::consts::{JSCLASS_GLOBAL_SLOT_COUNT, JSCLASS_RESERVED_SLOTS_MASK};
 use crate::consts::{JSCLASS_IS_DOMJSCLASS, JSCLASS_IS_GLOBAL};
@@ -56,7 +56,7 @@ use crate::jsapi::{JSClass, JSClassOps, JSContext, Realm, JSCLASS_RESERVED_SLOTS
 use crate::jsapi::{JSErrorReport, JSFunctionSpec, JSGCParamKey};
 use crate::jsapi::{JSObject, JSPropertySpec, JSRuntime};
 use crate::jsapi::{JSString, Object, PersistentRootedIdVector};
-use crate::jsapi::{JS_DefineFunctions, JS_DefineProperties, JS_DestroyContext, JS_ShutDown};
+use crate::jsapi::{JS_DestroyContext, JS_ShutDown};
 use crate::jsapi::{JS_EnumerateStandardClasses, JS_GlobalObjectTraceHook};
 use crate::jsapi::{JS_MayResolveStandardClass, JS_NewContext, JS_ResolveStandardClass};
 use crate::jsapi::{JS_RequestInterruptCallback, JS_RequestInterruptCallbackCanWait};
@@ -831,10 +831,9 @@ impl Deref for IdVector {
 ///
 /// # Safety
 ///
-/// - `cx` must be valid.
 /// - This function calls into unaudited C++ code.
 pub unsafe fn define_methods(
-    cx: *mut JSContext,
+    cx: &mut crate::context::JSContext,
     obj: HandleObject,
     methods: &'static [JSFunctionSpec],
 ) -> Result<(), ()> {
@@ -857,7 +856,7 @@ pub unsafe fn define_methods(
         }
     });
 
-    JS_DefineFunctions(cx, obj.into(), methods.as_ptr()).to_result()
+    JS_DefineFunctions(cx, obj, methods.as_ptr()).to_result()
 }
 
 /// Defines attributes on `obj`. The last entry of `properties` must contain
@@ -873,10 +872,9 @@ pub unsafe fn define_methods(
 ///
 /// # Safety
 ///
-/// - `cx` must be valid.
 /// - This function calls into unaudited C++ code.
 pub unsafe fn define_properties(
-    cx: *mut JSContext,
+    cx: &mut crate::context::JSContext,
     obj: HandleObject,
     properties: &'static [JSPropertySpec],
 ) -> Result<(), ()> {
@@ -887,7 +885,7 @@ pub unsafe fn define_properties(
         }
     });
 
-    JS_DefineProperties(cx, obj.into(), properties.as_ptr()).to_result()
+    JS_DefineProperties(cx, obj, properties.as_ptr()).to_result()
 }
 
 static SIMPLE_GLOBAL_CLASS_OPS: JSClassOps = JSClassOps {
@@ -973,9 +971,9 @@ pub unsafe fn try_to_outerize_object(mut rval: MutableHandleObject) {
 }
 
 #[inline]
-pub unsafe fn maybe_wrap_object(cx: *mut JSContext, mut obj: MutableHandleObject) {
-    if get_object_realm(*obj) != get_context_realm(cx) {
-        assert!(JS_WrapObject(cx, obj.reborrow().into()));
+pub unsafe fn maybe_wrap_object(cx: &mut crate::context::JSContext, mut obj: MutableHandleObject) {
+    if get_object_realm(*obj) != get_context_realm(cx.raw_cx()) {
+        assert!(JS_WrapObject(cx.raw_cx(), obj.reborrow().into()));
     }
     try_to_outerize_object(obj);
 }

--- a/mozjs/src/rust.rs
+++ b/mozjs/src/rust.rs
@@ -1334,14 +1334,20 @@ impl<OtherError> From<OtherError> for ForOfIterationFailure<OtherError> {
 ///
 /// The callback returns `Err()` to indicate a pending exception or `Ok()` containing a boolean
 /// value that is `true` if the iterator should continue iterating.
-pub fn for_of<Callback, OtherError>(
-    cx: *mut JSContext,
+pub fn for_of<Context, Callback, OtherError>(
+    cx: &mut Context,
     iterable: HandleValue<'_>,
     mut callback: Callback,
 ) -> Result<(), ForOfIterationFailure<OtherError>>
 where
-    Callback: FnMut(HandleValue<'_>) -> Result<ControlFlow<()>, ForOfIterationFailure<OtherError>>,
+    Context: AsMut<crate::context::JSContext>,
+    Callback: FnMut(
+        &mut Context,
+        HandleValue<'_>,
+    ) -> Result<ControlFlow<()>, ForOfIterationFailure<OtherError>>,
 {
+    let raw_cx = unsafe { cx.as_mut().raw_cx() };
+
     // Depending on the version of LLVM in use, bindgen can end up including
     // a padding field in the ForOfIterator. To support multiple versions of
     // LLVM that may not have the same fields as a result, we create an empty
@@ -1350,7 +1356,7 @@ where
     #[allow(unused_variables)]
     let zero = unsafe { mem::zeroed() };
     let mut iterator = jsapi::ForOfIterator {
-        cx_: cx,
+        cx_: raw_cx,
         iterator: RootedObject::new_unrooted(ptr::null_mut()),
         nextMethod: RootedValue::new_unrooted(JSVal { asBits_: 0 }),
         index: ::std::u32::MAX, // NOT_ARRAY
@@ -1377,8 +1383,8 @@ where
     let iterator = &mut *guard.inner;
 
     unsafe {
-        RootedObject::add_to_root_stack(&raw mut iterator.iterator, cx);
-        RootedValue::add_to_root_stack(&raw mut iterator.nextMethod, cx);
+        RootedObject::add_to_root_stack(&raw mut iterator.iterator, raw_cx);
+        RootedValue::add_to_root_stack(&raw mut iterator.nextMethod, raw_cx);
     }
 
     let success = unsafe {
@@ -1395,7 +1401,7 @@ where
     }
 
     let mut done = false;
-    rooted!(in(cx) let mut value = UndefinedValue());
+    rooted!(in(raw_cx) let mut value = UndefinedValue());
     loop {
         if !unsafe { iterator.next(value.handle_mut().into(), &mut done) } {
             return Err(ForOfIterationFailure::JSFailed);
@@ -1405,7 +1411,7 @@ where
             break;
         }
 
-        if callback(value.handle())?.is_break() {
+        if callback(cx, value.handle())?.is_break() {
             break;
         }
     }

--- a/mozjs/src/rust.rs
+++ b/mozjs/src/rust.rs
@@ -21,7 +21,8 @@ use std::sync::{Arc, Mutex, RwLock};
 use self::wrappers2::{
     BuildStackString, CaptureCurrentStack, CreateRootedIdVector, CreateRootedObjectVector,
     StackGCVectorStringAtIndex, StackGCVectorStringLength, StackGCVectorValueAtIndex,
-    StackGCVectorValueLength, ToStringSlow,
+    StackGCVectorValueLength, ToInt32Slow, ToInt64Slow, ToNumberSlow, ToStringSlow, ToUint16Slow,
+    ToUint32Slow, ToUint64Slow,
 };
 use crate::consts::{JSCLASS_GLOBAL_SLOT_COUNT, JSCLASS_RESERVED_SLOTS_MASK};
 use crate::consts::{JSCLASS_IS_DOMJSCLASS, JSCLASS_IS_GLOBAL};
@@ -43,7 +44,6 @@ use crate::jsapi::js::frontend::InitialStencilAndDelazifications;
 use crate::jsapi::mozilla::Utf8Unit;
 use crate::jsapi::shadow::BaseShape;
 use crate::jsapi::HandleObjectVector as RawHandleObjectVector;
-use crate::jsapi::HandleValue as RawHandleValue;
 use crate::jsapi::JS_AddExtraGCRootsTracer;
 use crate::jsapi::MutableHandleIdVector as RawMutableHandleIdVector;
 use crate::jsapi::MutableHandleValue as RawMutableHandleValue;
@@ -63,11 +63,8 @@ use crate::jsapi::{JS_RequestInterruptCallback, JS_RequestInterruptCallbackCanWa
 use crate::jsapi::{JS_SetGCParameter, JS_SetNativeStackQuota, JS_WrapObject, JS_WrapValue};
 use crate::jsapi::{JS_StackCapture_AllFrames, JS_StackCapture_MaxFrames};
 use crate::jsapi::{PersistentRootedObjectVector, ReadOnlyCompileOptions, RootingContext};
-use crate::jsapi::{
-    RootedObject, RootedValue, ToUint32Slow, ToUint64Slow, ToWindowProxyIfWindowSlow,
-};
+use crate::jsapi::{RootedObject, RootedValue, ToWindowProxyIfWindowSlow};
 use crate::jsapi::{SetWarningReporter, SourceText, ToBooleanSlow};
-use crate::jsapi::{ToInt32Slow, ToInt64Slow, ToNumberSlow, ToUint16Slow};
 use crate::jsval::{JSVal, ObjectValue, UndefinedValue};
 use crate::panic::maybe_resume_unwind;
 use crate::realm::AutoRealm;
@@ -679,14 +676,14 @@ pub unsafe fn ToBoolean(v: HandleValue) -> bool {
 }
 
 #[inline]
-pub unsafe fn ToNumber(cx: *mut JSContext, v: HandleValue) -> Result<f64, ()> {
+pub unsafe fn ToNumber(cx: &mut crate::context::JSContext, v: HandleValue) -> Result<f64, ()> {
     let val = *v.ptr.as_ptr();
     if val.is_number() {
         return Ok(val.to_number());
     }
 
     let mut out = Default::default();
-    if ToNumberSlow(cx, v.into_handle(), &mut out) {
+    if ToNumberSlow(cx, v, &mut out) {
         Ok(out)
     } else {
         Err(())
@@ -695,9 +692,9 @@ pub unsafe fn ToNumber(cx: *mut JSContext, v: HandleValue) -> Result<f64, ()> {
 
 #[inline]
 unsafe fn convert_from_int32<T: Default + Copy>(
-    cx: *mut JSContext,
+    cx: &mut crate::context::JSContext,
     v: HandleValue,
-    conv_fn: unsafe extern "C" fn(*mut JSContext, RawHandleValue, *mut T) -> bool,
+    conv_fn: unsafe fn(&mut crate::context::JSContext, HandleValue, *mut T) -> bool,
 ) -> Result<T, ()> {
     let val = *v.ptr.as_ptr();
     if val.is_int32() {
@@ -708,7 +705,7 @@ unsafe fn convert_from_int32<T: Default + Copy>(
     }
 
     let mut out = Default::default();
-    if conv_fn(cx, v.into(), &mut out) {
+    if conv_fn(cx, v, &mut out) {
         Ok(out)
     } else {
         Err(())
@@ -716,27 +713,27 @@ unsafe fn convert_from_int32<T: Default + Copy>(
 }
 
 #[inline]
-pub unsafe fn ToInt32(cx: *mut JSContext, v: HandleValue) -> Result<i32, ()> {
+pub unsafe fn ToInt32(cx: &mut crate::context::JSContext, v: HandleValue) -> Result<i32, ()> {
     convert_from_int32::<i32>(cx, v, ToInt32Slow)
 }
 
 #[inline]
-pub unsafe fn ToUint32(cx: *mut JSContext, v: HandleValue) -> Result<u32, ()> {
+pub unsafe fn ToUint32(cx: &mut crate::context::JSContext, v: HandleValue) -> Result<u32, ()> {
     convert_from_int32::<u32>(cx, v, ToUint32Slow)
 }
 
 #[inline]
-pub unsafe fn ToUint16(cx: *mut JSContext, v: HandleValue) -> Result<u16, ()> {
+pub unsafe fn ToUint16(cx: &mut crate::context::JSContext, v: HandleValue) -> Result<u16, ()> {
     convert_from_int32::<u16>(cx, v, ToUint16Slow)
 }
 
 #[inline]
-pub unsafe fn ToInt64(cx: *mut JSContext, v: HandleValue) -> Result<i64, ()> {
+pub unsafe fn ToInt64(cx: &mut crate::context::JSContext, v: HandleValue) -> Result<i64, ()> {
     convert_from_int32::<i64>(cx, v, ToInt64Slow)
 }
 
 #[inline]
-pub unsafe fn ToUint64(cx: *mut JSContext, v: HandleValue) -> Result<u64, ()> {
+pub unsafe fn ToUint64(cx: &mut crate::context::JSContext, v: HandleValue) -> Result<u64, ()> {
     convert_from_int32::<u64>(cx, v, ToUint64Slow)
 }
 

--- a/mozjs/src/rust.rs
+++ b/mozjs/src/rust.rs
@@ -1401,7 +1401,7 @@ where
     }
 
     let mut done = false;
-    rooted!(in(raw_cx) let mut value = UndefinedValue());
+    rooted!(&in(cx.as_mut()) let mut value = UndefinedValue());
     loop {
         if !unsafe { iterator.next(value.handle_mut().into(), &mut done) } {
             return Err(ForOfIterationFailure::JSFailed);

--- a/mozjs/src/typedarray.rs
+++ b/mozjs/src/typedarray.rs
@@ -8,6 +8,7 @@
 
 use std::ptr::NonNull;
 
+use crate::context::JSContext;
 use crate::context::NoGC;
 use crate::conversions::ConversionResult;
 use crate::conversions::FromJSValConvertible;
@@ -25,7 +26,6 @@ use crate::jsapi::GetArrayBufferData;
 use crate::jsapi::GetArrayBufferLengthAndData;
 use crate::jsapi::GetArrayBufferViewLengthAndData;
 use crate::jsapi::Heap;
-use crate::jsapi::JSContext;
 use crate::jsapi::JSObject;
 use crate::jsapi::JSTracer;
 use crate::jsapi::JS_GetArrayBufferViewType;
@@ -39,16 +39,6 @@ use crate::jsapi::JS_GetUint16ArrayData;
 use crate::jsapi::JS_GetUint32ArrayData;
 use crate::jsapi::JS_GetUint8ArrayData;
 use crate::jsapi::JS_GetUint8ClampedArrayData;
-use crate::jsapi::JS_NewFloat32Array;
-use crate::jsapi::JS_NewFloat64Array;
-use crate::jsapi::JS_NewInt16Array;
-use crate::jsapi::JS_NewInt32Array;
-use crate::jsapi::JS_NewInt8Array;
-use crate::jsapi::JS_NewUint16Array;
-use crate::jsapi::JS_NewUint32Array;
-use crate::jsapi::JS_NewUint8Array;
-use crate::jsapi::JS_NewUint8ClampedArray;
-use crate::jsapi::NewArrayBuffer;
 use crate::jsapi::Type;
 use crate::jsapi::UnwrapArrayBuffer;
 use crate::jsapi::UnwrapArrayBufferView;
@@ -61,6 +51,16 @@ use crate::jsapi::UnwrapUint16Array;
 use crate::jsapi::UnwrapUint32Array;
 use crate::jsapi::UnwrapUint8Array;
 use crate::jsapi::UnwrapUint8ClampedArray;
+use crate::rust::wrappers2::JS_NewFloat32Array;
+use crate::rust::wrappers2::JS_NewFloat64Array;
+use crate::rust::wrappers2::JS_NewInt16Array;
+use crate::rust::wrappers2::JS_NewInt32Array;
+use crate::rust::wrappers2::JS_NewInt8Array;
+use crate::rust::wrappers2::JS_NewUint16Array;
+use crate::rust::wrappers2::JS_NewUint32Array;
+use crate::rust::wrappers2::JS_NewUint8Array;
+use crate::rust::wrappers2::JS_NewUint8ClampedArray;
+use crate::rust::wrappers2::NewArrayBuffer;
 use crate::rust::CustomTrace;
 use crate::rust::{HandleValue, MutableHandleObject, MutableHandleValue};
 
@@ -102,7 +102,7 @@ impl<T: TypedArrayElement, S: JSObjectStorage> FromJSValConvertible for TypedArr
     type Config = ();
 
     fn safe_from_jsval(
-        _cx: &mut crate::context::JSContext,
+        _cx: &mut JSContext,
         value: HandleValue,
         _option: (),
     ) -> Result<ConversionResult<Self>, ()> {
@@ -116,7 +116,7 @@ impl<T: TypedArrayElement, S: JSObjectStorage> FromJSValConvertible for TypedArr
 
 impl<T: TypedArrayElement, S: JSObjectStorage> ToJSValConvertible for TypedArray<T, S> {
     #[inline]
-    fn safe_to_jsval(&self, cx: &mut crate::context::JSContext, rval: MutableHandleValue) {
+    fn safe_to_jsval(&self, cx: &mut JSContext, rval: MutableHandleValue) {
         ToJSValConvertible::safe_to_jsval(&self.object.as_raw(), cx, rval);
     }
 }
@@ -273,7 +273,7 @@ impl<T: TypedArrayElementCreator + TypedArrayElement, S: JSObjectStorage> TypedA
     /// Create a new JS typed array, optionally providing initial data that will
     /// be copied into the newly-allocated buffer. Returns the new JS reflector.
     pub unsafe fn create(
-        cx: *mut JSContext,
+        cx: &mut JSContext,
         with: CreateWith<T::Element>,
         mut result: MutableHandleObject,
     ) -> Result<(), ()> {
@@ -328,7 +328,7 @@ pub trait TypedArrayElement {
 /// Internal trait for creating new typed arrays.
 pub trait TypedArrayElementCreator: TypedArrayElement {
     /// Create a new typed array.
-    unsafe fn create_new(cx: *mut JSContext, length: usize) -> *mut JSObject;
+    fn create_new(cx: &mut JSContext, length: usize) -> *mut JSObject;
     /// Get the data.
     unsafe fn get_data(obj: *mut JSObject) -> *mut Self::Element;
 }
@@ -367,8 +367,8 @@ macro_rules! typed_array_element {
         typed_array_element!($t, $element, $unwrap, $length_and_data);
 
         impl TypedArrayElementCreator for $t {
-            unsafe fn create_new(cx: *mut JSContext, length: usize) -> *mut JSObject {
-                $create_new(cx, length)
+            fn create_new(cx: &mut JSContext, length: usize) -> *mut JSObject {
+                unsafe { $create_new(cx, length) }
             }
 
             unsafe fn get_data(obj: *mut JSObject) -> *mut Self::Element {

--- a/mozjs/tests/rooting.rs
+++ b/mozjs/tests/rooting.rs
@@ -42,7 +42,7 @@ fn rooting() {
 
         rooted!(&in(context) let prototype_proto = GetRealmObjectPrototype(context));
         rooted!(&in(context) let proto = JS_NewObjectWithGivenProto(context, &CLASS as *const _, prototype_proto.handle().into()));
-        define_methods(context.raw_cx(), proto.handle(), METHODS).unwrap();
+        define_methods(context, proto.handle(), METHODS).unwrap();
 
         rooted!(&in(context) let root: JSVal);
         assert_eq!(root.get().is_undefined(), true);

--- a/mozjs/tests/typedarray.rs
+++ b/mozjs/tests/typedarray.rs
@@ -62,12 +62,9 @@ fn typedarray() {
         assert_eq!(view.unwrap().get_array_type(), Type::Uint8);
 
         rooted!(&in(context) let mut rval = ptr::null_mut::<JSObject>());
-        assert!(Uint32Array::create(
-            context.raw_cx(),
-            CreateWith::Slice(&[1, 3, 5]),
-            rval.handle_mut()
-        )
-        .is_ok());
+        assert!(
+            Uint32Array::create(context, CreateWith::Slice(&[1, 3, 5]), rval.handle_mut()).is_ok()
+        );
 
         typedarray!(&in(context) let array: Uint32Array = rval.get());
         let mut uint32array = array.unwrap();
@@ -79,9 +76,7 @@ fn typedarray() {
         assert!(array.is_err());
 
         rooted!(&in(context) let mut rval = ptr::null_mut::<JSObject>());
-        assert!(
-            Uint32Array::create(context.raw_cx(), CreateWith::Length(5), rval.handle_mut()).is_ok()
-        );
+        assert!(Uint32Array::create(context, CreateWith::Length(5), rval.handle_mut()).is_ok());
 
         typedarray!(&in(context) let array: Uint32Array = rval.get());
         let mut uint32array = array.unwrap();
@@ -101,12 +96,9 @@ fn typedarray() {
         assert_eq!(view.is_shared(), false);
 
         rooted!(&in(context) let mut rval = ptr::null_mut::<JSObject>());
-        assert!(ArrayBuffer::create(
-            context.raw_cx(),
-            CreateWith::Slice(&[1, 2, 3]),
-            rval.handle_mut()
-        )
-        .is_ok());
+        assert!(
+            ArrayBuffer::create(context, CreateWith::Slice(&[1, 2, 3]), rval.handle_mut()).is_ok()
+        );
         typedarray!(&in(context) let arraybuffer: ArrayBuffer = rval.get());
         assert_eq!(
             arraybuffer.as_ref().unwrap().as_slice_safe(context),

--- a/mozjs/tests/typedarray_panic.rs
+++ b/mozjs/tests/typedarray_panic.rs
@@ -34,7 +34,7 @@ fn typedarray_update_panic() {
 
         rooted!(&in(context) let mut rval = ptr::null_mut::<JSObject>());
         let _ = Uint32Array::create(
-            context.raw_cx(),
+            context,
             CreateWith::Slice(&[1, 2, 3, 4, 5]),
             rval.handle_mut(),
         );


### PR DESCRIPTION
This PR completes mozjs's public API migration to `&mut JSContext`.
Only `for_of` remains, since the raw pointer is a field of `ForOfIterator` and is not used to call any methods, it can be left as is.

Testing: It compiles
Servo PR: https://github.com/servo/servo/pull/47446
