### PR TITLE
Store draining in JobQueue and thus simpify JobQueue

### DIFF
--- a/mozjs-sys/Cargo.toml
+++ b/mozjs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs_sys"
 description = "System crate for the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "153.0.0-0"
+version = "153.0.0-1"
 authors = ["Mozilla", "The Servo Project Developers"]
 links = "mozjs"
 license.workspace = true

--- a/mozjs-sys/etc/patches/0052-get-job-queue.patch
+++ b/mozjs-sys/etc/patches/0052-get-job-queue.patch
@@ -1,0 +1,29 @@
+diff --git a/js/public/Promise.h b/js/public/Promise.h
+index ffef2095ad..1bc86acc70 100644
+--- a/js/public/Promise.h
++++ b/js/public/Promise.h
+@@ -155,6 +155,8 @@ class JS_PUBLIC_API JobQueue {
+  */
+ extern JS_PUBLIC_API void SetJobQueue(JSContext* cx, JobQueue* queue);
+ 
++extern JS_PUBLIC_API JobQueue* GetJobQueue(JSContext* cx);
++
+ /**
+  * [SMDOC] Protecting the debuggee's job/microtask queue from debugger activity.
+  *
+diff --git a/js/src/jsapi.cpp b/js/src/jsapi.cpp
+index 5fafa677de..805809ada2 100644
+--- a/js/src/jsapi.cpp
++++ b/js/src/jsapi.cpp
+@@ -2862,6 +2862,11 @@ JS_PUBLIC_API void JS::SetJobQueue(JSContext* cx, JobQueue* queue) {
+   cx->jobQueue = queue;
+ }
+ 
++JS_PUBLIC_API JS::JobQueue* JS::GetJobQueue(JSContext* cx) {
++  MOZ_ASSERT(cx->jobQueue.ref());
++  return cx->jobQueue;
++}
++
+ extern JS_PUBLIC_API void JS::SetPromiseRejectionTrackerCallback(
+     JSContext* cx, PromiseRejectionTrackerCallback callback,
+     void* data /* = nullptr */) {

--- a/mozjs-sys/mozjs/js/public/Promise.h
+++ b/mozjs-sys/mozjs/js/public/Promise.h
@@ -155,6 +155,8 @@ class JS_PUBLIC_API JobQueue {
  */
 extern JS_PUBLIC_API void SetJobQueue(JSContext* cx, JobQueue* queue);
 
+extern JS_PUBLIC_API JobQueue* GetJobQueue(JSContext* cx);
+
 /**
  * [SMDOC] Protecting the debuggee's job/microtask queue from debugger activity.
  *

--- a/mozjs-sys/mozjs/js/src/jsapi.cpp
+++ b/mozjs-sys/mozjs/js/src/jsapi.cpp
@@ -2862,6 +2862,11 @@ JS_PUBLIC_API void JS::SetJobQueue(JSContext* cx, JobQueue* queue) {
   cx->jobQueue = queue;
 }
 
+JS_PUBLIC_API JS::JobQueue* JS::GetJobQueue(JSContext* cx) {
+  MOZ_ASSERT(cx->jobQueue.ref());
+  return cx->jobQueue;
+}
+
 extern JS_PUBLIC_API void JS::SetPromiseRejectionTrackerCallback(
     JSContext* cx, PromiseRejectionTrackerCallback callback,
     void* data /* = nullptr */) {

--- a/mozjs-sys/src/jsglue.cpp
+++ b/mozjs-sys/src/jsglue.cpp
@@ -51,7 +51,7 @@ struct JobQueueTraps {
       JS::MutableHandle<JSObject*> optionalHostDefinedData);
   bool (*getHostDefinedGlobal)(JSContext* cx,
                                JS::MutableHandle<JSObject*> data);
-  void (*runJobs)(RustJobQueue* queue, JSContext* cx);
+  void (*runJobs)(JSContext* cx);
   void (*traceNonGCThingMicroTask)(JSTracer* trc, JS::Value* valuePtr);
 };
 
@@ -72,7 +72,7 @@ class RustJobQueue : public JS::JobQueue {
       JSContext* cx, JS::MutableHandle<JSObject*> data) const override {
     return mTraps.getHostDefinedGlobal(cx, data);
   }
-  virtual void runJobs(JSContext* cx) override { mTraps.runJobs(this, cx); }
+  virtual void runJobs(JSContext* cx) override { mTraps.runJobs(cx); }
 
   bool isDrainingStopped() const override { return false; }
 

--- a/mozjs-sys/src/jsglue.cpp
+++ b/mozjs-sys/src/jsglue.cpp
@@ -86,24 +86,18 @@ class RustJobQueue : public JS::JobQueue {
    public:
     explicit SavedQueue(JSContext* cx, RustJobQueue* queue)
         : cx(cx), mQueue(queue) {
-      // TODO: assert that the context’s jobQueue hasn’t been cleared with
-      // SetJobQueue(nullptr) or DestroyContext(). Don’t know how to do this
-      // with only an opaque JSContext decl. Are we allowed to #include
-      // "vm/JSContext.h"?
-      //
-      // MOZ_ASSERT(cx->jobQueue.ref());
+      // assert that the context’s jobQueue hasn’t been changed or cleared with
+      // SetJobQueue(nullptr) or DestroyContext().
+      MOZ_ASSERT(JS::GetJobQueue(cx) == mQueue);
 
       mSavedMicroTaskQueue = JS::SaveMicroTaskQueue(cx);
       draining = mQueue->draining;
     }
 
     ~SavedQueue() {
-      // TODO: assert that the context’s jobQueue hasn’t been cleared with
-      // SetJobQueue(nullptr) or DestroyContext(). Don’t know how to do this
-      // with only an opaque JSContext decl. Are we allowed to #include
-      // "vm/JSContext.h"?
-      //
-      // MOZ_ASSERT(cx->jobQueue.ref());
+      // assert that the context’s jobQueue hasn’t been changed or cleared with
+      // SetJobQueue(nullptr) or DestroyContext().
+      MOZ_ASSERT(JS::GetJobQueue(cx) == mQueue);
 
       // Check that the current queue is empty, as required by the SavedJobQueue
       // contract.

--- a/mozjs-sys/src/jsglue.cpp
+++ b/mozjs-sys/src/jsglue.cpp
@@ -43,37 +43,24 @@ typedef size_t (*GetSize)(JSObject* obj);
 
 WantToMeasure gWantToMeasure = nullptr;
 
+class RustJobQueue;
+
 struct JobQueueTraps {
   bool (*getHostDefinedData)(
       JSContext* cx, JS::MutableHandle<JSObject*> incumbentGlobal,
       JS::MutableHandle<JSObject*> optionalHostDefinedData);
   bool (*getHostDefinedGlobal)(JSContext* cx,
                                JS::MutableHandle<JSObject*> data);
-  void (*runJobs)(const void* queue, JSContext* cx);
+  void (*runJobs)(RustJobQueue* queue, JSContext* cx);
   void (*traceNonGCThingMicroTask)(JSTracer* trc, JS::Value* valuePtr);
-
-  // Create a new queue, push it onto an embedder-side stack, and return the new
-  // queue.
-  const void* (*pushNewInterruptQueue)(void* aInterruptQueues);
-  // Destroy the queue most recently created by pushNewInterruptQueue(),
-  // returning its address so we can check if we are restoring the saved queue
-  // over the correct queue.
-  const void* (*popInterruptQueue)(void* aInterruptQueues);
-  // Destroy the embedder-side stack of interrupt queues.
-  void (*dropInterruptQueues)(void* aInterruptQueues);
 };
 
 class RustJobQueue : public JS::JobQueue {
   JobQueueTraps mTraps;
-  const void* mQueue;
-  void* mInterruptQueues;
+  bool draining;
 
  public:
-  RustJobQueue(const JobQueueTraps& aTraps, const void* aQueue,
-               void* aInterruptQueues)
-      : mTraps(aTraps), mQueue(aQueue), mInterruptQueues(aInterruptQueues) {}
-
-  ~RustJobQueue() override { mTraps.dropInterruptQueues(mInterruptQueues); }
+  RustJobQueue(const JobQueueTraps& aTraps) : mTraps(aTraps), draining(false) {}
 
   virtual bool getHostDefinedData(
       JSContext* cx, JS::MutableHandle<JSObject*> incumbentGlobal,
@@ -85,7 +72,7 @@ class RustJobQueue : public JS::JobQueue {
       JSContext* cx, JS::MutableHandle<JSObject*> data) const override {
     return mTraps.getHostDefinedGlobal(cx, data);
   }
-  virtual void runJobs(JSContext* cx) override { mTraps.runJobs(mQueue, cx); }
+  virtual void runJobs(JSContext* cx) override { mTraps.runJobs(this, cx); }
 
   bool isDrainingStopped() const override { return false; }
 
@@ -97,27 +84,17 @@ class RustJobQueue : public JS::JobQueue {
  private:
   class SavedQueue : public JS::JobQueue::SavedJobQueue {
    public:
-    explicit SavedQueue(const JobQueueTraps& aTraps, void* aInterruptQueues,
-                        const void** aCurrentQueue, const void* aNewQueue,
-                        JSContext* cx)
-        : mTraps(aTraps),
-          cx(cx),
-          mInterruptQueues(aInterruptQueues),
-          mCurrentQueue(aCurrentQueue),
-          mNewQueue(aNewQueue),
-          mSavedQueue(*aCurrentQueue) {
+    explicit SavedQueue(JSContext* cx, RustJobQueue* queue)
+        : cx(cx), mQueue(queue) {
       // TODO: assert that the context’s jobQueue hasn’t been cleared with
       // SetJobQueue(nullptr) or DestroyContext(). Don’t know how to do this
       // with only an opaque JSContext decl. Are we allowed to #include
       // "vm/JSContext.h"?
       //
       // MOZ_ASSERT(cx->jobQueue.ref());
-      mSavedMicroTaskQueue = JS::SaveMicroTaskQueue(cx);
 
-      // Set the current queue to mNewQueue.
-      // We need to take care of this, so that we can save the old queue in the
-      // member initializers above.
-      *mCurrentQueue = mNewQueue;
+      mSavedMicroTaskQueue = JS::SaveMicroTaskQueue(cx);
+      draining = mQueue->draining;
     }
 
     ~SavedQueue() {
@@ -134,42 +111,18 @@ class RustJobQueue : public JS::JobQueue {
 
       JS::RestoreMicroTaskQueue(cx, std::move(mSavedMicroTaskQueue));
 
-      // Destroy the topmost queue, checking that it was the queue this
-      // SavedQueue expects to restore from. Imagine we have normal queue A,
-      // then we switch to B (SavedQueue from B to A), then we switch to C
-      // (SavedQueue from C to B). If the SavedQueue from B to A is restored
-      // before the SavedQueue from C to B, the embedder will destroy both C and
-      // B, but in the end, the queue will be set to B, a freed queue.
-      MOZ_ASSERT(mTraps.popInterruptQueue(mInterruptQueues) == mNewQueue);
-
-      *mCurrentQueue = mSavedQueue;
+      mQueue->draining = draining;
     }
 
    private:
-    // Required for embedder FFI.
-    JobQueueTraps mTraps;
     JSContext* cx;
     js::UniquePtr<JS::SavedMicroTaskQueue> mSavedMicroTaskQueue;
-
-    void* mInterruptQueues;
-
-    // Pointer to the RustJobQueue::mQueue field to write to when switching.
-    const void** mCurrentQueue;
-
-    // The queue to switch to when saving.
-    const void* mNewQueue;
-
-    // The queue to switch to when restoring.
-    const void* mSavedQueue;
+    RustJobQueue* mQueue;
+    bool draining;
   };
 
   virtual js::UniquePtr<SavedJobQueue> saveJobQueue(JSContext* cx) override {
-    auto newQueue = mTraps.pushNewInterruptQueue(mInterruptQueues);
-    // Servo uses infallible allocation here, so it should never return nullptr.
-    MOZ_ASSERT(!!newQueue);
-
-    auto result = js::MakeUnique<SavedQueue>(mTraps, mInterruptQueues, &mQueue,
-                                             newQueue, cx);
+    auto result = js::MakeUnique<SavedQueue>(cx, this);
     if (!result) {
       // “On OOM, this should call JS_ReportOutOfMemory on the given JSContext,
       // and return a null UniquePtr.”
@@ -1166,12 +1119,11 @@ JSString* JS_ForgetStringLinearness(JSLinearString* str) {
   return JS_FORGET_STRING_LINEARNESS(str);
 }
 
-JS::JobQueue* CreateJobQueue(const JobQueueTraps* aTraps, const void* aQueue,
-                             void* aInterruptQueues) {
-  return new RustJobQueue(*aTraps, aQueue, aInterruptQueues);
+RustJobQueue* CreateJobQueue(const JobQueueTraps* aTraps) {
+  return new RustJobQueue(*aTraps);
 }
 
-void DeleteJobQueue(JS::JobQueue* queue) { delete queue; }
+void DeleteJobQueue(RustJobQueue* queue) { delete queue; }
 
 JSExternalStringCallbacks* CreateJSExternalStringCallbacks(
     const JSExternalStringCallbacksTraps* aTraps, void* privateData) {

--- a/mozjs/Cargo.toml
+++ b/mozjs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository.workspace = true
-version = "0.25.0"
+version = "0.26.0"
 authors = ["The Servo Project Developers"]
 license.workspace = true
 edition.workspace = true
@@ -27,7 +27,7 @@ encoding_rs = "0.8.35"
 libc.workspace = true
 log = "0.4"
 # When doing non-version changes also update ../mozjs-sys/etc/sm-security-bump.py
-mozjs_sys = { version = "=153.0.0-0", path = "../mozjs-sys" }
+mozjs_sys = { version = "=153.0.0-1", path = "../mozjs-sys" }
 num-traits = "0.2"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/mozjs/src/generate_wrappers.py
+++ b/mozjs/src/generate_wrappers.py
@@ -91,6 +91,7 @@ def grep_heur2(file_path: Path) -> list[str]:
             or "CurrentGlobal" in sig
             or "DescribeScriptedCaller" in sig
             or "JS_DequeueNextMicroTask" in sig
+            or "GetJobQueue" in sig
         ):
             sig = sig.replace("&mut JSContext", "&JSContext")
         return sig

--- a/mozjs/src/jsapi2_wrappers.in.rs
+++ b/mozjs/src/jsapi2_wrappers.in.rs
@@ -278,6 +278,7 @@ wrap!(jsapi: pub fn IsArray(cx: &mut JSContext, obj: Handle<*mut JSObject>, isAr
 wrap!(jsapi: pub fn IsArray1(cx: &mut JSContext, obj: Handle<*mut JSObject>, answer: *mut IsArrayAnswer) -> bool);
 wrap!(jsapi: pub fn GetBuiltinClass(cx: &mut JSContext, obj: Handle<*mut JSObject>, cls: *mut ESClass) -> bool);
 wrap!(jsapi: pub fn SetJobQueue(cx: &JSContext, queue: *mut JobQueue));
+wrap!(jsapi: pub fn GetJobQueue(cx: &JSContext) -> *mut JobQueue);
 wrap!(jsapi: pub fn SetPromiseRejectionTrackerCallback(cx: &JSContext, callback: PromiseRejectionTrackerCallback, data: *mut ::std::os::raw::c_void));
 wrap!(jsapi: pub fn JobQueueIsEmpty(cx: &JSContext));
 wrap!(jsapi: pub fn JobQueueMayNotBeEmpty(cx: &JSContext));


### PR DESCRIPTION
Store draining flag in JobQueue allows us to remove interrupt queues.
We also expose obtaining JobQueue from cx.

Testing: Tested in servo.
Servo PR: https://github.com/servo/servo/pull/47827
