### PR TITLE
Expose resizable ArrayBuffer view and native Error stack APIs

### DIFF
--- a/mozjs-sys/mozjs/js/public/ArrayBuffer.h
+++ b/mozjs-sys/mozjs/js/public/ArrayBuffer.h
@@ -288,6 +288,13 @@ extern JS_PUBLIC_API JSObject* GetObjectAsArrayBuffer(JSObject* obj,
  */
 extern JS_PUBLIC_API size_t GetArrayBufferByteLength(JSObject* obj);
 
+/**
+ * Return the maximum byte length of a resizable ArrayBuffer. Returns false if
+ * |obj| cannot be unwrapped as one.
+ */
+extern JS_PUBLIC_API bool GetResizableArrayBufferMaxByteLength(
+    JSObject* obj, size_t* maxByteLength);
+
 // This one isn't inlined because there are a bunch of different ArrayBuffer
 // classes that would have to be individually handled here.
 //

--- a/mozjs-sys/mozjs/js/public/Exception.h
+++ b/mozjs-sys/mozjs/js/public/Exception.h
@@ -248,6 +248,18 @@ extern JS_PUBLIC_API void SetPendingExceptionStack(
  */
 extern JS_PUBLIC_API JSObject* ExceptionStackOrNull(JS::HandleObject obj);
 
+/** Return a native Error object's stack string in the current realm. */
+extern JS_PUBLIC_API bool GetNativeErrorStackString(
+    JSContext* cx, HandleObject error, MutableHandleString result);
+
+/**
+ * Set a native Error object's stack string without defining an own "stack"
+ * property.
+ */
+extern JS_PUBLIC_API bool SetNativeErrorStackString(JSContext* cx,
+                                                    HandleObject error,
+                                                    HandleString stack);
+
 /**
  * If the given object is an exception object, return the error cause for that
  * exception, if any, or mozilla::Nothing.

--- a/mozjs-sys/mozjs/js/public/experimental/TypedData.h
+++ b/mozjs-sys/mozjs/js/public/experimental/TypedData.h
@@ -280,6 +280,26 @@ JS_PUBLIC_API bool IsLargeArrayBufferView(JSObject* obj);
  */
 JS_PUBLIC_API bool IsResizableArrayBufferView(JSObject* obj);
 
+struct ResizableArrayBufferViewState {
+  bool lengthTracking;
+  bool outOfBounds;
+};
+
+/*
+ * Return the state of a resizable ArrayBuffer view, or false if |obj| cannot
+ * be unwrapped as one.
+ */
+JS_PUBLIC_API bool GetResizableArrayBufferViewState(
+    JSObject* obj, ResizableArrayBufferViewState* state);
+
+/*
+ * Create a resizable ArrayBuffer view, including out-of-bounds state. |length|
+ * is bytes for DataView, elements otherwise, or zero when length-tracking.
+ */
+JS_PUBLIC_API bool CreateResizableArrayBufferView(
+    JSContext* cx, HandleObject buffer, Scalar::Type type, size_t byteOffset,
+    size_t length, bool lengthTracking, MutableHandleObject result);
+
 /*
  * Returns whether the passed array buffer view has an immutable array buffer.
  *

--- a/mozjs-sys/mozjs/js/src/builtin/DataViewObject.cpp
+++ b/mozjs-sys/mozjs/js/src/builtin/DataViewObject.cpp
@@ -63,7 +63,8 @@ DataViewObject* DataViewObject::create(
 
 ResizableDataViewObject* ResizableDataViewObject::create(
     JSContext* cx, size_t byteOffset, size_t byteLength, AutoLength autoLength,
-    Handle<ArrayBufferObjectMaybeShared*> arrayBuffer, HandleObject proto) {
+    Handle<ArrayBufferObjectMaybeShared*> arrayBuffer, HandleObject proto,
+    bool allowOutOfBounds) {
   MOZ_ASSERT(arrayBuffer->isResizable());
   MOZ_ASSERT(!arrayBuffer->isDetached());
   MOZ_ASSERT(!arrayBuffer->isImmutable());
@@ -72,7 +73,8 @@ ResizableDataViewObject* ResizableDataViewObject::create(
 
   auto* obj = NewObjectWithClassProto<ResizableDataViewObject>(cx, proto);
   if (!obj || !obj->initResizable(cx, arrayBuffer, byteOffset, byteLength,
-                                  /* bytesPerElement = */ 1, autoLength)) {
+                                  /* bytesPerElement = */ 1, autoLength,
+                                  allowOutOfBounds)) {
     return nullptr;
   }
 

--- a/mozjs-sys/mozjs/js/src/builtin/DataViewObject.h
+++ b/mozjs-sys/mozjs/js/src/builtin/DataViewObject.h
@@ -176,12 +176,12 @@ class FixedLengthDataViewObject : public DataViewObject {
 class ResizableDataViewObject : public DataViewObject {
   friend class DataViewObject;
 
+ public:
   static ResizableDataViewObject* create(
       JSContext* cx, size_t byteOffset, size_t byteLength,
       AutoLength autoLength, Handle<ArrayBufferObjectMaybeShared*> arrayBuffer,
-      HandleObject proto);
+      HandleObject proto, bool allowOutOfBounds = false);
 
- public:
   static const uint8_t RESERVED_SLOTS = RESIZABLE_RESERVED_SLOTS;
 
   static const JSClass class_;

--- a/mozjs-sys/mozjs/js/src/vm/ArrayBufferObject.cpp
+++ b/mozjs-sys/mozjs/js/src/vm/ArrayBufferObject.cpp
@@ -3655,6 +3655,19 @@ JS_PUBLIC_API size_t JS::GetArrayBufferByteLength(JSObject* obj) {
   return aobj ? aobj->byteLength() : 0;
 }
 
+JS_PUBLIC_API bool JS::GetResizableArrayBufferMaxByteLength(
+    JSObject* obj, size_t* maxByteLength) {
+  MOZ_ASSERT(maxByteLength);
+
+  auto* buffer = obj->maybeUnwrapIf<ResizableArrayBufferObject>();
+  if (!buffer) {
+    return false;
+  }
+
+  *maxByteLength = buffer->maxByteLength();
+  return true;
+}
+
 JS_PUBLIC_API uint8_t* JS::GetArrayBufferData(JSObject* obj,
                                               bool* isSharedMemory,
                                               const JS::AutoRequireNoGC&) {

--- a/mozjs-sys/mozjs/js/src/vm/ArrayBufferViewObject.cpp
+++ b/mozjs-sys/mozjs/js/src/vm/ArrayBufferViewObject.cpp
@@ -179,13 +179,20 @@ bool ArrayBufferViewObject::init(JSContext* cx,
   if (buffer) {
     size_t viewByteLength = length * bytesPerElement;
     size_t viewByteOffset = byteOffset;
-    size_t bufferByteLength = buffer->byteLength();
+    size_t validationByteLength = buffer->byteLength();
+    if (buffer->is<ResizableArrayBufferObject>()) {
+      validationByteLength =
+          buffer->as<ResizableArrayBufferObject>().maxByteLength();
+    } else if (buffer->is<GrowableSharedArrayBufferObject>()) {
+      validationByteLength =
+          buffer->as<GrowableSharedArrayBufferObject>().maxByteLength();
+    }
     // Unwraps are safe: both are for the pointer value.
     MOZ_ASSERT_IF(buffer->is<ArrayBufferObject>(),
                   buffer->dataPointerEither().unwrap(/*safe*/) <=
                       dataPointerEither().unwrap(/*safe*/));
-    MOZ_ASSERT(bufferByteLength - viewByteOffset >= viewByteLength);
-    MOZ_ASSERT(viewByteOffset <= bufferByteLength);
+    MOZ_ASSERT(viewByteOffset <= validationByteLength);
+    MOZ_ASSERT(validationByteLength - viewByteOffset >= viewByteLength);
   }
 #endif
 
@@ -203,7 +210,8 @@ bool ArrayBufferViewObject::initResizable(JSContext* cx,
                                           ArrayBufferObjectMaybeShared* buffer,
                                           size_t byteOffset, size_t length,
                                           uint32_t bytesPerElement,
-                                          AutoLength autoLength) {
+                                          AutoLength autoLength,
+                                          bool allowOutOfBounds) {
   MOZ_ASSERT(buffer->isResizable());
 
   initFixedSlot(AUTO_LENGTH_SLOT, BooleanValue(static_cast<bool>(autoLength)));
@@ -219,7 +227,8 @@ bool ArrayBufferViewObject::initResizable(JSContext* cx,
     computeResizableLengthAndByteOffset(bytesPerElement);
   }
 
-  MOZ_ASSERT(!isOutOfBounds(), "can't create out-of-bounds views");
+  MOZ_ASSERT(allowOutOfBounds || !isOutOfBounds(),
+             "can't create out-of-bounds views");
 
   return true;
 }
@@ -603,6 +612,20 @@ JS_PUBLIC_API bool JS::IsImmutableArrayBufferView(JSObject* obj) {
     return buffer->isImmutable();
   }
   return false;
+}
+
+JS_PUBLIC_API bool JS::GetResizableArrayBufferViewState(
+    JSObject* obj, ResizableArrayBufferViewState* state) {
+  MOZ_ASSERT(state);
+
+  auto* view = obj->maybeUnwrapIf<ArrayBufferViewObject>();
+  if (!view || !view->hasResizableBuffer()) {
+    return false;
+  }
+
+  state->lengthTracking = view->isAutoLength();
+  state->outOfBounds = !view->hasDetachedBuffer() && view->isOutOfBounds();
+  return true;
 }
 
 JS_PUBLIC_API bool JS::PinArrayBufferOrViewLength(JSObject* obj, bool pin) {

--- a/mozjs-sys/mozjs/js/src/vm/ArrayBufferViewObject.h
+++ b/mozjs-sys/mozjs/js/src/vm/ArrayBufferViewObject.h
@@ -99,7 +99,8 @@ class ArrayBufferViewObject : public NativeObject {
                                    ArrayBufferObjectMaybeShared* buffer,
                                    size_t byteOffset, size_t length,
                                    uint32_t bytesPerElement,
-                                   AutoLength autoLength);
+                                   AutoLength autoLength,
+                                   bool allowOutOfBounds = false);
 
   static ArrayBufferObjectMaybeShared* ensureBufferObject(
       JSContext* cx, Handle<ArrayBufferViewObject*> obj);

--- a/mozjs-sys/mozjs/js/src/vm/ErrorObject.cpp
+++ b/mozjs-sys/mozjs/js/src/vm/ErrorObject.cpp
@@ -14,6 +14,7 @@
 #include <cmath>
 #include <utility>
 
+#include "jsapi.h"
 #include "jspubtd.h"
 #include "NamespaceImports.h"
 
@@ -26,6 +27,7 @@
 #include "js/ColumnNumber.h"  // JS::ColumnNumberOneOrigin
 #include "js/Conversions.h"
 #include "js/ErrorReport.h"
+#include "js/Exception.h"
 #include "js/friend/ErrorMessages.h"  // js::GetErrorMessage, JSMSG_*
 #include "js/friend/StackLimits.h"    // js::AutoCheckRecursionLimit
 #include "js/PropertyAndElement.h"
@@ -646,6 +648,7 @@ bool js::ErrorObject::init(JSContext* cx, Handle<ErrorObject*> obj,
     obj->initReservedSlot(CAUSE_SLOT, MagicValue(JS_ERROR_WITHOUT_CAUSE));
   }
   obj->initReservedSlot(SOURCEID_SLOT, Int32Value(sourceId));
+  obj->initReservedSlot(STACK_STRING_OVERRIDE_SLOT, UndefinedValue());
   if (obj->mightBeWasmTrap()) {
     MOZ_ASSERT(JSCLASS_RESERVED_SLOTS(obj->getClass()) > WASM_TRAP_SLOT);
     obj->initReservedSlot(WASM_TRAP_SLOT, BooleanValue(false));
@@ -780,6 +783,70 @@ static bool FindErrorInstanceOrPrototype(JSContext* cx, HandleObject obj,
 
 static MOZ_ALWAYS_INLINE bool IsObject(HandleValue v) { return v.isObject(); }
 
+JS_PUBLIC_API bool JS::GetNativeErrorStackString(
+    JSContext* cx, HandleObject error, MutableHandleString result) {
+  js::AssertHeapIsIdle();
+  CHECK_THREAD(cx);
+  MOZ_RELEASE_ASSERT(cx->realm());
+  result.set(nullptr);
+
+  RootedObject unwrapped(cx, js::CheckedUnwrapStatic(error));
+  if (!unwrapped || !unwrapped->is<js::ErrorObject>()) {
+    JS_ReportErrorASCII(cx, "Expected a native Error object");
+    return false;
+  }
+
+  Rooted<js::ErrorObject*> errorObject(
+      cx, &unwrapped->as<js::ErrorObject>());
+  RootedString stackString(cx, errorObject->stackStringOverride());
+  if (stackString) {
+    RootedValue stackValue(cx, StringValue(stackString));
+    if (!JS_WrapValue(cx, &stackValue)) {
+      return false;
+    }
+    stackString = stackValue.toString();
+  } else {
+    RootedObject stack(cx, errorObject->stack());
+    if (!JS::BuildStackString(cx, errorObject->realm()->principals(), stack,
+                              &stackString)) {
+      return false;
+    }
+  }
+
+  result.set(stackString);
+  return true;
+}
+
+JS_PUBLIC_API bool JS::SetNativeErrorStackString(JSContext* cx,
+                                                 HandleObject error,
+                                                 HandleString stack) {
+  js::AssertHeapIsIdle();
+  CHECK_THREAD(cx);
+  MOZ_RELEASE_ASSERT(cx->realm());
+
+  if (!stack) {
+    JS_ReportErrorASCII(cx, "Expected an Error stack string");
+    return false;
+  }
+
+  RootedObject unwrapped(cx, js::CheckedUnwrapStatic(error));
+  if (!unwrapped || !unwrapped->is<js::ErrorObject>()) {
+    JS_ReportErrorASCII(cx, "Expected a native Error object");
+    return false;
+  }
+
+  RootedValue stackValue(cx, StringValue(stack));
+  {
+    JSAutoRealm ar(cx, unwrapped);
+    if (!JS_WrapValue(cx, &stackValue)) {
+      return false;
+    }
+    unwrapped->as<js::ErrorObject>().setStackStringOverride(
+        stackValue.toString());
+  }
+  return true;
+}
+
 /* static */
 bool js::ErrorObject::getStack(JSContext* cx, unsigned argc, Value* vp) {
   CallArgs args = CallArgsFromVp(argc, vp);
@@ -801,13 +868,8 @@ bool js::ErrorObject::getStack_impl(JSContext* cx, const CallArgs& args) {
     return true;
   }
 
-  // Do frame filtering based on the ErrorObject's principals. This ensures we
-  // don't see chrome frames when chrome code accesses .stack over Xrays.
-  JSPrincipals* principals = obj->as<ErrorObject>().realm()->principals();
-
-  RootedObject savedFrameObj(cx, obj->as<ErrorObject>().stack());
   RootedString stackString(cx);
-  if (!BuildStackString(cx, principals, savedFrameObj, &stackString)) {
+  if (!JS::GetNativeErrorStackString(cx, obj, &stackString)) {
     return false;
   }
 
@@ -1877,6 +1939,11 @@ JSObject* js::CopyErrorObject(JSContext* cx, Handle<ErrorObject*> err) {
   if (!cx->compartment()->wrap(cx, &fileName)) {
     return nullptr;
   }
+  RootedString stackStringOverride(cx, err->stackStringOverride());
+  if (stackStringOverride &&
+      !cx->compartment()->wrap(cx, &stackStringOverride)) {
+    return nullptr;
+  }
   RootedObject stack(cx, err->stack());
   if (!cx->compartment()->wrap(cx, &stack)) {
     return nullptr;
@@ -1906,6 +1973,10 @@ JSObject* js::CopyErrorObject(JSContext* cx, Handle<ErrorObject*> err) {
                           columnNumber, std::move(copyReport), message, cause));
   if (!copy) {
     return nullptr;
+  }
+
+  if (stackStringOverride) {
+    copy->setStackStringOverride(stackStringOverride);
   }
 
   // Preserve the Wasm trap flag so that a copied trap remains uncatchable by

--- a/mozjs-sys/mozjs/js/src/vm/ErrorObject.h
+++ b/mozjs-sys/mozjs/js/src/vm/ErrorObject.h
@@ -52,10 +52,12 @@ class ErrorObject : public NativeObject {
   static const uint32_t CAUSE_SLOT = MESSAGE_SLOT + 1;
   static const uint32_t SOURCEID_SLOT = CAUSE_SLOT + 1;
 
-  static const uint32_t RESERVED_SLOTS = SOURCEID_SLOT + 1;
+  static const uint32_t STACK_STRING_OVERRIDE_SLOT = SOURCEID_SLOT + 1;
+
+  static const uint32_t RESERVED_SLOTS = STACK_STRING_OVERRIDE_SLOT + 1;
 
   // This slot is only used for errors that could be Wasm traps.
-  static const uint32_t WASM_TRAP_SLOT = SOURCEID_SLOT + 1;
+  static const uint32_t WASM_TRAP_SLOT = STACK_STRING_OVERRIDE_SLOT + 1;
   static const uint32_t RESERVED_SLOTS_MAYBE_WASM_TRAP = WASM_TRAP_SLOT + 1;
 
  public:
@@ -117,6 +119,16 @@ class ErrorObject : public NativeObject {
 
   // Returns nullptr or a (possibly wrapped) SavedFrame object.
   inline JSObject* stack() const;
+
+  JSString* stackStringOverride() const {
+    const Value& value = getReservedSlot(STACK_STRING_OVERRIDE_SLOT);
+    return value.isString() ? value.toString() : nullptr;
+  }
+
+  void setStackStringOverride(JSString* stack) {
+    MOZ_ASSERT(stack);
+    setReservedSlot(STACK_STRING_OVERRIDE_SLOT, JS::StringValue(stack));
+  }
 
   JSString* getMessage() const {
     Value val = getReservedSlot(MESSAGE_SLOT);

--- a/mozjs-sys/mozjs/js/src/vm/TypedArrayObject.cpp
+++ b/mozjs-sys/mozjs/js/src/vm/TypedArrayObject.cpp
@@ -1121,7 +1121,7 @@ class ResizableTypedArrayObjectTemplate
   static ResizableTypedArrayObject* makeInstance(
       JSContext* cx, Handle<ArrayBufferObjectMaybeShared*> buffer,
       size_t byteOffset, size_t len, AutoLength autoLength,
-      HandleObject proto) {
+      HandleObject proto, bool allowOutOfBounds = false) {
     MOZ_ASSERT(buffer);
     MOZ_ASSERT(buffer->isResizable());
     MOZ_ASSERT(!buffer->isDetached());
@@ -1139,7 +1139,8 @@ class ResizableTypedArrayObjectTemplate
       obj = newBuiltinClassInstance(cx, allocKind, gc::Heap::Default);
     }
     if (!obj || !obj->initResizable(cx, buffer, byteOffset, len,
-                                    BYTES_PER_ELEMENT, autoLength)) {
+                                    BYTES_PER_ELEMENT, autoLength,
+                                    allowOutOfBounds)) {
       return nullptr;
     }
 
@@ -7446,6 +7447,106 @@ ArraySortResult js::TypedArraySortFromJit(
 }
 
 /* JS Public API */
+
+JS_PUBLIC_API bool JS::CreateResizableArrayBufferView(
+    JSContext* cx, HandleObject bufferObject, Scalar::Type type,
+    size_t byteOffset, size_t length, bool lengthTracking,
+    MutableHandleObject result) {
+  AssertHeapIsIdle();
+  CHECK_THREAD(cx);
+  MOZ_RELEASE_ASSERT(cx->realm());
+  cx->check(bufferObject);
+  result.set(nullptr);
+
+  if (!bufferObject->is<ResizableArrayBufferObject>()) {
+    JS_ReportErrorASCII(cx, "Resizable ArrayBuffer object required");
+    return false;
+  }
+
+  Rooted<ArrayBufferObjectMaybeShared*> buffer(
+      cx, &bufferObject->as<ResizableArrayBufferObject>());
+  auto* resizableBuffer = &buffer->as<ResizableArrayBufferObject>();
+  if (resizableBuffer->isDetached()) {
+    JS_ReportErrorNumberASCII(cx, GetErrorMessage, nullptr,
+                              JSMSG_TYPED_ARRAY_DETACHED);
+    return false;
+  }
+  if (resizableBuffer->hasDefinedDetachKey()) {
+    JS_ReportErrorASCII(cx, "Ordinary resizable ArrayBuffer object required");
+    return false;
+  }
+  if (lengthTracking && length != 0) {
+    JS_ReportErrorASCII(cx, "Invalid length-tracking view length");
+    return false;
+  }
+
+  bool isDataView = type == Scalar::MaxTypedArrayViewType;
+  size_t bytesPerElement = 0;
+  switch (type) {
+    case Scalar::MaxTypedArrayViewType:
+      bytesPerElement = 1;
+      break;
+#define SET_BYTES_PER_ELEMENT(ExternalType, NativeType, Name) \
+  case Scalar::Name:                                         \
+    bytesPerElement = sizeof(NativeType);                    \
+    break;
+      JS_FOR_EACH_TYPED_ARRAY(SET_BYTES_PER_ELEMENT)
+#undef SET_BYTES_PER_ELEMENT
+    case Scalar::Int64:
+    case Scalar::Simd128:
+      JS_ReportErrorASCII(cx, "Invalid ArrayBuffer view type");
+      return false;
+  }
+
+  if (!isDataView && byteOffset % bytesPerElement != 0) {
+    JS_ReportErrorASCII(cx, "Misaligned typed array byte offset");
+    return false;
+  }
+  mozilla::CheckedInt<size_t> viewByteLength(length);
+  viewByteLength *= bytesPerElement;
+  mozilla::CheckedInt<size_t> viewEnd(byteOffset);
+  viewEnd += viewByteLength;
+  if (!viewByteLength.isValid() || !viewEnd.isValid() ||
+      viewEnd.value() > resizableBuffer->maxByteLength()) {
+    JS_ReportErrorASCII(cx, "ArrayBuffer view exceeds maximum byte length");
+    return false;
+  }
+
+  auto autoLength = lengthTracking ? ArrayBufferViewObject::AutoLength::Yes
+                                   : ArrayBufferViewObject::AutoLength::No;
+  RootedObject object(cx);
+  if (isDataView) {
+    RootedObject proto(
+        cx, GlobalObject::getOrCreatePrototype(cx, JSProto_DataView));
+    if (!proto) {
+      return false;
+    }
+    object = ResizableDataViewObject::create(
+        cx, byteOffset, length, autoLength, buffer, proto,
+        /* allowOutOfBounds = */ true);
+  } else {
+    RootedObject noProto(cx);
+    switch (type) {
+#define CREATE_RESIZABLE_TYPED_ARRAY(ExternalType, NativeType, Name) \
+  case Scalar::Name:                                                \
+    object = ResizableTypedArrayObjectTemplate<NativeType>::        \
+        makeInstance(cx, buffer, byteOffset, length, autoLength,     \
+                     noProto, /* allowOutOfBounds = */ true);        \
+    break;
+      JS_FOR_EACH_TYPED_ARRAY(CREATE_RESIZABLE_TYPED_ARRAY)
+#undef CREATE_RESIZABLE_TYPED_ARRAY
+      case Scalar::MaxTypedArrayViewType:
+      case Scalar::Int64:
+      case Scalar::Simd128:
+        MOZ_CRASH("invalid typed array type");
+    }
+  }
+  if (!object) {
+    return false;
+  }
+  result.set(object);
+  return true;
+}
 
 #define IMPL_TYPED_ARRAY_JSAPI_CONSTRUCTORS(ExternalType, NativeType, Name)   \
   JS_PUBLIC_API JSObject* JS_New##Name##Array(JSContext* cx,                  \

--- a/mozjs-sys/src/jsapi.cpp
+++ b/mozjs-sys/src/jsapi.cpp
@@ -17,6 +17,7 @@
 #include "js/Date.h"
 #include "js/EnvironmentChain.h"
 #include "js/Equality.h"
+#include "js/Exception.h"
 #include "js/ForOfIterator.h"
 #include "js/Id.h"
 #include "js/Initialization.h"
@@ -114,6 +115,8 @@ uint16_t GetLinearStringCharAt(JSLinearString* s, size_t idx) {
 JSLinearString* AtomToLinearString(JSAtom* atom) {
   return JS::AtomToLinearString(atom);
 }
+
+bool IsProxyObject(const JSObject* obj) { return js::IsProxy(obj); }
 
 // Wrappers around UniquePtr functions
 
@@ -322,6 +325,21 @@ bool CreateError(JSContext* cx, JSExnType type, JS::HandleObject stack,
       cx, type, stack, fileName, lineNumber,
       JS::ColumnNumberOneOrigin(columnNumber), report, message,
       JS::Rooted<mozilla::Maybe<JS::Value>>(cx, mozilla::ToMaybe(&cause)),
+      rval);
+}
+
+bool CreateErrorWithOptionalCause(
+    JSContext* cx, JSExnType type, JS::HandleObject stack,
+    JS::HandleString fileName, uint32_t lineNumber, uint32_t columnNumber,
+    JSErrorReport* report, JS::HandleString message, JS::HandleValue cause,
+    bool hasCause, JS::MutableHandleValue rval) {
+  JS::Rooted<mozilla::Maybe<JS::Value>> maybeCause(cx, mozilla::Nothing());
+  if (hasCause) {
+    maybeCause = mozilla::Some(cause.get());
+  }
+  return JS::CreateError(
+      cx, type, stack, fileName, lineNumber,
+      JS::ColumnNumberOneOrigin(columnNumber), report, message, maybeCause,
       rval);
 }
 

--- a/mozjs/src/jsapi2_wrappers.in.rs
+++ b/mozjs/src/jsapi2_wrappers.in.rs
@@ -130,6 +130,8 @@ wrap!(jsapi: pub fn StealPendingExceptionStack(cx: &mut JSContext, exceptionStac
 wrap!(jsapi: pub fn SetPendingExceptionStack(cx: &JSContext, exceptionStack: *const ExceptionStack));
 wrap!(jsapi: pub fn ExceptionStackOrNull(obj: HandleObject) -> *mut JSObject);
 wrap!(jsapi: pub fn ReportUncatchableException(cx: &JSContext));
+wrap!(jsapi: pub fn GetNativeErrorStackString(cx: &mut JSContext, error: HandleObject, result: MutableHandleString) -> bool);
+wrap!(jsapi: pub fn SetNativeErrorStackString(cx: &mut JSContext, error: HandleObject, stack: HandleString) -> bool);
 wrap!(jsapi: pub fn CurrentGlobalOrNull(cx: &JSContext) -> *mut JSObject);
 wrap!(jsapi: pub fn CurrentGlobal(cx: &JSContext) -> *const *mut JSObject);
 wrap!(jsapi: pub fn NewMapObject(cx: &mut JSContext) -> *mut JSObject);
@@ -342,6 +344,7 @@ wrap!(jsapi: pub fn StartCollectingDelazifications1(cx: &JSContext, module: Hand
 wrap!(jsapi: pub fn FinishCollectingDelazifications(cx: &mut JSContext, script: Handle<*mut JSScript>, stencilOut: *mut *mut Stencil) -> bool);
 wrap!(jsapi: pub fn FinishCollectingDelazifications1(cx: &mut JSContext, module: Handle<*mut JSObject>, stencilOut: *mut *mut Stencil) -> bool);
 wrap!(jsapi: pub fn GetScriptSourceText(cx: &JSContext, stencil: *mut Stencil, result: MutableHandle<Value>) -> bool);
+wrap!(jsapi: pub fn CreateResizableArrayBufferView(cx: &mut JSContext, buffer: HandleObject, type_: Scalar::Type, byteOffset: usize, length: usize, lengthTracking: bool, result: MutableHandleObject) -> bool);
 wrap!(jsapi: pub fn EnsureNonInlineArrayBufferOrView(cx: &mut JSContext, obj: *mut JSObject) -> bool);
 wrap!(jsapi: pub fn RunJSMicroTask(cx: &mut JSContext, entry: Handle<*mut JSMicroTask>) -> bool);
 wrap!(jsapi: pub fn EnqueueMicroTask(cx: &JSContext, entry: *const GenericMicroTask) -> bool);
@@ -675,5 +678,6 @@ wrap!(jsapi: pub fn JS_GetOwnUCPropertyDescriptor(cx: &mut JSContext, obj: Handl
 wrap!(jsapi: pub fn JS_GetPropertyDescriptorById(cx: &mut JSContext, obj: HandleObject, id: HandleId, desc: MutableHandle<PropertyDescriptor>, holder: MutableHandleObject, isNone: *mut bool) -> bool);
 wrap!(jsapi: pub fn JS_GetUCPropertyDescriptor(cx: &mut JSContext, obj: HandleObject, name: *const u16, namelen: usize, desc: MutableHandle<PropertyDescriptor>, holder: MutableHandleObject, isNone: *mut bool) -> bool);
 wrap!(jsapi: pub fn CreateError(cx: &mut JSContext, type_: JSExnType, stack: HandleObject, fileName: HandleString, lineNumber: u32, columnNumber: u32, report: *mut JSErrorReport, message: HandleString, cause: HandleValue, rval: MutableHandleValue) -> bool);
+wrap!(jsapi: pub fn CreateErrorWithOptionalCause(cx: &mut JSContext, type_: JSExnType, stack: HandleObject, fileName: HandleString, lineNumber: u32, columnNumber: u32, report: *mut JSErrorReport, message: HandleString, cause: HandleValue, hasCause: bool, rval: MutableHandleValue) -> bool);
 wrap!(jsapi: pub fn GetExceptionCause(exc: *mut JSObject, dest: MutableHandleValue));
 wrap!(jsapi: pub fn NewEnvironmentChain(cx: &mut JSContext, supportUnscopables: SupportUnscopables) -> *mut EnvironmentChain);


### PR DESCRIPTION
we need these APIs to inspect RAB maxByteLength, length tracking and out-of-bounds state, and to recreate a view exactly after its buffer has shrunk, we also needs a way to preserve native Error stack text without exposing SM’s SavedFrame, and call the inline proxy check from Rust.